### PR TITLE
small fix

### DIFF
--- a/src/main/cpp/src/vcf/vcf2binary.cc
+++ b/src/main/cpp/src/vcf/vcf2binary.cc
@@ -90,7 +90,7 @@ void VCFBufferReader::read_and_advance() {
     //Parsed or made progress
     assert(new_offset > BufferReaderBase::m_offset);
     BufferReaderBase::m_offset = new_offset;
-    m_is_record_valid = true;
+    m_is_record_valid = m_line->errcode == 0;
   }
 }
 


### PR DESCRIPTION
This will make it so that we don't crash when we're using vcfbufferreader (for instance, when gatk/genomicsdbimport is being used) and the VCF happens to contains something invalid. Currently, we suffer a segfault, but this will make things consistent with vcf2tiledb in that we'll show an error from htslib and then end up ignoring that sample while continuing the import without a fatal error.