### PR TITLE
Allow for IOExceptions to propogate into GenomicsDBFeatureReader

### DIFF
--- a/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureIterator.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureIterator.java
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  * Copyright (c) 2016-2018 Intel Corporation
+ * Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureIterator.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureIterator.java
@@ -30,8 +30,13 @@ import htsjdk.variant.bcf2.BCF2Codec;
 import org.genomicsdb.model.GenomicsDBExportConfiguration;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
+import java.util.Collections;
+import java.lang.RuntimeException;
 
 import static org.genomicsdb.Constants.CHROMOSOME_FOLDER_DELIMITER_SYMBOL_REGEX;
 

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  * Copyright (c) 2016-2018 Intel Corporation
+ * Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -106,7 +106,7 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
      *
      * @return iterator over {@link htsjdk.variant.variantcontext.VariantContext} objects
      */
-    public CloseableTribbleIterator<T> iterator() {
+    public CloseableTribbleIterator<T> iterator() throws IOException {
         if (this.exportConfiguration.hasArrayName()) {
             return new GenomicsDBFeatureIterator<>(this.loaderJSONFile,
                     this.exportConfiguration, Optional.empty(), 
@@ -130,7 +130,7 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
      * @param end   end position, inclusive (1-based)
      * @return iterator over {@link htsjdk.variant.variantcontext.VariantContext} objects
      */
-    public CloseableTribbleIterator<T> query(final String chr, final int start, final int end) {
+    public CloseableTribbleIterator<T> query(final String chr, final int start, final int end) throws IOException {
         if (this.exportConfiguration.hasArrayName()) {
             return new GenomicsDBFeatureIterator<>(this.loaderJSONFile,
                     this.exportConfiguration, Optional.empty(), 

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBQueryStream.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBQueryStream.java
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 

--- a/src/main/jni/include/genomicsdb_GenomicsDBQueryStream.h
+++ b/src/main/jni/include/genomicsdb_GenomicsDBQueryStream.h
@@ -9,11 +9,16 @@ extern "C" {
 #endif
 #undef org_genomicsdb_reader_GenomicsDBQueryStream_MAX_SKIP_BUFFER_SIZE
 #define org_genomicsdb_reader_GenomicsDBQueryStream_MAX_SKIP_BUFFER_SIZE 2048L
-
+#undef org_genomicsdb_reader_GenomicsDBQueryStream_DEFAULT_READ_AS_BCF
+#define org_genomicsdb_reader_GenomicsDBQueryStream_DEFAULT_READ_AS_BCF 1L
+#undef org_genomicsdb_reader_GenomicsDBQueryStream_DEFAULT_USE_MISSING_ONLY_NOT_VECTOR_END
+#define org_genomicsdb_reader_GenomicsDBQueryStream_DEFAULT_USE_MISSING_ONLY_NOT_VECTOR_END 1L
+#undef org_genomicsdb_reader_GenomicsDBQueryStream_DEFAULT_KEEP_IDX_FIELDS_IN_HEADER
+#define org_genomicsdb_reader_GenomicsDBQueryStream_DEFAULT_KEEP_IDX_FIELDS_IN_HEADER 0L
 /*
  * Class:     org_genomicsdb_reader_GenomicsDBQueryStream
  * Method:    jniGenomicsDBInit
- * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIIJJ)J
+ * Signature: (Ljava/lang/String;[BLjava/lang/String;IIIJJZZZZ)J
  */
 JNIEXPORT jlong JNICALL Java_org_genomicsdb_reader_GenomicsDBQueryStream_jniGenomicsDBInit
   (JNIEnv *, jobject, jstring, jbyteArray, jstring, jint, jint, jint, jlong, jlong, jboolean, jboolean, jboolean, jboolean);

--- a/src/main/jni/src/genomicsdb_GenomicsDBQueryStream.cc
+++ b/src/main/jni/src/genomicsdb_GenomicsDBQueryStream.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 


### PR DESCRIPTION
Remove catch(...) in jniGenomicsDBInit as that was masking the C/C++ exceptions thrown. 
The FeatureReader interface has query/iterator/close all throw IOExceptions, so
- Matched GenomicsDBFeatureReader implementation of FeatureReader to throw IOExceptions. 
- Got GenomicsDBStream constructors and jniGenomicsDBInit to throw IOExceptions as well.
This allowed us to see the IOExceptions propagated into the gatk layers where the IOException was handled properly. e.g
```
org.broadinstitute.hellbender.exceptions.GATKException: Error querying gendb:///tmp/genomicsDBWorkspace5332118045648407634/workspace over interval 20:1-63025520
... Stack Trace ...
Caused by: java.io.IOException: GenomicsDB JNI Error: Broad combine GVCFs exception : Unknown contig for position 2728661124
... GenomicsDB Stack Trace ...
```
