### PR TITLE
Move GenomicsDB C/C++ tests to use Catch2 instead of Google Test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "dependencies/RapidJSON"]
 	path = dependencies/RapidJSON
 	url = https://github.com/miloyip/rapidjson.git
+[submodule "src/test/cpp/Catch2"]
+	path = src/test/cpp/Catch2
+	url = https://github.com/catchorg/Catch2

--- a/src/test/cpp/include/test_mapping_data_loader.h
+++ b/src/test/cpp/include/test_mapping_data_loader.h
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 
@@ -29,7 +30,6 @@
 #include "headers.h"
 #include "vid_mapper_sql.h"
 #include <limits.h>
-#include "gtest/gtest.h"
 
 const std::string config_file_name = "/tmp/sql_mapper/sql_mapper_config.txt";
 

--- a/src/test/cpp/src/CMakeLists.txt
+++ b/src/test/cpp/src/CMakeLists.txt
@@ -1,17 +1,45 @@
-find_package(GTest)
-if(GTEST_FOUND)
-    set(CPP_TEST_SOURCES
-        main_testall.cc
-        test_non_diploid_mapper.cc
-        test_multid_vector.cc
-        )
-    if(LIBDBI_FOUND)
-        set(CPP_TEST_SOURCES
-            ${CPP_TEST_SOURCES}
-            test_mapping_data_loader.cc)
-    endif()
-    add_executable(runAllGTests ${CPP_TEST_SOURCES})
-    target_link_libraries(runAllGTests ${GTEST_BOTH_LIBRARIES})
-    build_GenomicsDB_executable_common(runAllGTests)
-    add_test(NAME All_GTests COMMAND runAllGTests)
+#
+# src/test/cpp/src/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2019 Omics Data Automation, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include_directories(Catch INTERFACE ${CMAKE_SOURCE_DIR}/src/test/cpp/Catch2/single_include)
+
+set(CPP_TEST_SOURCES
+  ctest_main.cc
+  test_non_diploid_mapper.cc
+  test_multid_vector.cc)
+
+if(LIBDBI_FOUND)
+  set(CPP_TEST_SOURCES
+    ${CPP_TEST_SOURCES}
+    test_mapping_data_loader.cc)
 endif()
+
+add_executable(ctests ${CPP_TEST_SOURCES})
+build_GENOMICSDB_executable_common(ctests)
+add_test(ctests ctests)
+
+add_custom_target(all_ctests COMMAND ${CMAKE_CTEST_COMMAND} -V DEPENDS ctests)

--- a/src/test/cpp/src/CMakeLists.txt
+++ b/src/test/cpp/src/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 
 add_executable(ctests ${CPP_TEST_SOURCES})
 build_GENOMICSDB_executable_common(ctests)
-add_test(ctests ctests)
+add_test(ctests ctests -d yes)
 
 add_custom_target(all_ctests COMMAND ${CMAKE_CTEST_COMMAND} -V DEPENDS ctests)
+

--- a/src/test/cpp/src/ctest_main.cc
+++ b/src/test/cpp/src/ctest_main.cc
@@ -1,0 +1,32 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2019 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * this software and associated documentation files (the "Software"), to deal in 
+ * the Software without restriction, including without limitation the rights to 
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+ * the Software, and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+// Amortize the cost of building catch2.hpp for
+// every unit test by linking in ctest_main.o
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+TEST_CASE("test1", "[test1]") {
+  CHECK(true);
+}

--- a/src/test/cpp/src/ctest_main.cc
+++ b/src/test/cpp/src/ctest_main.cc
@@ -27,6 +27,3 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-TEST_CASE("test1", "[test1]") {
-  CHECK(true);
-}

--- a/src/test/cpp/src/main_testall.cc
+++ b/src/test/cpp/src/main_testall.cc
@@ -1,7 +1,0 @@
-#include <limits.h>
-#include "gtest/gtest.h"
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return(RUN_ALL_TESTS());
-}

--- a/src/test/cpp/src/test_mapping_data_loader.cc
+++ b/src/test/cpp/src/test_mapping_data_loader.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 
@@ -18,7 +19,9 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+ */
+
+#include <catch2/catch.hpp>
 
 #include <test_mapping_data_loader.h>
 
@@ -51,7 +54,7 @@ void MappingDataLoaderTester::validate_contig_info() {
   for (auto& contig : m_contig_idx_to_info) {
     std::cout <<contig.m_contig_idx <<" - " <<contig.m_name <<" - " 
       <<contig.m_tiledb_column_offset <<" - " <<contig.m_length <<"\n";
-    EXPECT_GT(contig.m_tiledb_column_offset, prev_offset);
+    CHECK(contig.m_tiledb_column_offset > prev_offset);
     prev_offset = contig.m_tiledb_column_offset;
   }
 
@@ -60,7 +63,7 @@ void MappingDataLoaderTester::validate_contig_info() {
 
   for (auto& contig_begin : m_contig_begin_2_idx) {
     std::cout <<contig_begin.first <<" - " <<contig_begin.second <<"\n";
-    EXPECT_GT(contig_begin.first, prev_begin_first);
+    CHECK(contig_begin.first > prev_begin_first);
     prev_begin_first = contig_begin.first;
   }
 
@@ -69,7 +72,7 @@ void MappingDataLoaderTester::validate_contig_info() {
 
   for (auto& contig_end : m_contig_end_2_idx) {
     std::cout <<contig_end.first <<" - " <<contig_end.second <<"\n";
-    EXPECT_GT(contig_end.first, prev_end_first);
+    CHECK(contig_end.first > prev_end_first);
     prev_end_first = contig_end.first;
   }
 
@@ -84,8 +87,8 @@ void MappingDataLoaderTester::validate_callset_info() {
   for (std::vector<CallSetInfo>::iterator it = m_row_idx_to_info.begin(); it != m_row_idx_to_info.end(); ++it) {
     index++;
     std::cout <<it->m_row_idx <<" - " <<it->m_name <<" - " <<it->m_file_idx <<" - " <<it->m_idx_in_file <<"\n";
-    EXPECT_EQ(index, it->m_row_idx);
-    EXPECT_EQ(m_callset_name_to_row_idx[it->m_name], index);
+    REQUIRE(index == it->m_row_idx);
+    CHECK(m_callset_name_to_row_idx[it->m_name] == index);
   }
 
   std::cout <<"------------------------------------------------------\n";
@@ -102,8 +105,8 @@ void MappingDataLoaderTester::validate_field_info() {
       <<field.m_bcf_ht_type <<" - " <<field.m_is_vcf_FILTER_field <<" - " 
       <<field.m_is_vcf_INFO_field <<" - " <<field.m_is_vcf_FORMAT_field <<" - "
       <<field.m_VCF_field_combine_operation <<"\n";
-    EXPECT_EQ(++index, field.m_field_idx);
-    EXPECT_EQ(m_field_name_to_idx[field.m_name], index);
+    REQUIRE(++index == field.m_field_idx);
+    CHECK(m_field_name_to_idx[field.m_name] == index);
   }
 
   std::cout <<"------------------------------------------------------\n";
@@ -112,14 +115,14 @@ void MappingDataLoaderTester::validate_field_info() {
 
 MappingDataLoaderTester* SQLMapperTest::loaderTester = NULL;
 
-TEST_F(SQLMapperTest, ValidContigInfo) {
+TEST_CASE_METHOD(SQLMapperTest, "Test valid contig info", test_valid_contig_info) {
   loaderTester->validate_contig_info();
 }
 
-TEST_F(SQLMapperTest, ValidCallSetInfo) {
+TEST_CASE_METHOD(SQLMapperTest, "Test valid callset info", test_valid_callset_info) {
   loaderTester->validate_callset_info();
 }
 
-TEST_F(SQLMapperTest, ValidFieldInfo) {
+TEST_CASE_METHOD(SQLMapperTest, "Test valid field info", test_valid_field_info) {
   loaderTester->validate_field_info();
 }

--- a/src/test/cpp/src/test_multid_vector.cc
+++ b/src/test/cpp/src/test_multid_vector.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 
@@ -20,14 +21,17 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <gtest/gtest.h>
+#include <catch2/catch.hpp>
+
 #include "vid_mapper.h"
 #include "genomicsdb_multid_vector_field.h"
 #include "variant_operations.h"
 
+using Catch::Equals;
+
 void initialize_LUT_reordered(CombineAllelesLUT& lut);
 
-TEST(multid_vector, 2D_test)
+TEST_CASE("multid_vector 2D_test", "[2D_test]")
 {
   FieldInfo field_info;
   field_info.set_info("test", 0);
@@ -47,55 +51,55 @@ TEST(multid_vector, 2D_test)
   auto total_size = two_d_vector.parse_and_store_numeric(value.c_str(), value.length());
   //Size of dim 0 in first 8 bytes
   auto dim_0_data_size = *(reinterpret_cast<const uint64_t*>(&(two_d_vector.get_rw_data(0u)[0u])));
-  EXPECT_EQ(total_size[0u], dim_0_data_size
+  CHECK(total_size[0u] == dim_0_data_size
       +sizeof(uint64_t) //size - 8 bytes
       +sizeof(uint64_t) //#entries - 8 bytes
       +3*sizeof(uint64_t)); //3 offsets
   //Index
   GenomicsDBMultiDVectorIdx dim_0_idx(&(two_d_vector.get_rw_data(0u)[0]), &field_info);
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), -1);
+  CHECK(dim_0_idx.get_current_dim_index() == -1);
   //A[0]
   dim_0_idx.advance_to_index_in_next_dimension(0u);
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 0u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 8u);
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 0u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+  CHECK(dim_0_idx.get_size_of_current_index() == 8u);
   auto data_ptr = dim_0_idx.get_ptr<int>();
-  EXPECT_EQ(data_ptr[0u], 1);
-  EXPECT_EQ(data_ptr[1u], 2);
+  CHECK(data_ptr[0u] == 1);
+  CHECK(data_ptr[1u] == 2);
   {
     //A[0][i]
     auto dim_1_idx = dim_0_idx;
     //A[0][0]
     dim_1_idx.advance_to_index_in_next_dimension(0u);
-    EXPECT_EQ(dim_1_idx.get_current_dim_index(), 1);
-    EXPECT_EQ(dim_1_idx.get_current_index_in_current_dimension(), 0u);
-    EXPECT_EQ(dim_1_idx.get_num_entries_in_current_dimension(), 2u);
-    EXPECT_EQ(dim_1_idx.get_size_of_current_index(), sizeof(int));
-    EXPECT_EQ(dim_1_idx.get_element<int>(), 1);
+    CHECK(dim_1_idx.get_current_dim_index() == 1);
+    CHECK(dim_1_idx.get_current_index_in_current_dimension() == 0u);
+    CHECK(dim_1_idx.get_num_entries_in_current_dimension() == 2u);
+    CHECK(dim_1_idx.get_size_of_current_index() == sizeof(int));
+    CHECK(dim_1_idx.get_element<int>() == 1);
     //A[0][1]
     dim_1_idx.advance_index_in_current_dimension();
-    EXPECT_EQ(dim_1_idx.get_current_dim_index(), 1);
-    EXPECT_EQ(dim_1_idx.get_current_index_in_current_dimension(), 1u);
-    EXPECT_EQ(dim_1_idx.get_num_entries_in_current_dimension(), 2u);
-    EXPECT_EQ(dim_1_idx.get_size_of_current_index(), sizeof(int));
-    EXPECT_EQ(dim_1_idx.get_element<int>(), 2);
+    CHECK(dim_1_idx.get_current_dim_index() == 1);
+    CHECK(dim_1_idx.get_current_index_in_current_dimension() == 1u);
+    CHECK(dim_1_idx.get_num_entries_in_current_dimension() == 2u);
+    CHECK(dim_1_idx.get_size_of_current_index() == sizeof(int));
+    CHECK(dim_1_idx.get_element<int>() == 2);
   }
   //A[1]
   dim_0_idx.advance_index_in_current_dimension();
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 1u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 12u);
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 1u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+  CHECK(dim_0_idx.get_size_of_current_index() == 12u);
   data_ptr = dim_0_idx.get_ptr<int>();
-  EXPECT_EQ(data_ptr[0u], 3);
-  EXPECT_EQ(data_ptr[1u], 4);
-  EXPECT_EQ(data_ptr[2u], 5);
+  CHECK(data_ptr[0u] == 3);
+  CHECK(data_ptr[1u] == 4);
+  CHECK(data_ptr[2u] == 5);
   //VCF printer
   std::ostringstream fptr;
   GenomicsDBMultiDVectorFieldVCFPrinter print_op(fptr, field_info);
   two_d_vector.run_operation(print_op, std::vector<const uint8_t*>(1u, &(two_d_vector.get_rw_data(0u)[0])));
-  EXPECT_EQ(fptr.str(), value);
+  CHECK(fptr.str() == value);
   {
     //Test re-ordering
     CombineAllelesLUT tmp_lut;
@@ -115,47 +119,47 @@ TEST(multid_vector, 2D_test)
         field_info);
     //Size of dim 0 in first 8 bytes
     auto dim_0_data_size = *(reinterpret_cast<const uint64_t*>(&(reordered_data[0u])));
-    EXPECT_EQ(total_size[0u]
-        +3*sizeof(int) //the extra 3 integers because B_merged gets mapped to C_inp (NON_REF) and the [3, 4, 5] is duplicated
-        +sizeof(uint64_t), //one extra entry so one more offset value
-        dim_0_data_size
-        +sizeof(uint64_t) //size - 8 bytes
-        +sizeof(uint64_t) //#entries - 8 bytes
-        +4*sizeof(uint64_t)); //4 offsets
+    CHECK((total_size[0u]
+	   +3*sizeof(int) //the extra 3 integers because B_merged gets mapped to C_inp (NON_REF) and the [3, 4, 5] is duplicated
+           +sizeof(uint64_t)) == //one extra entry so one more offset value
+          (dim_0_data_size
+	   +sizeof(uint64_t) //size - 8 bytes
+	   +sizeof(uint64_t) //#entries - 8 bytes
+           +4*sizeof(uint64_t))); //4 offsets
     //Index
     GenomicsDBMultiDVectorIdx dim_0_idx(&(reordered_data[0]), &field_info);
-    EXPECT_EQ(dim_0_idx.get_current_dim_index(), -1);
+    CHECK(dim_0_idx.get_current_dim_index() == -1);
     //A[0] - B_merged == C_inp (NON_REF)
     dim_0_idx.advance_to_index_in_next_dimension(0u);
-    EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-    EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 0u);
-    EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 3u);
-    EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 3*sizeof(int)); //[3, 4, 5]
+    CHECK(dim_0_idx.get_current_dim_index() == 0);
+    CHECK(dim_0_idx.get_current_index_in_current_dimension() == 0u);
+    CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 3u);
+    CHECK(dim_0_idx.get_size_of_current_index() == 3*sizeof(int)); //[3, 4, 5]
     auto data_ptr = dim_0_idx.get_ptr<int>();
-    EXPECT_EQ(data_ptr[0u], 3);
-    EXPECT_EQ(data_ptr[1u], 4);
-    EXPECT_EQ(data_ptr[2u], 5);
+    CHECK(data_ptr[0u] == 3);
+    CHECK(data_ptr[1u] == 4);
+    CHECK(data_ptr[2u] == 5);
     //A[1] - C_merged == B_inp
     dim_0_idx.advance_index_in_current_dimension();
-    EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 1u);
-    EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 3u);
-    EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 2*sizeof(int)); //[1, 2]
+    CHECK(dim_0_idx.get_current_index_in_current_dimension() == 1u);
+    CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 3u);
+    CHECK(dim_0_idx.get_size_of_current_index() == 2*sizeof(int)); //[1, 2]
     data_ptr = dim_0_idx.get_ptr<int>();
-    EXPECT_EQ(data_ptr[0u], 1);
-    EXPECT_EQ(data_ptr[1u], 2);
+    CHECK(data_ptr[0u] == 1);
+    CHECK(data_ptr[1u] == 2);
     //A[2] - D_merged == C_inp (NON_REF)
     dim_0_idx.advance_index_in_current_dimension();
-    EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 2u);
-    EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 3u);
-    EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 3*sizeof(int)); //[3, 4, 5]
+    CHECK(dim_0_idx.get_current_index_in_current_dimension() == 2u);
+    CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 3u);
+    CHECK(dim_0_idx.get_size_of_current_index() == 3*sizeof(int)); //[3, 4, 5]
     data_ptr = dim_0_idx.get_ptr<int>();
-    EXPECT_EQ(data_ptr[0u], 3);
-    EXPECT_EQ(data_ptr[1u], 4);
-    EXPECT_EQ(data_ptr[2u], 5);
+    CHECK(data_ptr[0u] == 3);
+    CHECK(data_ptr[1u] == 4);
+    CHECK(data_ptr[2u] == 5);
   }
 }
 
-TEST(multid_vector, 3D_test)
+TEST_CASE("multid_vector 3D_test", "[3D_test]")
 {
   FieldInfo field_info;
   field_info.set_info("test", 0);
@@ -177,113 +181,113 @@ TEST(multid_vector, 3D_test)
   auto total_size = three_d_vector.parse_and_store_numeric(value.c_str(), value.length());
   //Size of dim 0 data in first 8 bytes
   auto dim_0_data_size = *(reinterpret_cast<const uint64_t*>(&(three_d_vector.get_rw_data(0u)[0u])));
-  EXPECT_EQ(total_size[0u], dim_0_data_size
+  CHECK(total_size[0u] == dim_0_data_size
       +sizeof(uint64_t) //size - 8 bytes
       +sizeof(uint64_t) //#entries - 8 bytes
       +3*sizeof(uint64_t)); //3 offsets
   //Index
   GenomicsDBMultiDVectorIdx dim_0_idx(&(three_d_vector.get_rw_data(0u)[0]), &field_info);
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), -1);
+  CHECK(dim_0_idx.get_current_dim_index() == -1);
   //A[0]
   dim_0_idx.advance_to_index_in_next_dimension(0u);
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 0u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 60u);
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 0u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+  CHECK(dim_0_idx.get_size_of_current_index() == 60u);
   {
     //A[0][i]
     auto dim_1_idx = dim_0_idx;
     //A[0][0]
     dim_1_idx.advance_to_index_in_next_dimension(0u);
-    EXPECT_EQ(dim_1_idx.get_current_dim_index(), 1);
-    EXPECT_EQ(dim_1_idx.get_current_index_in_current_dimension(), 0u);
-    EXPECT_EQ(dim_1_idx.get_num_entries_in_current_dimension(), 2u);
-    EXPECT_EQ(dim_1_idx.get_size_of_current_index(), 8u);
+    CHECK(dim_1_idx.get_current_dim_index() == 1);
+    CHECK(dim_1_idx.get_current_index_in_current_dimension() == 0u);
+    CHECK(dim_1_idx.get_num_entries_in_current_dimension() == 2u);
+    CHECK(dim_1_idx.get_size_of_current_index() == 8u);
     auto data_ptr = dim_1_idx.get_ptr<int>();
-    EXPECT_EQ(data_ptr[0], 1);
-    EXPECT_EQ(data_ptr[1], 2);
+    CHECK(data_ptr[0] == 1);
+    CHECK(data_ptr[1] == 2);
     //A[0][1]
     dim_1_idx.advance_index_in_current_dimension();
-    EXPECT_EQ(dim_1_idx.get_current_dim_index(), 1);
-    EXPECT_EQ(dim_1_idx.get_current_index_in_current_dimension(), 1u);
-    EXPECT_EQ(dim_1_idx.get_num_entries_in_current_dimension(), 2u);
-    EXPECT_EQ(dim_1_idx.get_size_of_current_index(), 12u);
+    CHECK(dim_1_idx.get_current_dim_index() == 1);
+    CHECK(dim_1_idx.get_current_index_in_current_dimension() == 1u);
+    CHECK(dim_1_idx.get_num_entries_in_current_dimension() == 2u);
+    CHECK(dim_1_idx.get_size_of_current_index() == 12u);
     data_ptr = dim_1_idx.get_ptr<int>();
-    EXPECT_EQ(data_ptr[0], 3);
-    EXPECT_EQ(data_ptr[1], 4);
-    EXPECT_EQ(data_ptr[2], 5);
+    CHECK(data_ptr[0] == 3);
+    CHECK(data_ptr[1] == 4);
+    CHECK(data_ptr[2] == 5);
     {
       //A[0][1][i]
       auto dim_2_idx = dim_1_idx;
       dim_2_idx.advance_to_index_in_next_dimension(0u);
       //A[0][1][0]
-      EXPECT_EQ(dim_2_idx.get_current_dim_index(), 2);
-      EXPECT_EQ(dim_2_idx.get_current_index_in_current_dimension(), 0u);
-      EXPECT_EQ(dim_2_idx.get_num_entries_in_current_dimension(), 3u);
-      EXPECT_EQ(dim_2_idx.get_size_of_current_index(), sizeof(int));
-      EXPECT_EQ(dim_2_idx.get_element<int>(), 3);
+      CHECK(dim_2_idx.get_current_dim_index() == 2);
+      CHECK(dim_2_idx.get_current_index_in_current_dimension() == 0u);
+      CHECK(dim_2_idx.get_num_entries_in_current_dimension() == 3u);
+      CHECK(dim_2_idx.get_size_of_current_index() == sizeof(int));
+      CHECK(dim_2_idx.get_element<int>() == 3);
       //A[0][1][1]
       dim_2_idx.advance_index_in_current_dimension();
-      EXPECT_EQ(dim_2_idx.get_current_dim_index(), 2);
-      EXPECT_EQ(dim_2_idx.get_current_index_in_current_dimension(), 1u);
-      EXPECT_EQ(dim_2_idx.get_num_entries_in_current_dimension(), 3u);
-      EXPECT_EQ(dim_2_idx.get_size_of_current_index(), sizeof(int));
-      EXPECT_EQ(dim_2_idx.get_element<int>(), 4);
+      CHECK(dim_2_idx.get_current_dim_index() == 2);
+      CHECK(dim_2_idx.get_current_index_in_current_dimension() == 1u);
+      CHECK(dim_2_idx.get_num_entries_in_current_dimension() == 3u);
+      CHECK(dim_2_idx.get_size_of_current_index() == sizeof(int));
+      CHECK(dim_2_idx.get_element<int>() == 4);
       //A[0][1][2]
       dim_2_idx.advance_index_in_current_dimension();
-      EXPECT_EQ(dim_2_idx.get_current_dim_index(), 2);
-      EXPECT_EQ(dim_2_idx.get_current_index_in_current_dimension(), 2u);
-      EXPECT_EQ(dim_2_idx.get_num_entries_in_current_dimension(), 3u);
-      EXPECT_EQ(dim_2_idx.get_size_of_current_index(), sizeof(int));
-      EXPECT_EQ(dim_2_idx.get_element<int>(), 5);
+      CHECK(dim_2_idx.get_current_dim_index() == 2);
+      CHECK(dim_2_idx.get_current_index_in_current_dimension() == 2u);
+      CHECK(dim_2_idx.get_num_entries_in_current_dimension() == 3u);
+      CHECK(dim_2_idx.get_size_of_current_index() == sizeof(int));
+      CHECK(dim_2_idx.get_element<int>() == 5);
     }
   }
   //A[1]
   dim_0_idx.advance_index_in_current_dimension();
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 1u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 76u);
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 1u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+  CHECK(dim_0_idx.get_size_of_current_index() == 76u);
   {
     //A[1][i]
     auto dim_1_idx = dim_0_idx;
     //A[1][0]
     dim_1_idx.advance_to_index_in_next_dimension(0u);
-    EXPECT_EQ(dim_1_idx.get_current_dim_index(), 1);
-    EXPECT_EQ(dim_1_idx.get_current_index_in_current_dimension(), 0u);
-    EXPECT_EQ(dim_1_idx.get_num_entries_in_current_dimension(), 3u);
-    EXPECT_EQ(dim_1_idx.get_size_of_current_index(), 16u);
+    CHECK(dim_1_idx.get_current_dim_index() == 1);
+    CHECK(dim_1_idx.get_current_index_in_current_dimension() == 0u);
+    CHECK(dim_1_idx.get_num_entries_in_current_dimension() == 3u);
+    CHECK(dim_1_idx.get_size_of_current_index() == 16u);
     auto data_ptr = dim_1_idx.get_ptr<int>();
-    EXPECT_EQ(data_ptr[0], 6);
-    EXPECT_EQ(data_ptr[1], 7);
-    EXPECT_EQ(data_ptr[2], 8);
-    EXPECT_EQ(data_ptr[3], 9);
+    CHECK(data_ptr[0] == 6);
+    CHECK(data_ptr[1] == 7);
+    CHECK(data_ptr[2]== 8);
+    CHECK(data_ptr[3] == 9);
     //A[0][1]
     dim_1_idx.advance_index_in_current_dimension();
-    EXPECT_EQ(dim_1_idx.get_current_dim_index(), 1);
-    EXPECT_EQ(dim_1_idx.get_current_index_in_current_dimension(), 1u);
-    EXPECT_EQ(dim_1_idx.get_num_entries_in_current_dimension(), 3u);
-    EXPECT_EQ(dim_1_idx.get_size_of_current_index(), 8u);
+    CHECK(dim_1_idx.get_current_dim_index() == 1);
+    CHECK(dim_1_idx.get_current_index_in_current_dimension() == 1u);
+    CHECK(dim_1_idx.get_num_entries_in_current_dimension() == 3u);
+    CHECK(dim_1_idx.get_size_of_current_index() == 8u);
     data_ptr = dim_1_idx.get_ptr<int>();
-    EXPECT_EQ(data_ptr[0], 10);
-    EXPECT_EQ(data_ptr[1], 11);
+    CHECK(data_ptr[0] == 10);
+    CHECK(data_ptr[1] == 11);
     //A[0][2]
     dim_1_idx.advance_index_in_current_dimension();
-    EXPECT_EQ(dim_1_idx.get_current_dim_index(), 1);
-    EXPECT_EQ(dim_1_idx.get_current_index_in_current_dimension(), 2u);
-    EXPECT_EQ(dim_1_idx.get_num_entries_in_current_dimension(), 3u);
-    EXPECT_EQ(dim_1_idx.get_size_of_current_index(), 4u);
+    CHECK(dim_1_idx.get_current_dim_index() == 1);
+    CHECK(dim_1_idx.get_current_index_in_current_dimension() == 2u);
+    CHECK(dim_1_idx.get_num_entries_in_current_dimension() == 3u);
+    CHECK(dim_1_idx.get_size_of_current_index() == 4u);
     data_ptr = dim_1_idx.get_ptr<int>();
-    EXPECT_EQ(data_ptr[0], 12);
+    CHECK(data_ptr[0] == 12);
   }
   //VCF printer
   std::ostringstream fptr;
   GenomicsDBMultiDVectorFieldVCFPrinter print_op(fptr, field_info);
   three_d_vector.run_operation(print_op, std::vector<const uint8_t*>(1u, &(three_d_vector.get_rw_data(0u)[0])));
-  EXPECT_EQ(fptr.str(), value);
+  CHECK(fptr.str() == value);
 }
 
-TEST(multid_vector, 2D_test_with_missing_values)
+TEST_CASE("multid_vector 2D_test_with_missing_values", "[2D_test_with_missing_values]")
 {
   FieldInfo field_info;
   field_info.set_info("test", 0);
@@ -303,38 +307,38 @@ TEST(multid_vector, 2D_test_with_missing_values)
   auto total_size = two_d_vector.parse_and_store_numeric(value.c_str(), value.length());
   //Size of dim 0 data in first 8 bytes
   auto dim_0_data_size = *(reinterpret_cast<const uint64_t*>(&(two_d_vector.get_rw_data(0u)[0u])));
-  EXPECT_EQ(total_size[0u], dim_0_data_size
+  CHECK(total_size[0u] == dim_0_data_size
       +sizeof(uint64_t) //size - 8 bytes
       +sizeof(uint64_t) //#entries - 8 bytes
       +3*sizeof(uint64_t)); //3 offsets
   //Index
   GenomicsDBMultiDVectorIdx dim_0_idx(&(two_d_vector.get_rw_data(0u)[0]), &field_info);
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), -1);
+  CHECK(dim_0_idx.get_current_dim_index() == -1);
   //A[0]
   dim_0_idx.advance_to_index_in_next_dimension(0u);
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 0u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), sizeof(float));
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 0u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+  CHECK(dim_0_idx.get_size_of_current_index() == sizeof(float));
   //A[1]
   dim_0_idx.advance_index_in_current_dimension();
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 1u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 3*sizeof(int));
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 1u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+  CHECK(dim_0_idx.get_size_of_current_index() == 3*sizeof(int));
   auto data_ptr = dim_0_idx.get_ptr<int>();
-  EXPECT_EQ(data_ptr[0u], 3);
-  EXPECT_EQ(data_ptr[1u], get_bcf_missing_value<int>());
-  EXPECT_EQ(data_ptr[2u], get_bcf_missing_value<int>());
+  CHECK(data_ptr[0u] == 3);
+  CHECK(data_ptr[1u] == get_bcf_missing_value<int>());
+  CHECK(data_ptr[2u] == get_bcf_missing_value<int>());
   //VCF printer
   std::ostringstream fptr;
   GenomicsDBMultiDVectorFieldVCFPrinter print_op(fptr, field_info);
   two_d_vector.run_operation(print_op, std::vector<const uint8_t*>(1u, &(two_d_vector.get_rw_data(0u)[0])));
   std::string serialization_return_value = "|3,,"; //NaN gets replaced with missing
-  EXPECT_EQ(fptr.str(), serialization_return_value);
+  CHECK_THAT(fptr.str(),  Equals(serialization_return_value));
 }
 
-TEST(multid_vector, 2D_float_test)
+TEST_CASE("multid_vector 2D_float_test", "[2D_float_test]")
 {
   FieldInfo field_info;
   field_info.set_info("test", 0);
@@ -353,65 +357,66 @@ TEST(multid_vector, 2D_float_test)
   auto total_size = two_d_vector.parse_and_store_numeric(value.c_str(), value.length());
   //Size of dim 0 in first 8 bytes
   auto dim_0_data_size = *(reinterpret_cast<const uint64_t*>(&(two_d_vector.get_rw_data(0u)[0u])));
-  EXPECT_EQ(total_size[0u], dim_0_data_size
+  CHECK(total_size[0u] == dim_0_data_size
       +sizeof(uint64_t) //size - 8 bytes
       +sizeof(uint64_t) //#entries - 8 bytes
       +5*sizeof(uint64_t)); //5 offsets
   //Index
   GenomicsDBMultiDVectorIdx dim_0_idx(&(two_d_vector.get_rw_data(0u)[0]), &field_info);
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), -1);
+  CHECK(dim_0_idx.get_current_dim_index() == -1);
   //A[0]
   dim_0_idx.advance_to_index_in_next_dimension(0u);
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 0u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 4u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), sizeof(float));
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 0u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 4u);
+  CHECK(dim_0_idx.get_size_of_current_index() == sizeof(float));
   auto data_ptr = dim_0_idx.get_ptr<float>();
-  EXPECT_NEAR(data_ptr[0u], 29659.0f, 1e-5f);
+  //  EXPECT_NEAR(data_ptr[0u] == 29659.0f == 1e-5f);
+  CHECK(data_ptr[0u] == Approx(29659.0f).margin(1e-5f)); 
   {
     //A[0][i]
     auto dim_1_idx = dim_0_idx;
     //A[0][0]
     dim_1_idx.advance_to_index_in_next_dimension(0u);
-    EXPECT_EQ(dim_1_idx.get_current_dim_index(), 1);
-    EXPECT_EQ(dim_1_idx.get_current_index_in_current_dimension(), 0u);
-    EXPECT_EQ(dim_1_idx.get_num_entries_in_current_dimension(), 1u);
-    EXPECT_EQ(dim_1_idx.get_size_of_current_index(), sizeof(float));
-    EXPECT_EQ(dim_1_idx.get_element<float>(), 29659.0);
+    CHECK(dim_1_idx.get_current_dim_index() == 1);
+    CHECK(dim_1_idx.get_current_index_in_current_dimension() == 0u);
+    CHECK(dim_1_idx.get_num_entries_in_current_dimension() == 1u);
+    CHECK(dim_1_idx.get_size_of_current_index() == sizeof(float));
+    CHECK(dim_1_idx.get_element<float>() == 29659.0);
   }
   //A[1]
   dim_0_idx.advance_index_in_current_dimension();
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 1u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 4u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), sizeof(float));
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 1u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 4u);
+  CHECK(dim_0_idx.get_size_of_current_index() == sizeof(float));
   data_ptr = dim_0_idx.get_ptr<float>();
-  EXPECT_EQ(data_ptr[0u], 1.0);
+  CHECK(data_ptr[0u] == 1.0);
   //A[2]
   dim_0_idx.advance_index_in_current_dimension();
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 2u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 4u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), sizeof(float));
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 2u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 4u);
+  CHECK(dim_0_idx.get_size_of_current_index() == sizeof(float));
   data_ptr = dim_0_idx.get_ptr<float>();
-  EXPECT_EQ(data_ptr[0u], 2.0);
+  CHECK(data_ptr[0u] == 2.0);
   //A[3]
   dim_0_idx.advance_index_in_current_dimension();
-  EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-  EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 3u);
-  EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 4u);
-  EXPECT_EQ(dim_0_idx.get_size_of_current_index(), sizeof(float));
+  CHECK(dim_0_idx.get_current_dim_index() == 0);
+  CHECK(dim_0_idx.get_current_index_in_current_dimension() == 3u);
+  CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 4u);
+  CHECK(dim_0_idx.get_size_of_current_index() == sizeof(float));
   data_ptr = dim_0_idx.get_ptr<float>();
-  EXPECT_EQ(data_ptr[0u], 3.0);
+  CHECK(data_ptr[0u] == 3.0);
   //VCF printer
   std::ostringstream fptr;
   GenomicsDBMultiDVectorFieldVCFPrinter print_op(fptr, field_info);
   two_d_vector.run_operation(print_op, std::vector<const uint8_t*>(1u, &(two_d_vector.get_rw_data(0u)[0])));
   //EXPECT_THAT(fptr.str(), MatchesRegex("29659\\.?.*|\\s*1\\.?.*|\\s*2\\.?.*|\\s*3\\.?.*"));
-  //EXPECT_EQ(fptr.str(), "29659|1|2|3");
+  //CHECK(fptr.str(), "29659|1|2|3");
 }
 
-TEST(multid_vector, 2D_tuple_test)
+TEST_CASE("multid_vector 2D_tuple_test", "[2D_tuple_test]")
 {
   FieldInfo field_info;
   field_info.set_info("test", 0);
@@ -436,7 +441,7 @@ TEST(multid_vector, 2D_tuple_test)
     auto total_size = two_d_vector.parse_and_store_numeric(value.c_str(), value.length());
     //Size of dim 0 in first 8 bytes
     auto dim_0_data_size = *(reinterpret_cast<const uint64_t*>(&(two_d_vector.get_rw_data(0u)[0u])));
-    EXPECT_EQ(total_size[0u], dim_0_data_size
+    CHECK(total_size[0u] == dim_0_data_size
         +sizeof(uint64_t) //size - 8 bytes
         +sizeof(uint64_t) //#entries - 8 bytes
         +3*sizeof(uint64_t)); //3 offsets
@@ -444,26 +449,26 @@ TEST(multid_vector, 2D_tuple_test)
     {
       //Index
       GenomicsDBMultiDVectorIdx dim_0_idx(&(two_d_vector.get_rw_data(0u)[0]), &field_info);
-      EXPECT_EQ(dim_0_idx.get_current_dim_index(), -1);
+      CHECK(dim_0_idx.get_current_dim_index() == -1);
       //A[0]
       dim_0_idx.advance_to_index_in_next_dimension(0u);
-      EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-      EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 0u);
-      EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-      EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 8u);
+      CHECK(dim_0_idx.get_current_dim_index() == 0);
+      CHECK(dim_0_idx.get_current_index_in_current_dimension() == 0u);
+      CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+      CHECK(dim_0_idx.get_size_of_current_index() == 8u);
       auto data_ptr = dim_0_idx.get_ptr<int>();
-      EXPECT_EQ(data_ptr[0u], 1);
-      EXPECT_EQ(data_ptr[1u], 2);
+      CHECK(data_ptr[0u] == 1);
+      CHECK(data_ptr[1u] == 2);
       //A[1]
       dim_0_idx.advance_index_in_current_dimension();
-      EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-      EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 1u);
-      EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-      EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 12u);
+      CHECK(dim_0_idx.get_current_dim_index() == 0);
+      CHECK(dim_0_idx.get_current_index_in_current_dimension() == 1u);
+      CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+      CHECK(dim_0_idx.get_size_of_current_index() == 12u);
       data_ptr = dim_0_idx.get_ptr<int>();
-      EXPECT_EQ(data_ptr[0u], 3);
-      EXPECT_EQ(data_ptr[1u], 4);
-      EXPECT_EQ(data_ptr[2u], 5);
+      CHECK(data_ptr[0u] == 3);
+      CHECK(data_ptr[1u] == 4);
+      CHECK(data_ptr[2u] == 5);
       //VCF printer
       std::ostringstream fptr;
       FieldInfo int_tuple_element_field_info;
@@ -478,32 +483,32 @@ TEST(multid_vector, 2D_tuple_test)
       GenomicsDBMultiDVectorField int_tuple_element_vector(int_tuple_element_field_info);
       GenomicsDBMultiDVectorFieldVCFPrinter print_op(fptr, int_tuple_element_field_info);
       int_tuple_element_vector.run_operation(print_op, std::vector<const uint8_t*>(1u, &(two_d_vector.get_rw_data(0u)[0])));
-      EXPECT_EQ(fptr.str(), "1,2|3,4,5");
+      CHECK(fptr.str() == "1,2|3,4,5");
     }
     //FP element of the tuple
     {
       //Index
       GenomicsDBMultiDVectorIdx dim_0_idx(&(two_d_vector.get_rw_data(1u)[0]), &field_info);
-      EXPECT_EQ(dim_0_idx.get_current_dim_index(), -1);
+      CHECK(dim_0_idx.get_current_dim_index() == -1);
       //A[0]
       dim_0_idx.advance_to_index_in_next_dimension(0u);
-      EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-      EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 0u);
-      EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-      EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 8u);
+      CHECK(dim_0_idx.get_current_dim_index() == 0);
+      CHECK(dim_0_idx.get_current_index_in_current_dimension() == 0u);
+      CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+      CHECK(dim_0_idx.get_size_of_current_index() == 8u);
       auto data_ptr = dim_0_idx.get_ptr<float>();
-      EXPECT_EQ(data_ptr[0u], 1.5);
-      EXPECT_EQ(data_ptr[1u], 2.5);
+      CHECK(data_ptr[0u] == 1.5);
+      CHECK(data_ptr[1u] == 2.5);
       //A[1]
       dim_0_idx.advance_index_in_current_dimension();
-      EXPECT_EQ(dim_0_idx.get_current_dim_index(), 0);
-      EXPECT_EQ(dim_0_idx.get_current_index_in_current_dimension(), 1u);
-      EXPECT_EQ(dim_0_idx.get_num_entries_in_current_dimension(), 2u);
-      EXPECT_EQ(dim_0_idx.get_size_of_current_index(), 12u);
+      CHECK(dim_0_idx.get_current_dim_index() == 0);
+      CHECK(dim_0_idx.get_current_index_in_current_dimension() == 1u);
+      CHECK(dim_0_idx.get_num_entries_in_current_dimension() == 2u);
+      CHECK(dim_0_idx.get_size_of_current_index() == 12u);
       data_ptr = dim_0_idx.get_ptr<float>();
-      EXPECT_EQ(data_ptr[0u], 3.5);
-      EXPECT_EQ(data_ptr[1u], 4.5);
-      EXPECT_EQ(data_ptr[2u], 5.5);
+      CHECK(data_ptr[0u] == 3.5);
+      CHECK(data_ptr[1u] == 4.5);
+      CHECK(data_ptr[2u] == 5.5);
     }
     {
       std::ostringstream fptr;

--- a/src/test/cpp/src/test_non_diploid_mapper.cc
+++ b/src/test/cpp/src/test_non_diploid_mapper.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 
@@ -20,8 +21,11 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <gtest/gtest.h>
+#include <catch2/catch.hpp>
+
 #include "variant_operations.h"
+
+using Catch::Equals;
 
 class RemapDataTestClass : public RemappedDataWrapperBase
 {
@@ -72,8 +76,8 @@ void verify_remapped_gt_order(const std::vector<DataType>& input_data,
   std::string s;
   for(auto i=0u;i<ploidy;++i)
     s += (static_cast<char>(remapped_allele_idx_vec_for_current_gt_combination[i]) + 'A');
-  EXPECT_EQ(dynamic_cast<RemapDataTestClass&>(remapped_data).get_genotype_combination(remapped_gt_idx),
-      s);
+  CHECK_THAT(dynamic_cast<RemapDataTestClass&>(remapped_data).get_genotype_combination(remapped_gt_idx),
+	       Equals(s));
   s.clear();
   auto input_gt_idx = VariantOperations::get_genotype_index(input_call_allele_idx_vec, false);
   auto found_unmatched_allele = false;
@@ -81,7 +85,7 @@ void verify_remapped_gt_order(const std::vector<DataType>& input_data,
   {
     if(input_call_allele_idx_vec[i] < 0)
     {
-      EXPECT_TRUE(curr_genotype_combination_contains_missing_allele_for_input);
+      CHECK(curr_genotype_combination_contains_missing_allele_for_input);
       found_unmatched_allele = true;
     }
     else
@@ -90,17 +94,17 @@ void verify_remapped_gt_order(const std::vector<DataType>& input_data,
   if(!curr_genotype_combination_contains_missing_allele_for_input)
   {
     //Verifies functionality of get_genotype_index()
-    EXPECT_EQ(dynamic_cast<RemapDataTestClass&>(remapped_data).get_genotype_combination(input_gt_idx),
-        s);
+    CHECK_THAT(dynamic_cast<RemapDataTestClass&>(remapped_data).get_genotype_combination(input_gt_idx),
+	       Equals(s));
     //Verifies that lookup from merged genotype to input genotype is correct
-    EXPECT_EQ(dynamic_cast<RemapDataTestClass&>(remapped_data).get_input_genotype_combination(remapped_gt_idx),
-        s);
+    CHECK_THAT(dynamic_cast<RemapDataTestClass&>(remapped_data).get_input_genotype_combination(remapped_gt_idx),
+	       Equals(s));
   }
   else
   {
-    EXPECT_TRUE(found_unmatched_allele);
-    EXPECT_EQ(dynamic_cast<RemapDataTestClass&>(remapped_data).get_input_genotype_combination(remapped_gt_idx),
-        ".");
+    CHECK(found_unmatched_allele);
+    CHECK_THAT(dynamic_cast<RemapDataTestClass&>(remapped_data).get_input_genotype_combination(remapped_gt_idx),
+	       Equals("."));
   }
 }
 
@@ -143,7 +147,7 @@ void initialize_LUT_reordered_without_NON_REF(CombineAllelesLUT& lut)
 //Golden outputs copied from:
 //http://genome.sph.umich.edu/wiki/Relationship_between_Ploidy,_Alleles_and_Genotypes
 
-TEST(genotype_ordering, haploid_5_alleles)
+TEST_CASE("genotype_ordering haploid_5_alleles", "[haploid_5_alleles]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;
@@ -163,7 +167,7 @@ TEST(genotype_ordering, haploid_5_alleles)
       verify_remapped_gt_order);
 }
 
-TEST(genotype_ordering, diploid_2_alleles)
+TEST_CASE("genotype_ordering diploid_2_alleles", "[diploid_2_alleles]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;
@@ -187,7 +191,7 @@ TEST(genotype_ordering, diploid_2_alleles)
       verify_remapped_gt_order);
 }
 
-TEST(genotype_ordering, diploid_3_alleles)
+TEST_CASE("genotype_ordering diploid_3_alleles", "[diploid_3_alleles]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;
@@ -214,7 +218,7 @@ TEST(genotype_ordering, diploid_3_alleles)
       verify_remapped_gt_order);
 }
 
-TEST(genotype_ordering, diploid_4_alleles)
+TEST_CASE("genotype_ordering diploid_4_alleles", "[diploid_4_alleles]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;
@@ -245,7 +249,7 @@ TEST(genotype_ordering, diploid_4_alleles)
       verify_remapped_gt_order);
 }
 
-TEST(genotype_ordering, triploid_2_alleles)
+TEST_CASE("genotype_ordering triploid_2_alleles", "[triploid_2_alleles]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;
@@ -270,7 +274,7 @@ TEST(genotype_ordering, triploid_2_alleles)
       verify_remapped_gt_order);
 }
 
-TEST(genotype_ordering, triploid_3_alleles)
+TEST_CASE("genotype_ordering triploid_3_alleles", "[triploid_3_alleles]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;
@@ -301,7 +305,7 @@ TEST(genotype_ordering, triploid_3_alleles)
       verify_remapped_gt_order);
 }
 
-TEST(genotype_ordering, triploid_4_alleles)
+TEST_CASE("genotype_ordering triploid_4_alleles", "[triploid_4_alleles]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;
@@ -342,7 +346,7 @@ TEST(genotype_ordering, triploid_4_alleles)
       verify_remapped_gt_order);
 }
 
-TEST(genotype_ordering, triploid_4_alleles_reordered_alleles)
+TEST_CASE("genotype_ordering triploid_4_alleles_reordered_alleles", "[triploid_4_alleles_reordered_alleles]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;
@@ -409,7 +413,7 @@ TEST(genotype_ordering, triploid_4_alleles_reordered_alleles)
       verify_remapped_gt_order);
 }
 
-TEST(genotype_ordering, triploid_4_alleles_reordered_alleles_without_NON_REF)
+TEST_CASE("genotype_ordering triploid_4_alleles_reordered_alleles_without_NON_REF", "[triploid_4_alleles_reordered_alleles_without_NON_REF]")
 {
   std::vector<int> tmp_vector;
   std::vector<std::pair<int, int> > tmp_stack;


### PR DESCRIPTION
Catch2 is
- Header only   
-  No need for fixtures   
-  Really nice expression support for matchers.