### PR TITLE
minor cleanup for warnings

### DIFF
--- a/src/main/java/org/genomicsdb/spark/GenomicsDBConfiguration.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBConfiguration.java
@@ -188,7 +188,7 @@ public class GenomicsDBConfiguration extends Configuration implements Serializab
     JSONArray colPar = (JSONArray)obj.get("column_partitions");
     if(colPar == null)
       throw new RuntimeException("Could not find attribute \"column_partitions\" in the JSON configuration");
-    Iterator<JSONObject> it = colPar.iterator();
+    Iterator it = colPar.iterator();
     while (it.hasNext()) {
       JSONObject obj0 = (JSONObject)it.next();
       String workspace = null, array = null, vcf_output_filename = null;

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBDataSourceReader.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBDataSourceReader.java
@@ -42,7 +42,7 @@ import java.util.Map;
 
 public class GenomicsDBDataSourceReader implements DataSourceReader {
 
-  GenomicsDBInput input;
+  GenomicsDBInput<GenomicsDBInputPartition> input;
 
   public GenomicsDBDataSourceReader() {}
 
@@ -150,7 +150,7 @@ public class GenomicsDBDataSourceReader implements DataSourceReader {
                     sf.name(), DataType.fromDDL(dtypeDDL), sf.nullable(), sf.metadata()));
       }
     }
-    input = new GenomicsDBInput<GenomicsDBInputPartition>(
+    input = new GenomicsDBInput<>(
             genomicsDBConfiguration,
             finalSchema,
             vMap,
@@ -173,11 +173,11 @@ public class GenomicsDBDataSourceReader implements DataSourceReader {
       FileReader vidReader = new FileReader(vidMapping);
       JSONObject objVid = (JSONObject) parser.parse(vidReader);
 
-      JSONObject fields = (JSONObject) objVid.get("fields");
+      HashMap<?,?> fields = (HashMap<?,?>) objVid.get("fields");
       fields.forEach(
           (k, vObj) -> {
             // ignore fields without vcf_field_class
-            JSONObject v = (JSONObject) vObj;
+            HashMap<?,?> v = (HashMap<?,?>) vObj;
             JSONArray fieldClass = (JSONArray) v.get("vcf_field_class");
             if (fieldClass != null) {
               Class<?> clazz;
@@ -201,7 +201,12 @@ public class GenomicsDBDataSourceReader implements DataSourceReader {
                 default:
                   throw new RuntimeException("Unsupported type " + vType + " in vid mapping");
               }
-              String length = (String) v.getOrDefault("length", "1").toString();
+              String length;
+              if(v.get("length") == null) {
+                length = "1";
+              } else {
+                length = v.get("length").toString();
+              }
               // if field is INFO or FORMAT
               if (fieldClass.size() == 1) {
                 vMap.put((String) k, new GenomicsDBVidSchema(fieldClass.get(0).equals("INFO"), clazz, length));
@@ -223,10 +228,13 @@ public class GenomicsDBDataSourceReader implements DataSourceReader {
     return vMap;
   }
 
+  @Override
+  @SuppressWarnings("unchecked")
   public List<InputPartition<InternalRow>> planInputPartitions() {
-    return input.divideInput();
+    return (List)input.divideInput();
   }
 
+  @Override
   public StructType readSchema() {
     return input.getSchema();
   }

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
@@ -435,9 +435,9 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
     try {
       JSONParser parser = new JSONParser();
       FileReader queryJsonReader = new FileReader(queryFile);
-      JSONObject obj = null;
+      HashMap<?,?> obj = null;
       try {
-        obj = (JSONObject)parser.parse(queryJsonReader);
+        obj = (HashMap<?,?>)parser.parse(queryJsonReader);
       }
       catch(ParseException | IOException e) {
         queryJsonReader.close();
@@ -564,24 +564,24 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
           case "query_block_size":
             {
               if(exportConfigurationBuilder.hasSparkConfig()) {
-                exportConfigurationBuilder.getSparkConfigBuilder().setQueryBlockSize((long)val);
+                exportConfigurationBuilder.getSparkConfigBuilder().setQueryBlockSize((long)((Object)val));
               }
               else {
                 GenomicsDBExportConfiguration.SparkConfig.Builder configBuilder = 
                         GenomicsDBExportConfiguration.SparkConfig.newBuilder();
-                exportConfigurationBuilder.setSparkConfig(configBuilder.setQueryBlockSize((long)val).build());
+                exportConfigurationBuilder.setSparkConfig(configBuilder.setQueryBlockSize((long)((Object)val)).build());
               }
             }
             break;
           case "query_block_size_margin":
             {
               if(exportConfigurationBuilder.hasSparkConfig()) {
-                exportConfigurationBuilder.getSparkConfigBuilder().setQueryBlockSizeMargin((long)val);
+                exportConfigurationBuilder.getSparkConfigBuilder().setQueryBlockSizeMargin((long)((Object)val));
               }
               else {
                 GenomicsDBExportConfiguration.SparkConfig.Builder configBuilder = 
                         GenomicsDBExportConfiguration.SparkConfig.newBuilder();
-                exportConfigurationBuilder.setSparkConfig(configBuilder.setQueryBlockSizeMargin((long)val).build());
+                exportConfigurationBuilder.setSparkConfig(configBuilder.setQueryBlockSizeMargin((long)((Object)val)).build());
               }
             }
             break;

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInputPartition.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInputPartition.java
@@ -65,10 +65,12 @@ public class GenomicsDBInputPartition
     this.schema = schema;
   }
 
-  public InputPartitionReader createPartitionReader() {
+  @Override
+  public InputPartitionReader<InternalRow> createPartitionReader() {
     return new GenomicsDBInputPartitionReader(this);
   }
 
+  @Override
   public String[] preferredLocations() {
     if (hosts == null) {
       return new String[] {};

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInputPartitionReader.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInputPartitionReader.java
@@ -286,7 +286,7 @@ public class GenomicsDBInputPartitionReader implements InputPartitionReader<Inte
             */
             rowObjectArray[i++] =
                 ArrayData.toArrayData(
-                    ((List) (g.getAnyAttribute(fName)))
+                    ((List<?>) (g.getAnyAttribute(fName)))
                         .toArray((Object[]) Array.newInstance(field.getFieldClass(), 0)));
           } else {
             rowObjectArray[i++] = null;

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBJavaSparkFactory.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBJavaSparkFactory.java
@@ -40,6 +40,7 @@ import java.util.List;
  */
 public final class GenomicsDBJavaSparkFactory {
 
+  @SuppressWarnings("unchecked")
   public static void usingNewAPIHadoopRDD(String[] args) {
     
     String loaderJsonFile = args[0];
@@ -56,8 +57,7 @@ public final class GenomicsDBJavaSparkFactory {
     hadoopConf.set(GenomicsDBConfiguration.MPIHOSTFILE, hostfile);
 
     JavaPairRDD variants;
-    Class gformatClazz = GenomicsDBInputFormat.class;
-    variants = sc.newAPIHadoopRDD(hadoopConf, gformatClazz, String.class, VariantContext.class);
+    variants = sc.newAPIHadoopRDD(hadoopConf, GenomicsDBInputFormat.class, String.class, VariantContext.class);
 
     System.out.println("Number of variants "+variants.count());
     List variantList = variants.collect();


### PR DESCRIPTION
I had to resort to SuppressWarning annotation for a few of these. In a couple of instances I'm trying to reuse some code that breaks up spark work into chunks for the workers. The interfaces/classes used for the RDD path vs the dataframe path don't share any common superclasses...so I couldn't figure out a way to get rid of the unchecked cast for those.
