### PR TITLE
Support jacoco for the new allinone GenomicsDB jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ src/main/java/com/intel/genomicsdb/GenomicsDBExportConfiguration.java
 src/main/java/com/intel/genomicsdb/GenomicsDBImportConfiguration.java
 src/main/java/com/intel/genomicsdb/GenomicsDBVidMapProto.java
 
+#python
+*.pyc
+
 #emacs
 *~
 \#*\#

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ script:
       elif [[ $TRAVIS_OS_NAME == osx && ! -f $CACHE_DIR/initialized ]]; then
         touch $CACHE_DIR/initialized;
       elif [[ $TRAVIS_OS_NAME == osx && -f $CACHE_DIR/initialized ]]; then
-        travis_wait 50 python2 $TRAVIS_BUILD_DIR/tests/run.py $GENOMICSDB_BUILD_DIR $GENOMICSDB_INSTALL_DIR $OSX_PHASE;
+        travis_wait 50 python2 $TRAVIS_BUILD_DIR/tests/run.py $GENOMICSDB_BUILD_DIR $GENOMICSDB_INSTALL_DIR Coverage $OSX_PHASE;
       else
         make test ARGS=-V;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
         - GENOMICSDB_INSTALL_DIR=$GENOMICSDB_BUILD_DIR/install
         - PATH=$GENOMICSDB_INSTALL_DIR/bin:$TRAVIS_BUILD_DIR/bin:$PATH
         - GENOMICSDB_RELEASE_VERSION=x.y.z-travis-test
-        - CLASSPATH=$GENOMICSDB_INSTALL_DIR/bin/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-allinone.jar:$GENOMICSDB_BUILD_DIR/target/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-examples.jar:.
         - secure: ns0xWDbnmDb71J0/edoJ4jN/xtPg4yxnbexe/AcTwHUOkLehEuGHY7tlZa8cTlBsV19+CFXpYXn4LezS/7989gPfI5Kl0lLg1T8I4V+t2iJTAXurjew0i1AVjQBKfVWtYhGJQOws8DMUDunTxEJMahZzdNK1McLxvongJ7mD1rLabSlLE81lSnsVwvms/4Cp6c2hxec8mNsxxV9CUDzrsX63te/srvPuG+FMD1E32PYuTJJpNH3O7/nvbuW5bOvdwT5Yq/dHGF96U+YZpvqH1PqqtXUuZRJltFUaTsdEclv9Q1DpSpikEmPL+iOJRgS1W0i+mZ2wShFYmSZIv/fwlVoE4bNnLd/dJOTsS6hSpVpEPJnK/YizPNxoB21LAZACdg6rSBnPClfMnYdkNilL9h1s/u4P6RTHUztc8Ty6z1qpi78pOjS3t26o36m87MtXnkkTp06Q0O5kDSM35xsTdBevGeT3lWfYSxRpM/ypqb6xTnii8ZQ+Ohe+m7AVFhE5nFh2JUxQRCcl0xjZQyy2nbLPmDfvnAM+yIvGBZPPiCVJgWy5Vs3Jm1TC5Ju63Rz+RzJfAIiy6DhnUDK74ip5NMP1PXey8ySKnOfcPcxCdJVqqtEARvt+zIhrbGZCkjDUR1L2OOBheZ6RKY/rsuAsVOBo9s+ELBz0Y4hWXDhmn5c=
 
 matrix:
@@ -134,12 +133,12 @@ script:
     - if [[ $INSTALL_TYPE == hdfs ]]; then
         echo "Run spark/hdfs tests";
         /usr/local/spark/sbin/start-master.sh;
-        travis_wait 40 python2 $TRAVIS_BUILD_DIR/tests/run_spark_hdfs.py $GENOMICSDB_BUILD_DIR $GENOMICSDB_INSTALL_DIR local hdfs://localhost:9000/ client $GENOMICSDB_RELEASE_VERSION $TRAVIS_BUILD_DIR/tests;
+        travis_wait 40 python2 $TRAVIS_BUILD_DIR/tests/run_spark_hdfs.py $GENOMICSDB_BUILD_DIR $GENOMICSDB_INSTALL_DIR local hdfs://localhost:9000/ client $GENOMICSDB_RELEASE_VERSION $TRAVIS_BUILD_DIR/tests Coverage;
       elif [[ $INSTALL_TYPE == gcs ]]; then
         echo "Run spark/gcs tests";
         /usr/local/spark/sbin/start-master.sh;
         export GOOGLE_APPLICATION_CREDENTIALS=~/GCS.json;
-        travis_wait 40 python2 $TRAVIS_BUILD_DIR/tests/run_spark_hdfs.py $GENOMICSDB_BUILD_DIR $GENOMICSDB_INSTALL_DIR local gs://$GS_BUCKET client $GENOMICSDB_RELEASE_VERSION $TRAVIS_BUILD_DIR/tests;
+        travis_wait 40 python2 $TRAVIS_BUILD_DIR/tests/run_spark_hdfs.py $GENOMICSDB_BUILD_DIR $GENOMICSDB_INSTALL_DIR local gs://$GS_BUCKET client $GENOMICSDB_RELEASE_VERSION $TRAVIS_BUILD_DIR/tests Coverage;
       elif [[ $TRAVIS_OS_NAME == osx && ! -f $CACHE_DIR/initialized ]]; then
         touch $CACHE_DIR/initialized;
       elif [[ $TRAVIS_OS_NAME == osx && -f $CACHE_DIR/initialized ]]; then
@@ -155,4 +154,4 @@ after_success:
     - lcov --remove coverage.info '/opt*' '/usr*' '*/dependencies/*' '*/src/test*' '*.pb.h' '*.pb.cc' -o coverage.info
     - lcov --list coverage.info
     # Uploading report to CodeCov
-    - cd $GENOMICSDB_INSTALL_DIR && bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+    - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,9 +105,6 @@ install:
 
     - cd $TRAVIS_BUILD_DIR
     - mkdir -p $GENOMICSDB_BUILD_DIR
-    # get jacoco
-    - wget https://github.com/jacoco/jacoco/releases/download/v0.8.2/jacoco-0.8.2.zip
-    - unzip -j jacoco-0.8.2.zip lib/jacocoagent.jar lib/jacococli.jar -d $GENOMICSDB_BUILD_DIR
 
 before_script:
     - cd $GENOMICSDB_BUILD_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,8 +456,9 @@ if(BUILD_JAVA)
     add_dependencies(mvn_central_deploy genomicsdb-${GENOMICSDB_RELEASE_VERSION}-examples)
 
     add_test(NAME CI_tests
-        COMMAND python2 ${CMAKE_SOURCE_DIR}/tests/run.py
-        ${CMAKE_BINARY_DIR}
-        ${CMAKE_INSTALL_PREFIX})
+      COMMAND python2 ${CMAKE_SOURCE_DIR}/tests/run.py
+      ${CMAKE_BINARY_DIR}
+      ${CMAKE_INSTALL_PREFIX}
+      ${CMAKE_BUILD_TYPE})
 
 endif()

--- a/tests/common.py
+++ b/tests/common.py
@@ -110,8 +110,10 @@ def report_jacoco_coverage(jacoco_report_cmd):
             stdout_string = pid.communicate()[0]
             if(pid.returncode != 0):
                 __error('jacoco report generation command:'+jacoco_report_cmd+' failed')
+            else:
+                rc = 0
         except Exception as e:
             __error('exception thrown while generating jacoco reports:'+str(e))
-        rc = 0
-    __error('jacoco_report_cmd does not seem to be passed as argument')
+    else:
+        __error('jacoco_report_cmd is null')
     return rc

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+#The MIT License (MIT)
+#Copyright (c) 2019 Omics Data Automation, Inc.
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy of 
+#this software and associated documentation files (the "Software"), to deal in
+#the Software without restriction, including without limitation the rights to
+#use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+#the Software, and to permit persons to whom the Software is furnished to do so, 
+#subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+#FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+#COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+#IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+#CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import errno
+import glob
+import os
+from os import environ
+import subprocess
+import sys
+import urllib
+import zipfile
+
+def __error(message):
+    sys.stderr.write('Error: '+message+'\n')
+
+def __error_exit(message):
+    __error(message)
+    sys.exit(-1)
+
+def __find_genomicsdb_jar(target_dir, jar_file_name):
+    jar_files=glob.glob(os.path.join(target_dir,jar_file_name))
+    jar_file=''
+    if (len(jar_files) == 1):
+        jar_file=jar_files[0]
+    else:
+        if (len(jar_files) == 0):
+            __error_exit('libraries matching '+jar_file_name+' not found')
+        else:
+            __error_exit('multiple libraries matching '+jar_file_name+ ' found')
+    if (not os.path.isfile(jar_file)):
+        __error_exit(jar_file+' found is not a library file')
+    return jar_file
+
+def setup_classpath(build_dir):
+    target_dir=os.path.join(build_dir,'target')
+    allinone_jar=__find_genomicsdb_jar(target_dir,'genomicsdb-*allinone.jar')
+    examples_jar=__find_genomicsdb_jar(target_dir,'genomicsdb-*examples.jar')
+    classpath=os.environ['CLASSPATH']
+    if (len(classpath) > 0):
+        environ["CLASSPATH"] = allinone_jar+os.pathsep+examples_jar
+    else:
+        environ["CLASSPATH"] = allinone_jar+os.pathsep+examples_jar+os.pathsep+classpath
+
+def setup_jacoco(build_dir, build_type):
+    jacoco= ''
+    jacoco_report_cmd=''
+    if (build_type.lower() == "coverage"):
+        target_dir = os.path.join(build_dir, 'target')
+        jacoco_cli_jar = os.path.join(build_dir,'lib/jacococli.jar')
+        jacoco_agent_jar = os.path.join(build_dir,'lib/jacocoagent.jar')
+        if (not os.path.isfile(jacoco_cli_jar) or not os.path.isfile(jacoco_agent_jar)):
+            jacoco_zip_file = os.path.join(build_dir, "jacoco-0.8.2.zip")
+            urllib.urlretrieve ("https://github.com/jacoco/jacoco/releases/download/v0.8.2/jacoco-0.8.2.zip", 
+                                jacoco_zip_file)
+            with zipfile.ZipFile(jacoco_zip_file, 'r') as zip_ref:
+                zip_ref.extract('lib/jacocoagent.jar', build_dir)
+                zip_ref.extract('lib/jacococli.jar', build_dir)
+            os.remove(jacoco_zip_file)
+        if (not os.path.isfile(jacoco_cli_jar) or not os.path.isfile(jacoco_agent_jar)):
+            __error_exit('could not find jacoco cli or agent jar files')
+        jacoco_reports_dir = os.path.join(target_dir, 'jacoco-reports')
+        jacoco_dest_file = os.path.join(jacoco_reports_dir,"jacoco-ci.exec")
+        jacoco = ' -javaagent:'+jacoco_agent_jar \
+                 +'=destfile='+jacoco_dest_file \
+                 +',includes=org.genomicsdb.*'
+        try:
+            os.makedirs(os.path.join(jacoco_reports_dir, 'jacoco-ci'))
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                __error_exit('could not create jacoco-reports dir:'+e.errno+' '+e.filename+' '+e.strerror)
+        genomicsdb_classes_dir = os.path.join(target_dir, 'jacoco-classes')
+        allinone_archive = zipfile.ZipFile(__find_genomicsdb_jar(target_dir,'genomicsdb-*allinone.jar'))
+        for file in allinone_archive.namelist():
+            if file.startswith('org/genomicsdb'):
+                allinone_archive.extract(file, genomicsdb_classes_dir)
+        jacoco_report_cmd = 'java -jar '+jacoco_cli_jar \
+                            +' report '+jacoco_dest_file \
+                            +' --classfiles '+genomicsdb_classes_dir \
+                            +' --html '+jacoco_reports_dir \
+                            +' --xml '+os.path.join(os.path.join(jacoco_reports_dir, 'jacoco-ci'),'jacoco-ci.xml')
+    return jacoco, jacoco_report_cmd
+
+def report_jacoco_coverage(jacoco_report_cmd):
+    rc = -1
+    if (len(jacoco_report_cmd) > 0):
+        try:
+            pid = subprocess.Popen(jacoco_report_cmd, shell=True, stdout=subprocess.PIPE);
+            stdout_string = pid.communicate()[0]
+            if(pid.returncode != 0):
+                __error('jacoco report generation command:'+jacoco_report_cmd+' failed')
+        except Exception as e:
+            __error('exception thrown while generating jacoco reports:'+str(e))
+        rc = 0
+    __error('jacoco_report_cmd does not seem to be passed as argument')
+    return rc

--- a/tests/common.py
+++ b/tests/common.py
@@ -115,5 +115,5 @@ def report_jacoco_coverage(jacoco_report_cmd):
         except Exception as e:
             __error('exception thrown while generating jacoco reports:'+str(e))
     else:
-        __error('jacoco_report_cmd is null')
+        rc = 0
     return rc

--- a/tests/common.py
+++ b/tests/common.py
@@ -54,7 +54,10 @@ def setup_classpath(build_dir):
     target_dir=os.path.join(build_dir,'target')
     allinone_jar=__find_genomicsdb_jar(target_dir,'genomicsdb-*allinone.jar')
     examples_jar=__find_genomicsdb_jar(target_dir,'genomicsdb-*examples.jar')
-    classpath=os.environ['CLASSPATH']
+    if 'CLASSPATH' in os.environ:
+        classpath=os.environ['CLASSPATH']
+    else:
+        classpath=''
     if (len(classpath) > 0):
         environ["CLASSPATH"] = allinone_jar+os.pathsep+examples_jar
     else:

--- a/tests/run.py
+++ b/tests/run.py
@@ -335,14 +335,14 @@ def main():
         sys.stderr.write('Usage ./run.py <build_dir> <install_dir> [<build_type>] [<split_batch_num>]\n')
         sys.stderr.write('   Optional Argument 3 - build_type=Release|Coverage|...\n')
         sys.stderr.write('   Optional Argument 4 - Tests are batched into two to help with Travis builds on MacOS\n')
-        sys.stderr.write('                         specify batch with split_batch_num=0|1\n')
+        sys.stderr.write('                         specify batch with split_batch_num=1|2\n')
         sys.stderr.write('                         Otherwise all tests are run.\n\n')
         sys.exit(-1);
     build_dir=os.path.abspath(sys.argv[1])
     ctest_dir = os.path.join(build_dir, 'src/test/cpp')
     exe_path = os.path.join(sys.argv[2],'bin')
     tool_sanity_checks(exe_path);
-    if (len(sys.argv) == 4):
+    if (len(sys.argv) >= 4):
         build_type = sys.argv[3]
     else:
         build_type = "default"
@@ -1313,7 +1313,6 @@ def main():
         loader_tests = loader_tests0
     else:
         loader_tests = loader_tests1
-
     for test_params_dict in loader_tests:
         test_name = test_params_dict['name']
         test_loader_dict = create_loader_json(ws_dir, test_name, test_params_dict);
@@ -1495,7 +1494,7 @@ def main():
     test_pre_1_0_0_query_compatibility(tmpdir)
     rc = common.report_jacoco_coverage(jacoco_report_cmd)
     if (rc != 0):
-        cleanup_and_exit(namenode, tmpdir, -1);
+        cleanup_and_exit(tmpdir, -1);
     cleanup_and_exit(tmpdir, 0)
 
 if __name__ == '__main__':

--- a/tests/run_spark_hdfs.py
+++ b/tests/run_spark_hdfs.py
@@ -2,6 +2,7 @@
 
 #The MIT License (MIT)
 #Copyright (c) 2018 University of California, Los Angeles and Intel Corporation
+#Copyright (c) 2019 Omics Data Automation, Inc.
 
 #Permission is hereby granted, free of charge, to any person obtaining a copy of 
 #this software and associated documentation files (the "Software"), to deal in 
@@ -31,6 +32,8 @@ import shutil
 import difflib
 import errno
 from collections import OrderedDict
+
+import common
 
 query_json_template_string="""
 {   
@@ -192,7 +195,8 @@ def cleanup_and_exit(namenode, tmpdir, exit_code):
 
 def main():
     if(len(sys.argv) < 8):
-        sys.stderr.write('Needs 7 arguments <build_dir> <install_dir> <spark_master> <hdfs_namenode> <spark_deploy> <genomicsdb_version> <test_dir>\n');
+        sys.stderr.write('Usage: ./run_spark_hdfs.py <build_dir> <install_dir> <spark_master> <hdfs_namenode> <spark_deploy> <genomicsdb_version> <test_dir> [<build_type>]\n');
+        sys.stderr.write('   Optional Argument 8 - build_type=Release|Coverage|...\n')
         sys.exit(-1);
     exe_path = sys.argv[2]+os.path.sep+'bin';
     spark_master = sys.argv[3];
@@ -201,6 +205,10 @@ def main():
     spark_deploy = sys.argv[5];
     genomicsdb_version = sys.argv[6];
     test_dir = sys.argv[7];
+    if (len(sys.argv) == 9):
+        build_type = sys.argv[8]
+    else:
+        build_type = "default"
     #Switch to tests directory
     parent_dir=os.path.dirname(os.path.realpath(__file__))
     os.chdir(parent_dir)
@@ -209,7 +217,7 @@ def main():
     template_vcf_header_path=parent_dir+os.path.sep+'inputs'+os.path.sep+'template_vcf_header.vcf';
     tmpdir = tempfile.mkdtemp()
     ws_dir=tmpdir+os.path.sep+'ws';
-    jacoco_enabled = os.path.isfile(sys.argv[1]+os.path.sep+'jacocoagent.jar') and os.path.isfile(sys.argv[1]+os.path.sep+'jacococli.jar')
+    jacoco, jacoco_report_cmd = common.setup_jacoco(os.path.abspath(sys.argv[1]), build_type)
     loader_tests = [
             { "name" : "t0_1_2", 'golden_output' : 'golden_outputs/t0_1_2_loading',
                 'callset_mapping_file': 'inputs/callsets/t0_1_2.json',
@@ -347,17 +355,6 @@ def main():
                 ]
             },
     ];
-    if jacoco_enabled:
-        jacoco_dest_file = "=destfile="+sys.argv[1]+os.path.sep+"target"+os.path.sep+"jacoco-reports"+os.path.sep+"jacoco-ci.exec"
-        jacoco = " -javaagent:"+sys.argv[1]+os.path.sep+"jacocoagent.jar"+jacoco_dest_file
-        try:
-            os.makedirs(sys.argv[1]+os.path.sep+'target'+os.path.sep+'jacoco-reports'+os.path.sep+'jacoco-ci')
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                sys.stderr.write('Error creating jacoco-reports dir:'+e.errno+' '+e.filename+' '+e.strerror)
-                cleanup_and_exit("", tmpdir, -1);
-    else:
-        jacoco = ''
     if("://" in namenode):
         pid = subprocess.Popen('hadoop fs -mkdir -p '+namenode+'/home/hadoop/.tiledb/', shell=True, stdout=subprocess.PIPE);
         stdout_string = pid.communicate()[0]
@@ -464,16 +461,10 @@ def main():
                         sys.stderr.write('Spark stdout was: '+stdout_string+'\n');
                         sys.stderr.write('Spark stderr was: '+stderr_string+'\n');
                         cleanup_and_exit(namenode, tmpdir, -1);
-            
-    if jacoco_enabled:
-        jacoco_ci_report_dir = sys.argv[1]+os.path.sep+'target'+os.path.sep+'jacoco-reports'+os.path.sep
-        jacoco_report_cmd = 'java -jar '+sys.argv[1]+os.path.sep+'jacococli.jar report '+jacoco_ci_report_dir+'jacoco-ci.exec --classfiles '+sys.argv[1]+os.path.sep+'target'+os.path.sep+'classes --html '+jacoco_ci_report_dir+'jacoco-ci --xml '+jacoco_ci_report_dir+'jacoco-ci'+os.path.sep+'jacoco-ci.xml'
-        pid = subprocess.Popen(jacoco_report_cmd, shell=True, stdout=subprocess.PIPE);
-        stdout_string = pid.communicate()[0]
-        if(pid.returncode != 0):
-            sys.stderr.write('Jacoco report generation command:'+jacoco_report_cmd+' failed\n')
-            cleanup_and_exit(namenode, tmpdir, -1); 
-    cleanup_and_exit(namenode, tmpdir, 0); 
+        rc = common.report_jacoco_coverage(jacoco_report_cmd)
+        if (rc != 0):
+            cleanup_and_exit(namenode, tmpdir, -1)
+    cleanup_and_exit(namenode, tmpdir, 0)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Refactored common jacoco parts out of run.py and run_spark_hdfs.py into common.py
Added support to pass an optional build-type argument to the CI scripts.