### PR TITLE
Remove installing gtest for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,11 +83,6 @@ install:
         sudo apt-get -y install zip unzip;
         wget -nv https://github.com/GenomicsDB/GenomicsDB/releases/download/v1.0.0/protobuf-3.0.2-trusty.tar.gz -O protobuf-3.0.2-trusty.tar.gz;
         tar xzf protobuf-3.0.2-trusty.tar.gz && sudo rsync -a protobuf-3.0.2-trusty/ /usr/;
-        sudo apt-get -y install libgtest-dev;
-        cd /usr/src/gtest;
-        sudo cmake . -DBUILD_SHARED_LIBS=1;
-        sudo make;
-        sudo mv libgtest* /usr/lib;
         cd $TRAVIS_BUILD_DIR;
         cd dependencies && git clone https://github.com/rgamble/libcsv && cd libcsv && ./configure && make;
         jdk_switcher use openjdk8;

--- a/.travis/scripts/install_osx_dependencies.sh
+++ b/.travis/scripts/install_osx_dependencies.sh
@@ -1,28 +1,5 @@
 #!/bin/bash
 
-install_gtest() {
-  GTEST_DIR=$TRAVIS_BUILD_DIR/dependencies/googletest-release-1.8.1
-  if [ ! -f $CACHE_DIR/googletest.tar ]; then
-     echo "Installing google test"
-     cd $TRAVIS_BUILD_DIR/dependencies
-     wget -nv https://github.com/google/googletest/archive/release-1.8.1.tar.gz &&
-     tar -xzf release-1.8.1.tar.gz &&
-     cd googletest-release-1.8.1/googletest && cmake . -DBUILD_SHARED_LIBS=1 && make &&
-     cd $GTEST_DIR && tar cf $CACHE_DIR/googletest.tar googletest/libgtest* googletest/include/gtest
-  else
-     echo "Extracting gtest"
-     if [ ! -d $GTEST_DIR ]; then
-       mkdir -p $GTEST_DIR
-     fi
-     cd $GTEST_DIR
-     tar -xf $CACHE_DIR/googletest.tar
-  fi
-  cd $GTEST_DIR/googletest &&
-  cp libgtest* /usr/local/lib && 
-  cp -r include/gtest /usr/local/include &&
-  echo "Installing google test SUCCESSFUL"
-}
-
 install_protobuf() {
   if [ ! -d $PROTOBUF_HOME ]; then
     mkdir -p $PROTOBUF_HOME
@@ -48,6 +25,5 @@ install_protobuf() {
 }
 
 echo "Installing OSX Dependencies"
-install_gtest &&
 install_protobuf &&
 echo "Installing OSX Dependencies DONE"


### PR DESCRIPTION
We do not need guest anymore as we have moved to Catch2.