### PR TITLE
Reduce memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,11 @@ else()
   set(PROTOBUF_JAVA_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/src/main/java")
 endif()
 include_directories(${PROTOBUF_INCLUDE_DIRS})
+CHECK_IF_USING_PROTOBUF_V_3_0_0_BETA_1(USE_PROTOBUF_V_3_0_0_BETA_1)
+if(USE_PROTOBUF_V_3_0_0_BETA_1)
+  add_definitions(-DUSE_PROTOBUF_V_3_0_0_BETA_1)
+  message(STATUS "Using Protobuf v3.0.0-beta-1")
+endif()
 
 #JNI
 if(BUILD_JAVA)

--- a/cmake/Modules/FindProtobufWrapper.cmake
+++ b/cmake/Modules/FindProtobufWrapper.cmake
@@ -17,3 +17,24 @@ if(PROTOBUF_FOUND)
     set(PROTOBUF_INCLUDE_DIR ${PROTOBUF_INCLUDE_DIRS})
 endif()
 include(FindProtobuf)
+
+include(CheckCXXSourceCompiles)
+function(CHECK_IF_USING_PROTOBUF_V_3_0_0_BETA_1 FLAG_VAR_NAME)
+  set(PB_test_source
+    "
+    #include <google/protobuf/util/json_util.h>
+    int main() {
+      google::protobuf::util::JsonParseOptions parse_opt;
+      parse_opt.ignore_unknown_fields = true;
+      return 0;
+    }
+    "
+    )
+  set(CMAKE_REQUIRED_INCLUDES ${PROTOBUF_INCLUDE_DIRS})
+  check_cxx_source_compiles("${PB_test_source}" PROTOBUF_V3_STABLE_FOUND)
+  if(PROTOBUF_V3_STABLE_FOUND)
+    set(${FLAG_VAR_NAME} False PARENT_SCOPE)
+  else()
+    set(${FLAG_VAR_NAME} True PARENT_SCOPE)
+  endif()
+endfunction()

--- a/src/main/cpp/include/query_operations/broad_combined_gvcf.h
+++ b/src/main/cpp/include/query_operations/broad_combined_gvcf.h
@@ -78,7 +78,9 @@ class BroadCombinedGVCFOperator : public GA4GHOperator {
   //(sum) and not if the combine is a median operation for example.
   bool remap_if_needed_and_combine(const Variant& variant,
     const unsigned query_field_idxs[],
-    const VCFFieldCombineOperationEnum combine_op);
+    const VCFFieldCombineOperationEnum combine_op,
+    const void** output_idx,
+    unsigned& num_result_elements);
   void handle_INFO_fields(const Variant& variant);
   void handle_FORMAT_fields(const Variant& variant);
   void handle_deletions(Variant& variant, const VariantQueryConfig& query_config);

--- a/src/main/cpp/include/utils/vid_mapper.h
+++ b/src/main/cpp/include/utils/vid_mapper.h
@@ -239,7 +239,7 @@ class FieldLengthDescriptor {
     assert(m_is_length_ploidy_dependent);
     return (get_length_descriptor(0u) == BCF_VL_Phased_Ploidy);
   }
-  size_t get_num_elements(const unsigned num_ALT_alleles, const unsigned ploidy, const unsigned num_elements);
+  size_t get_num_elements(const unsigned num_ALT_alleles, const unsigned ploidy, const unsigned num_elements) const;
   void set_vcf_delimiter(const size_t dim_idx, const char* vcf_delim) {
     assert(vcf_delim);
     assert(dim_idx < m_vcf_delimiter_vec.size());

--- a/src/main/cpp/src/config/pb_config.cc
+++ b/src/main/cpp/src/config/pb_config.cc
@@ -257,10 +257,11 @@ void GenomicsDBConfigBase::get_pb_from_json_file(
   if (TileDBUtils::read_entire_file(json_file, (void **)&json_buffer, &json_buffer_length) != TILEDB_OK
         || !json_buffer || json_buffer_length == 0) { 
     free(json_buffer);
-    std::cerr << "Could not open JSON file "+json_file+"\n";
-    exit(-1);
+    throw GenomicsDBConfigException(std::string("Could not open query JSON file ")+json_file);
   }
   std::string json_to_binary_output;
+  google::protobuf::util::JsonParseOptions parse_opt;
+  parse_opt.ignore_unknown_fields = true;
   //The function JsonStringToMessage was made available in Protobuf version 3.0.0. However,
   //to maintain compatibility with GATK-4, we need to use 3.0.0-beta-1. This version doesn't have
   //the JsonStringToMessage method. A workaround is as follows.
@@ -269,15 +270,15 @@ void GenomicsDBConfigBase::get_pb_from_json_file(
       "", google::protobuf::DescriptorPool::generated_pool());
   auto status = google::protobuf::util::JsonToBinaryString(resolver,
       "/"+pb_config->GetDescriptor()->full_name(), json_buffer,
-      &json_to_binary_output);
+      &json_to_binary_output, parse_opt);
   if (!status.ok()) {
-    std::cerr << "Error converting JSON to binary string\n";
-    exit(-1);
+    delete resolver;
+    free(json_buffer);
+    throw GenomicsDBConfigException(std::string("Error converting JSON to binary string from file ")+json_file);
   }
   delete resolver;
+  free(json_buffer);
   auto success = pb_config->ParseFromString(json_to_binary_output);
-  if(!success) {
-    std::cerr << "Could not parse JSON file to protobuf\n";
-    exit(-1);
-  }
+  if(!success)
+    throw GenomicsDBConfigException(std::string("Could not parse query JSON file to protobuf ")+json_file);
 }

--- a/src/main/cpp/src/config/pb_config.cc
+++ b/src/main/cpp/src/config/pb_config.cc
@@ -260,8 +260,10 @@ void GenomicsDBConfigBase::get_pb_from_json_file(
     throw GenomicsDBConfigException(std::string("Could not open query JSON file ")+json_file);
   }
   std::string json_to_binary_output;
+#ifndef USE_PROTOBUF_V_3_0_0_BETA_1
   google::protobuf::util::JsonParseOptions parse_opt;
   parse_opt.ignore_unknown_fields = true;
+#endif
   //The function JsonStringToMessage was made available in Protobuf version 3.0.0. However,
   //to maintain compatibility with GATK-4, we need to use 3.0.0-beta-1. This version doesn't have
   //the JsonStringToMessage method. A workaround is as follows.
@@ -270,7 +272,11 @@ void GenomicsDBConfigBase::get_pb_from_json_file(
       "", google::protobuf::DescriptorPool::generated_pool());
   auto status = google::protobuf::util::JsonToBinaryString(resolver,
       "/"+pb_config->GetDescriptor()->full_name(), json_buffer,
-      &json_to_binary_output, parse_opt);
+      &json_to_binary_output
+#ifndef USE_PROTOBUF_V_3_0_0_BETA_1
+      , parse_opt
+#endif
+      );
   if (!status.ok()) {
     delete resolver;
     free(json_buffer);

--- a/src/main/cpp/src/genomicsdb/query_variants.cc
+++ b/src/main/cpp/src/genomicsdb/query_variants.cc
@@ -754,7 +754,7 @@ void VariantQueryProcessor::gt_get_column_interval(
 #if VERBOSE>0
   std::cerr << "[query_variants:gt_get_column_interval] re-arrangement of variants " << std::endl;
 #endif
-  GA4GHOperator variant_operator(query_config, *m_vid_mapper);
+  GA4GHOperator variant_operator(query_config, *m_vid_mapper, false);
   for (auto i=start_variant_idx; i<variants.size(); ++i)
     if (variants[i].get_num_calls() > 1u) { //possible re-arrangement of PL/AD/GT fields needed
 #ifdef DO_PROFILING

--- a/src/main/cpp/src/genomicsdb/variant_field_handler.cc
+++ b/src/main/cpp/src/genomicsdb/variant_field_handler.cc
@@ -400,7 +400,7 @@ void GenotypeForMinValueTracker<DataType>::determine_allele_combination_and_geno
 
 template<class DataType>
 GenotypeForMinValueResultTuple VariantFieldHandler<DataType>::determine_allele_combination_and_genotype_index_for_min_value(
-  std::unique_ptr<VariantFieldBase>& orig_field_ptr,
+  const std::unique_ptr<VariantFieldBase>& orig_field_ptr,
   unsigned num_merged_alleles, bool non_ref_exists, const unsigned ploidy) {
   m_min_genotype_tracker.reset();
   if (!(orig_field_ptr.get() && orig_field_ptr->is_valid()))
@@ -453,7 +453,8 @@ GenotypeForMinValueResultTuple VariantFieldHandler<DataType>::determine_allele_c
 
 //Variant handler functions
 template<class DataType>
-void VariantFieldHandler<DataType>::remap_vector_data(std::unique_ptr<VariantFieldBase>& orig_field_ptr, uint64_t curr_call_idx_in_variant,
+void VariantFieldHandler<DataType>::remap_vector_data(const std::unique_ptr<VariantFieldBase>& orig_field_ptr,
+    uint64_t curr_call_idx_in_variant,
     const CombineAllelesLUT& alleles_LUT,
     unsigned num_merged_alleles, bool non_ref_exists, const unsigned ploidy,
     const FieldLengthDescriptor& length_descriptor, unsigned num_merged_elements, RemappedVariant& remapper_variant) {
@@ -520,19 +521,8 @@ bool VariantFieldHandler<DataType>::get_valid_sum(const Variant& variant, const 
   //Iterate over valid calls
   for (auto iter=variant.begin(), end_iter = variant.end(); iter != end_iter; ++iter) {
     auto& curr_call = *iter;
-    auto& field_ptr = curr_call.get_field(query_idx);
-    //Valid field
-    if (field_ptr.get() && field_ptr->is_valid()) {
-      //Must always be vector<DataType>
-      auto* ptr = dynamic_cast<VariantFieldPrimitiveVectorData<DataType>*>(field_ptr.get());
-      assert(ptr);
-      assert((ptr->get()).size() > 0u);
-      auto val = ptr->get()[0u];
-      if (is_bcf_valid_value<DataType>(val)) {
-        sum += val;
-        ++valid_idx;
-      }
-    }
+    auto is_valid = get_valid_sum(curr_call.get_field(query_idx), sum);
+    valid_idx += (is_valid ? 1u : 0u);
   }
   num_valid_elements = valid_idx;
   if (valid_idx == 0u)  //no valid fields found
@@ -542,6 +532,24 @@ bool VariantFieldHandler<DataType>::get_valid_sum(const Variant& variant, const 
   return true;
 }
 
+template<class DataType>
+bool VariantFieldHandler<DataType>::get_valid_sum(const std::unique_ptr<VariantFieldBase>& field_ptr,
+    DataType& sum) {
+  auto is_valid = false;
+  //Valid field
+  if (field_ptr.get() && field_ptr->is_valid()) {
+    //Must always be vector<DataType>
+    const auto* ptr = dynamic_cast<const VariantFieldPrimitiveVectorData<DataType>*>(field_ptr.get());
+    assert(ptr);
+    assert((ptr->get()).size() > 0u);
+    auto val = ptr->get()[0u];
+    if (is_bcf_valid_value<DataType>(val)) {
+      sum += val;
+      is_valid = true;
+    }
+  }
+  return is_valid;
+}
 
 template<class DataType>
 bool VariantFieldHandler<DataType>::get_valid_mean(const Variant& variant, const VariantQueryConfig& query_config,
@@ -563,44 +571,56 @@ bool VariantFieldHandler<std::string>::get_valid_mean(const Variant& variant, co
 }
 
 template<class DataType>
+void VariantFieldHandler<DataType>::compute_valid_element_wise_sum(
+    const std::unique_ptr<VariantFieldBase>& field_ptr,
+    const bool reset_accumulator) {
+  if(reset_accumulator)
+    m_element_wise_operations_result.clear();
+  const auto prev_num_elements = m_element_wise_operations_result.size();
+  //Valid field
+  if (field_ptr.get() && field_ptr->is_valid()) {
+    //Must always be vector<DataType>
+    const auto* ptr = dynamic_cast<const VariantFieldPrimitiveVectorData<DataType>*>(field_ptr.get());
+    assert(ptr);
+    const auto& vec = ptr->get();
+    if (vec.size() > m_element_wise_operations_result.size())
+      m_element_wise_operations_result.resize(vec.size(), get_bcf_missing_value<DataType>());
+    for (auto i=0ull; i<std::min(vec.size(), prev_num_elements); ++i) {
+      auto old_value = m_element_wise_operations_result[i];
+      auto new_value = vec[i];
+      auto is_old_value_valid = is_bcf_valid_value<DataType>(old_value);
+      auto is_new_value_valid = is_bcf_valid_value<DataType>(new_value);
+      auto updated_val = get_zero_value<DataType>();
+      if(!is_old_value_valid && !is_new_value_valid)
+	updated_val = new_value;
+      else {
+	if(is_old_value_valid)
+	  updated_val += old_value;
+	if(is_new_value_valid)
+	  updated_val += new_value;
+      }
+      m_element_wise_operations_result[i] = updated_val;
+    }
+    if(prev_num_elements < vec.size()) {
+      auto num_bytes = (vec.size()-prev_num_elements)*sizeof(DataType); 
+      memcpy_s(&(m_element_wise_operations_result[prev_num_elements]), num_bytes,
+	  &(vec[prev_num_elements]), num_bytes);
+    }
+  }
+}
+
+template<class DataType>
 bool VariantFieldHandler<DataType>::compute_valid_element_wise_sum(const Variant& variant, const VariantQueryConfig& query_config,
     unsigned query_idx, const void** output_ptr, unsigned& num_elements) {
-  auto num_valid_elements = 0u;
+  m_element_wise_operations_result.clear();
   //Iterate over valid calls
   for (auto iter=variant.begin(), end_iter = variant.end(); iter != end_iter; ++iter) {
     auto& curr_call = *iter;
-    auto& field_ptr = curr_call.get_field(query_idx);
-    //Valid field
-    if (field_ptr.get() && field_ptr->is_valid()) {
-      //Must always be vector<DataType>
-      auto* ptr = dynamic_cast<VariantFieldPrimitiveVectorData<DataType>*>(field_ptr.get());
-      assert(ptr);
-      auto& vec = ptr->get();
-      if (vec.size() > m_element_wise_operations_result.size())
-        m_element_wise_operations_result.resize(vec.size());
-      for (auto i=0ull; i<vec.size(); ++i) {
-        auto val = vec[i];
-        if (is_bcf_valid_value<DataType>(val)) {
-          if (i < num_valid_elements && is_bcf_valid_value<DataType>(m_element_wise_operations_result[i]))
-            m_element_wise_operations_result[i] += val;
-          else {
-            m_element_wise_operations_result[i] = val;
-            if (i >= num_valid_elements) {
-              //Set all elements after the last valid value upto i to missing
-              for (auto j=num_valid_elements; j<i; ++j)
-                m_element_wise_operations_result[j] = get_bcf_missing_value<DataType>();
-              num_valid_elements = i+1u;
-            }
-          }
-        }
-      }
-    }
+    compute_valid_element_wise_sum(curr_call.get_field(query_idx));
   }
-  if (num_valid_elements > 0u)
-    m_element_wise_operations_result.resize(num_valid_elements);
   (*output_ptr) = &(m_element_wise_operations_result[0]);
-  num_elements = num_valid_elements;
-  return (num_valid_elements > 0u);
+  num_elements = m_element_wise_operations_result.size();
+  return (m_element_wise_operations_result.size() > 0u);
 }
 
 template<class DataType>
@@ -614,37 +634,49 @@ bool VariantFieldHandler<DataType>::compute_valid_element_wise_sum_2D_vector(con
   //Iterate over valid calls
   for (auto iter=variant.begin(), end_iter = variant.end(); iter != end_iter; ++iter) {
     auto& curr_call = *iter;
-    auto& field_ptr = curr_call.get_field(query_idx);
-    //Valid field
-    if (field_ptr.get() && field_ptr->is_valid()) {
-      //Must always be vector<uint8_t>
-      auto* ptr = dynamic_cast<VariantFieldPrimitiveVectorData<uint8_t, unsigned>*>(field_ptr.get());
-      assert(ptr);
-      auto& vec = ptr->get();
-      GenomicsDBMultiDVectorIdx curr_field_index(&(vec[0u]), vid_field_info, 0u);
-      if (curr_field_index.get_num_entries_in_current_dimension() > m_2D_element_wise_operations_result.size())
-        m_2D_element_wise_operations_result.resize(curr_field_index.get_num_entries_in_current_dimension());
-      for (auto dim0_idx=0ull; dim0_idx<curr_field_index.get_num_entries_in_current_dimension();
-           ++dim0_idx) {
-        auto num_elements = curr_field_index.get_size_of_current_index()/sizeof(DataType);
-        if (num_elements > m_2D_element_wise_operations_result[dim0_idx].size())
-          m_2D_element_wise_operations_result[dim0_idx].resize(num_elements, get_bcf_missing_value<DataType>());
-        auto data_ptr = curr_field_index.get_ptr<DataType>();
-        for (auto i=0ull; i<num_elements; ++i) {
-          auto val = data_ptr[i];
-          if (is_bcf_valid_value<DataType>(val)) {
-            if (is_bcf_valid_value<DataType>(m_2D_element_wise_operations_result[dim0_idx][i]))
-              m_2D_element_wise_operations_result[dim0_idx][i] += val;
-            else
-              m_2D_element_wise_operations_result[dim0_idx][i] = val;
-            ++num_valid_elements;
-          }
-        }
-        curr_field_index.advance_index_in_current_dimension();
-      }
-    }
+    auto is_valid = compute_valid_element_wise_sum_2D_vector(curr_call.get_field(query_idx), *vid_field_info);
+    num_valid_elements += (is_valid ? 1u : 0u);
   }
   return (num_valid_elements > 0u);
+}
+
+template<class DataType>
+bool VariantFieldHandler<DataType>::compute_valid_element_wise_sum_2D_vector(
+    const std::unique_ptr<VariantFieldBase>& field_ptr, const FieldInfo& vid_field_info,
+    const bool reset_accumulator) {
+  assert(vid_field_info.get_genomicsdb_type().get_tuple_element_type_index(0u) == std::type_index(typeid(DataType)));
+  if(reset_accumulator)
+    m_2D_element_wise_operations_result.clear();
+  auto is_valid = false;
+  //Valid field
+  if (field_ptr.get() && field_ptr->is_valid()) {
+    //Must always be vector<uint8_t>
+    auto* ptr = dynamic_cast<VariantFieldPrimitiveVectorData<uint8_t, unsigned>*>(field_ptr.get());
+    assert(ptr);
+    auto& vec = ptr->get();
+    GenomicsDBMultiDVectorIdx curr_field_index(&(vec[0u]), &vid_field_info, 0u);
+    if (curr_field_index.get_num_entries_in_current_dimension() > m_2D_element_wise_operations_result.size())
+      m_2D_element_wise_operations_result.resize(curr_field_index.get_num_entries_in_current_dimension());
+    for (auto dim0_idx=0ull; dim0_idx<curr_field_index.get_num_entries_in_current_dimension();
+	++dim0_idx) {
+      auto num_elements = curr_field_index.get_size_of_current_index()/sizeof(DataType);
+      if (num_elements > m_2D_element_wise_operations_result[dim0_idx].size())
+	m_2D_element_wise_operations_result[dim0_idx].resize(num_elements, get_bcf_missing_value<DataType>());
+      auto data_ptr = curr_field_index.get_ptr<DataType>();
+      for (auto i=0ull; i<num_elements; ++i) {
+	auto val = data_ptr[i];
+	if (is_bcf_valid_value<DataType>(val)) {
+	  if (is_bcf_valid_value<DataType>(m_2D_element_wise_operations_result[dim0_idx][i]))
+	    m_2D_element_wise_operations_result[dim0_idx][i] += val;
+	  else
+	    m_2D_element_wise_operations_result[dim0_idx][i] = val;
+	  is_valid = true;
+	}
+      }
+      curr_field_index.advance_index_in_current_dimension();
+    }
+  }
+  return is_valid;
 }
 
 template<class DataType>
@@ -788,6 +820,109 @@ bool VariantFieldHandler<DataType>::collect_and_extend_fields(const Variant& var
   num_elements = extended_field_vector_idx;
   return true;
 }
+
+template<class T1, class T2>
+bool VariantFieldHandlerBase::compute_valid_histogram_sum_2D_vector(
+    const std::unique_ptr<VariantFieldBase>& field_ptr_bin,
+    const std::unique_ptr<VariantFieldBase>& field_ptr_count,
+    const FieldInfo* vid_field_info_bin,
+    const FieldInfo* vid_field_info_count,
+    std::vector<std::map<T1, T2>>& histogram_map_vec) {
+  auto num_valid_elements = 0ull;
+  auto num_calls_with_field = 0ull;
+  assert(vid_field_info_bin->get_genomicsdb_type().get_tuple_element_type_index(0u) == std::type_index(typeid(T1)));
+  assert(vid_field_info_count->get_genomicsdb_type().get_tuple_element_type_index(0u) == std::type_index(typeid(T2)));
+  //Either both valid or both invalid
+  assert((field_ptr_bin.get() && field_ptr_bin->is_valid()
+	&& field_ptr_count.get() && field_ptr_count->is_valid())
+      || (!(field_ptr_bin.get() && field_ptr_bin->is_valid())
+	&& !(field_ptr_count.get() && field_ptr_count->is_valid())
+	)
+      );
+  //Valid field
+  if (field_ptr_bin.get() && field_ptr_bin->is_valid()) {
+    //Must always be vector<uint8_t>
+    auto* cast_ptr_bin = dynamic_cast<VariantFieldPrimitiveVectorData<uint8_t, unsigned>*>(field_ptr_bin.get());
+    assert(cast_ptr_bin);
+    auto* cast_ptr_count = dynamic_cast<VariantFieldPrimitiveVectorData<uint8_t, unsigned>*>(field_ptr_count.get());
+    assert(cast_ptr_count);
+    GenomicsDBMultiDVectorIdx index_bin(&(cast_ptr_bin->get()[0u]), vid_field_info_bin, 0u);
+    GenomicsDBMultiDVectorIdx index_count(&(cast_ptr_count->get()[0u]), vid_field_info_count, 0u);
+    assert(index_bin.get_num_entries_in_current_dimension() == index_count.get_num_entries_in_current_dimension());
+    if (index_bin.get_num_entries_in_current_dimension() > histogram_map_vec.size())
+      histogram_map_vec.resize(index_bin.get_num_entries_in_current_dimension());
+    for (auto dim0_idx=0ull; dim0_idx<index_bin.get_num_entries_in_current_dimension();
+	++dim0_idx) {
+      auto num_elements = index_bin.get_size_of_current_index()/sizeof(T1);
+      assert(num_elements == index_count.get_size_of_current_index()/sizeof(T2));
+      auto data_ptr_bin = index_bin.get_ptr<T1>();
+      auto data_ptr_count = index_count.get_ptr<T2>();
+      auto& histogram_map = histogram_map_vec[dim0_idx];
+      for (auto i=0ull; i<num_elements; ++i) {
+	auto val_bin = data_ptr_bin[i];
+	auto val_count = data_ptr_count[i];
+	if (is_bcf_valid_value<T1>(val_bin) && is_bcf_valid_value<T2>(val_count)) {
+	  auto iter_flag_pair = histogram_map.insert(std::pair<T1, T2>(val_bin, val_count));
+	  //Existing key
+	  if (!(iter_flag_pair.second))
+	    (*(iter_flag_pair.first)).second += val_count;
+	  ++num_valid_elements;
+	}
+      }
+      index_bin.advance_index_in_current_dimension();
+      index_count.advance_index_in_current_dimension();
+    }
+    ++num_calls_with_field;
+  }
+  if (num_calls_with_field == 0u)
+    return false;
+  return true;
+}
+
+template<class T1, class T2>
+bool VariantFieldHandlerBase::compute_valid_histogram_sum_2D_vector_and_stringify(const Variant& variant,
+    const VariantQueryConfig& query_config,
+    const unsigned query_idx_bin, const unsigned query_idx_count, std::string& result_str) {
+  assert(query_config.get_length_descriptor_for_query_attribute_idx(query_idx_bin).get_num_dimensions() == 2u);
+  assert(query_config.get_length_descriptor_for_query_attribute_idx(query_idx_count).get_num_dimensions() == 2u);
+  auto vid_field_info_bin = query_config.get_field_info_for_query_attribute_idx(query_idx_bin);
+  auto vid_field_info_count = query_config.get_field_info_for_query_attribute_idx(query_idx_count);
+  assert(vid_field_info_bin->get_genomicsdb_type().get_tuple_element_type_index(0u) == std::type_index(typeid(T1)));
+  assert(vid_field_info_count->get_genomicsdb_type().get_tuple_element_type_index(0u) == std::type_index(typeid(T2)));
+  std::vector<std::map<T1, T2>> histogram_map_vec;
+  auto contains_one_valid_data = false;
+  //Iterate over valid calls
+  for (auto iter=variant.begin(), end_iter = variant.end(); iter != end_iter; ++iter) {
+    auto& curr_call = *iter;
+    auto& field_ptr_bin = curr_call.get_field(query_idx_bin);
+    auto& field_ptr_count = curr_call.get_field(query_idx_count);
+    contains_one_valid_data = compute_valid_histogram_sum_2D_vector(field_ptr_bin, field_ptr_count,
+	vid_field_info_bin, vid_field_info_count,
+	histogram_map_vec) || contains_one_valid_data;
+  }
+  if (!contains_one_valid_data)
+    return false;
+  auto& length_descriptor = vid_field_info_bin->m_length_descriptor;
+  assert(length_descriptor.get_num_dimensions() == 2u);
+  auto first_outer_index = true;
+  std::stringstream s;
+  for (auto i=0ull; i<histogram_map_vec.size(); ++i) {
+    if (!first_outer_index)
+      s << length_descriptor.get_vcf_delimiter(0u);
+    auto& histogram_map = histogram_map_vec[i];
+    auto first_inner_index = true;
+    for (auto& pair : histogram_map) {
+      if (!first_inner_index)
+        s << length_descriptor.get_vcf_delimiter(1u);
+      s << std::fixed << std::setprecision(3) << pair.first << length_descriptor.get_vcf_delimiter(1u) << pair.second;
+      first_inner_index = false;
+    }
+    first_outer_index = false;
+  }
+  result_str = std::move(s.str());
+  return true;
+}
+
 //Explicit template instantiation
 template class VariantFieldHandler<int>;
 template class VariantFieldHandler<unsigned>;
@@ -797,6 +932,23 @@ template class VariantFieldHandler<float>;
 template class VariantFieldHandler<double>;
 template class VariantFieldHandler<std::string>;
 template class VariantFieldHandler<char>;
+
+template
+bool VariantFieldHandlerBase::compute_valid_histogram_sum_2D_vector_and_stringify<int, int>(const Variant& variant,
+    const VariantQueryConfig& query_config,
+    const unsigned query_idx_bin, const unsigned query_idx_count, std::string& result_str);
+template
+bool VariantFieldHandlerBase::compute_valid_histogram_sum_2D_vector_and_stringify<int, float>(const Variant& variant,
+    const VariantQueryConfig& query_config,
+    const unsigned query_idx_bin, const unsigned query_idx_count, std::string& result_str);
+template
+bool VariantFieldHandlerBase::compute_valid_histogram_sum_2D_vector_and_stringify<float, int>(const Variant& variant,
+    const VariantQueryConfig& query_config,
+    const unsigned query_idx_bin, const unsigned query_idx_count, std::string& result_str);
+template
+bool VariantFieldHandlerBase::compute_valid_histogram_sum_2D_vector_and_stringify<float, float>(const Variant& variant,
+    const VariantQueryConfig& query_config,
+    const unsigned query_idx_bin, const unsigned query_idx_count, std::string& result_str);
 
 //The following function is called in variant_operations.cc also. For some compilers, explicit instantiation
 //of VariantFieldHandler is insufficient. The following function must also be instantiated, else weird link time

--- a/src/main/cpp/src/query_operations/variant_operations.cc
+++ b/src/main/cpp/src/query_operations/variant_operations.cc
@@ -51,7 +51,7 @@ void* RemappedMatrix<DataType>::put_address(uint64_t input_call_idx, unsigned al
 }
 
 void* RemappedVariant::put_address(uint64_t input_call_idx, unsigned allele_or_gt_idx) {
-  auto& curr_call = m_variant->get_call(input_call_idx);
+  auto& curr_call = m_variant->get_call(m_only_write_to_first_call ? 0u : input_call_idx);
   assert(curr_call.is_valid());
   auto& field = curr_call.get_field(m_queried_field_idx);
   assert(field.get());  //not null

--- a/src/main/cpp/src/query_operations/variant_operations.cc
+++ b/src/main/cpp/src/query_operations/variant_operations.cc
@@ -370,14 +370,17 @@ void DummyGenotypingOperator::operate(Variant& variant, const VariantQueryConfig
 
 //GA4GHOperator functions
 GA4GHOperator::GA4GHOperator(const VariantQueryConfig& query_config,
-                             const VidMapper& vid_mapper)
+                             const VidMapper& vid_mapper,
+			     const bool skip_remapping_INFO_fields_with_sum_combine_operation)
   : SingleVariantOperatorBase(&vid_mapper) {
   m_GT_query_idx = UNDEFINED_ATTRIBUTE_IDX_VALUE;
   m_max_diploid_alt_alleles_that_can_be_genotyped =
     query_config.get_max_diploid_alt_alleles_that_can_be_genotyped();
   m_max_genotype_count = query_config.get_max_genotype_count();
+  m_skip_remapping_INFO_fields_with_sum_combine_operation = skip_remapping_INFO_fields_with_sum_combine_operation;
   m_remapped_fields_query_idxs.clear();
   for (auto query_field_idx=0u; query_field_idx<query_config.get_num_queried_attributes(); ++query_field_idx) {
+    const auto vid_field_info = query_config.get_field_info_for_query_attribute_idx(query_field_idx);
     //Does the length dependent on number of alleles
     if (query_config.get_length_descriptor_for_query_attribute_idx(query_field_idx).is_length_allele_dependent())
       m_remapped_fields_query_idxs.push_back(query_field_idx);
@@ -520,13 +523,108 @@ void remap_allele_specific_annotations(
                                     *(query_config.get_field_info_for_query_attribute_idx(query_field_idx)));
 }
 
+bool GA4GHOperator::check_if_too_many_alleles_and_print_message(
+    const Variant& variant,
+    const FieldLengthDescriptor& length_descriptor) const {
+  const unsigned num_merged_alleles = m_merged_alt_alleles.size()+1u;        //+1 for REF allele
+  if (length_descriptor.is_length_genotype_dependent()
+      && too_many_alt_alleles_for_genotype_length_fields(num_merged_alleles-1u)) {      //#alt = merged-1
+    assert(m_vid_mapper);
+    std::string contig_name;
+    int64_t  contig_position = -1;
+    auto contig_status = m_vid_mapper->get_contig_location(variant.get_column_begin(), contig_name, contig_position);
+    if (contig_status)
+      std::cerr << "Chromosome "<<contig_name<<" position "<<contig_position+1<<" ("; //VCF contig coords are 1 based
+    std::cerr << "TileDB column "<<variant.get_column_begin();
+    if (contig_status)
+      std::cerr << ")";
+    std::cerr << " has too many alleles in the combined VCF record : "<<num_merged_alleles-1
+      << " : current limit : "<<m_max_diploid_alt_alleles_that_can_be_genotyped
+      << ". Fields, such as  PL, with length equal to the number of genotypes will NOT be added for this location.\n";
+    return true;
+  }
+  return false;
+}
+
+bool GA4GHOperator::remap_if_needed(const Variant& variant,
+    const VariantQueryConfig& query_config,
+    const uint64_t curr_call_idx_in_variant,
+    const unsigned query_field_idx,
+    std::unique_ptr<VariantFieldBase>& remapped_field,
+    RemappedVariant& remapper_variant,
+    const FieldLengthDescriptor& length_descriptor) {
+  auto& orig_call = variant.get_call(curr_call_idx_in_variant);
+  auto& orig_field = orig_call.get_field(query_field_idx);
+  copy_field(remapped_field, orig_field);
+  const unsigned num_merged_alleles = m_merged_alt_alleles.size()+1u;        //+1 for REF allele
+  if (remapped_field.get() && remapped_field->is_valid()) {   //Not null
+    auto curr_ploidy = m_ploidy[curr_call_idx_in_variant];
+    if (length_descriptor.is_length_genotype_dependent()
+	&& too_many_genotypes_for_genotype_length_fields(num_merged_alleles-1u, curr_ploidy)) {  //#alt = merged-1
+      assert(m_vid_mapper);
+      std::string contig_name;
+      int64_t  contig_position = -1;
+      auto contig_status = m_vid_mapper->get_contig_location(
+	  variant.get_column_begin(), contig_name, contig_position);
+      std::string callset_name;
+      auto callset_status = m_vid_mapper->get_callset_name(
+	  orig_call.get_row_idx(), callset_name);
+      if(callset_status)
+	std::cerr << "Sample/Callset "<<callset_name << "( ";
+      std::cerr << "TileDB row idx "<<orig_call.get_row_idx();
+      if(callset_status)
+	std::cerr << ")";
+      std::cerr << " at ";
+      if (contig_status)
+	std::cerr << "Chromosome "<<contig_name<<" position "<<contig_position+1<<" ("; //VCF contig coords are 1 based
+      std::cerr << "TileDB column "<<variant.get_column_begin();
+      if (contig_status)
+	std::cerr << ")";
+      std::cerr << " has too many genotypes in the combined VCF record : ";
+      auto num_genotypes = KnownFieldInfo::get_number_of_genotypes(num_merged_alleles-1u, curr_ploidy);
+      if(num_genotypes == UINT64_MAX)
+	std::cerr << "<uint64_t overflow>";
+      else
+	std::cerr << num_genotypes;
+      std::cerr  << " : current limit : "<<m_max_genotype_count
+	<< " (num_alleles, ploidy) = ("<<num_merged_alleles<< ", "<<curr_ploidy
+	<< "). Fields, such as  PL, with length equal to the number of genotypes will NOT be added \
+	for this sample for this location.\n";
+      remapped_field->set_valid(false);
+      return false; //no remapping done
+    }
+
+    //Multi-D field
+    if (query_config.get_length_descriptor_for_query_attribute_idx(query_field_idx).get_num_dimensions() > 1u)
+      remap_allele_specific_annotations(orig_field, remapped_field,
+	  curr_call_idx_in_variant,
+	  m_alleles_LUT, num_merged_alleles, m_NON_REF_exists, curr_ploidy,
+	  query_config, query_field_idx);
+    else {
+      unsigned num_merged_elements =
+	length_descriptor.get_num_elements(num_merged_alleles-1u, curr_ploidy, 0u);  //#alt alleles, current ploidy
+      remapped_field->resize(num_merged_elements);
+      //Get handler for current type
+      auto& handler = get_handler_for_type(query_config.get_element_type(query_field_idx));
+      assert(handler.get());
+      //Call remap function
+      handler->remap_vector_data(
+	  orig_field, curr_call_idx_in_variant,
+	  m_alleles_LUT, num_merged_alleles, m_NON_REF_exists, curr_ploidy,
+	  query_config.get_length_descriptor_for_query_attribute_idx(query_field_idx), num_merged_elements, remapper_variant);
+    }
+    return true;
+  }
+  return false;
+}
+
 void GA4GHOperator::operate(Variant& variant, const VariantQueryConfig& query_config) {
   //Compute merged REF and ALT
   SingleVariantOperatorBase::operate(variant, query_config);
   //Copy variant to m_remapped_variant - only simple elements, not all fields
   m_remapped_variant.deep_copy_simple_members(variant);
   //Setup code for re-ordering PL/AD etc field elements in m_remapped_variant
-  unsigned num_merged_alleles = m_merged_alt_alleles.size()+1u;        //+1 for REF allele
+  const unsigned num_merged_alleles = m_merged_alt_alleles.size()+1u;        //+1 for REF allele
   //Known fields that need to be re-mapped
   if (m_remapping_needed) {
     //if GT field is queried
@@ -553,25 +651,16 @@ void GA4GHOperator::operate(Variant& variant, const VariantQueryConfig& query_co
     }
     for (auto query_field_idx : m_remapped_fields_query_idxs) {
       auto length_descriptor = query_config.get_length_descriptor_for_query_attribute_idx(query_field_idx);
+      const auto vid_field_info = query_config.get_field_info_for_query_attribute_idx(query_field_idx);
       //field length depends on #alleles
       assert(length_descriptor.is_length_allele_dependent());
+      //Combine operation is sum - skip doing remapping
+      if(m_skip_remapping_INFO_fields_with_sum_combine_operation
+	  && vid_field_info->m_is_vcf_INFO_field && vid_field_info->is_VCF_field_combine_operation_sum())
+	continue;
       //Fields such as PL should be skipped, if the #alleles is above a threshold
-      if (length_descriptor.is_length_genotype_dependent()
-          && too_many_alt_alleles_for_genotype_length_fields(num_merged_alleles-1u)) {      //#alt = merged-1
-        assert(m_vid_mapper);
-        std::string contig_name;
-        int64_t  contig_position = -1;
-        auto contig_status = m_vid_mapper->get_contig_location(variant.get_column_begin(), contig_name, contig_position);
-        if (contig_status)
-          std::cerr << "Chromosome "<<contig_name<<" position "<<contig_position+1<<" ("; //VCF contig coords are 1 based
-        std::cerr << "TileDB column "<<variant.get_column_begin();
-        if (contig_status)
-          std::cerr << ")";
-        std::cerr << " has too many alleles in the combined VCF record : "<<num_merged_alleles-1
-                  << " : current limit : "<<m_max_diploid_alt_alleles_that_can_be_genotyped
-                  << ". Fields, such as  PL, with length equal to the number of genotypes will NOT be added for this location.\n";
-        continue;
-      }
+      if(check_if_too_many_alleles_and_print_message(variant, length_descriptor))
+	continue;
       //Remapper for m_remapped_variant
       RemappedVariant remapper_variant(m_remapped_variant, query_field_idx);
       //Iterate over valid calls - m_remapped_variant and variant have same list of valid calls
@@ -579,64 +668,13 @@ void GA4GHOperator::operate(Variant& variant, const VariantQueryConfig& query_co
         auto& remapped_call = *iter;
         auto curr_call_idx_in_variant = iter.get_call_idx_in_variant();
         auto& remapped_field = remapped_call.get_field(query_field_idx);
-        auto& orig_field = variant.get_call(curr_call_idx_in_variant).get_field(query_field_idx);
-        copy_field(remapped_field, orig_field);
-        if (remapped_field.get() && remapped_field->is_valid()) {   //Not null
-          auto curr_ploidy = m_ploidy[curr_call_idx_in_variant];
-	  if (length_descriptor.is_length_genotype_dependent()
-	      && too_many_genotypes_for_genotype_length_fields(num_merged_alleles-1u, curr_ploidy)) {  //#alt = merged-1
-	    assert(m_vid_mapper);
-	    std::string contig_name;
-	    int64_t  contig_position = -1;
-	    auto contig_status = m_vid_mapper->get_contig_location(
-		variant.get_column_begin(), contig_name, contig_position);
-	    std::string callset_name;
-	    auto callset_status = m_vid_mapper->get_callset_name(remapped_call.get_row_idx(), callset_name);
-	    if(callset_status)
-	      std::cerr << "Sample/Callset "<<callset_name << "( ";
-	    std::cerr << "TileDB row idx "<<remapped_call.get_row_idx();
-	    if(callset_status)
-	      std::cerr << ")";
-	    std::cerr << " at ";
-	    if (contig_status)
-	      std::cerr << "Chromosome "<<contig_name<<" position "<<contig_position+1<<" ("; //VCF contig coords are 1 based
-	    std::cerr << "TileDB column "<<variant.get_column_begin();
-	    if (contig_status)
-	      std::cerr << ")";
-	    std::cerr << " has too many genotypes in the combined VCF record : ";
-	    auto num_genotypes = KnownFieldInfo::get_number_of_genotypes(num_merged_alleles-1u, curr_ploidy);
-	    if(num_genotypes == UINT64_MAX)
-	      std::cerr << "<uint64_t overflow>";
-	    else
-	      std::cerr << num_genotypes;
-	    std::cerr  << " : current limit : "<<m_max_genotype_count
-	      << " (num_alleles, ploidy) = ("<<num_merged_alleles<< ", "<<curr_ploidy
-	      << "). Fields, such as  PL, with length equal to the number of genotypes will NOT be added \
-	      for this sample for this location.\n";
-	    remapped_field->set_valid(false);
-	    continue;
-	  }
-
-          //Multi-D field
-          if (query_config.get_length_descriptor_for_query_attribute_idx(query_field_idx).get_num_dimensions() > 1u)
-            remap_allele_specific_annotations(orig_field, remapped_field,
-                                              curr_call_idx_in_variant,
-                                              m_alleles_LUT, num_merged_alleles, m_NON_REF_exists, curr_ploidy,
-                                              query_config, query_field_idx);
-          else {
-            unsigned num_merged_elements =
-              length_descriptor.get_num_elements(num_merged_alleles-1u, curr_ploidy, 0u);  //#alt alleles, current ploidy
-            remapped_field->resize(num_merged_elements);
-            //Get handler for current type
-            auto& handler = get_handler_for_type(query_config.get_element_type(query_field_idx));
-            assert(handler.get());
-            //Call remap function
-            handler->remap_vector_data(
-              orig_field, curr_call_idx_in_variant,
-              m_alleles_LUT, num_merged_alleles, m_NON_REF_exists, curr_ploidy,
-              query_config.get_length_descriptor_for_query_attribute_idx(query_field_idx), num_merged_elements, remapper_variant);
-          }
-        }
+	remap_if_needed(variant,
+	    query_config,
+	    curr_call_idx_in_variant,
+	    query_field_idx,
+	    remapped_field,
+	    remapper_variant,
+	    length_descriptor);
       }
     }
   }

--- a/src/main/cpp/src/utils/vid_mapper.cc
+++ b/src/main/cpp/src/utils/vid_mapper.cc
@@ -100,7 +100,8 @@ std::unordered_map<std::string, int>({
   {"element_wise_sum", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_ELEMENT_WISE_SUM},
   {"elementwise_sum", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_ELEMENT_WISE_SUM},
   {"concatenate", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_CONCATENATE},
-  {"histogram_sum", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_HISTOGRAM_SUM}
+  {"histogram_sum", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_HISTOGRAM_SUM},
+  {"ignore", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_IGNORE}
 });
 
 auto g_FORMAT_suffix = "_FORMAT";
@@ -1236,6 +1237,11 @@ void FileBasedVidMapper::common_constructor_initialization(
         //Map
         m_field_name_to_idx[field_name] = field_idx;
         m_field_idx_to_info[field_idx].set_info(field_name, field_idx);
+	//Field renamed due to collision in the VCF header
+	if(field_info_dict.HasMember("vcf_name")) {
+	  VERIFY_OR_THROW(field_info_dict["vcf_name"].IsString());
+	  m_field_idx_to_info[field_idx].m_vcf_name = field_info_dict["vcf_name"].GetString();
+	}
         if (field_info_dict.HasMember("vcf_field_class")) {
           //Array which specifies whether field if INFO, FORMAT, FILTER etc
           const auto& vcf_field_class_array = field_info_dict["vcf_field_class"];

--- a/src/main/cpp/src/utils/vid_mapper.cc
+++ b/src/main/cpp/src/utils/vid_mapper.cc
@@ -100,8 +100,7 @@ std::unordered_map<std::string, int>({
   {"element_wise_sum", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_ELEMENT_WISE_SUM},
   {"elementwise_sum", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_ELEMENT_WISE_SUM},
   {"concatenate", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_CONCATENATE},
-  {"histogram_sum", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_HISTOGRAM_SUM},
-  {"ignore", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_IGNORE}
+  {"histogram_sum", VCFFieldCombineOperationEnum::VCF_FIELD_COMBINE_OPERATION_HISTOGRAM_SUM}
 });
 
 auto g_FORMAT_suffix = "_FORMAT";

--- a/src/main/cpp/src/utils/vid_mapper.cc
+++ b/src/main/cpp/src/utils/vid_mapper.cc
@@ -156,7 +156,7 @@ void FieldLengthDescriptor::set_length_descriptor(const int length_dim_idx, cons
                                  || KnownFieldInfo::is_length_descriptor_ploidy_dependent(length_descriptor);
 }
 
-size_t FieldLengthDescriptor::get_num_elements(const unsigned num_ALT_alleles, const unsigned ploidy, const unsigned num_elements) {
+size_t FieldLengthDescriptor::get_num_elements(const unsigned num_ALT_alleles, const unsigned ploidy, const unsigned num_elements) const {
   assert(get_num_dimensions() == 1u);
   return KnownFieldInfo::get_num_elements_given_length_descriptor(get_length_descriptor(0u),
          num_ALT_alleles, ploidy, num_elements);

--- a/src/main/cpp/src/utils/vid_mapper_pb.cc
+++ b/src/main/cpp/src/utils/vid_mapper_pb.cc
@@ -280,6 +280,9 @@ int VidMapper::parse_infofields_from_vidmap(
     m_field_idx_to_info[field_idx].set_info(field_name, field_idx);
     auto& ref = m_field_idx_to_info[field_idx];
 
+    if(vid_map_protobuf->fields(pb_field_idx).has_vcf_name())
+      ref.m_vcf_name = vid_map_protobuf->fields(pb_field_idx).vcf_name();
+
     // VCF class type can be an array of values: INFO, FORMAT and FILTER
     auto class_type_size =
       vid_map_protobuf->fields(pb_field_idx).vcf_field_class_size();

--- a/src/main/java/org/genomicsdb/importer/extensions/VidMapExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/VidMapExtensions.java
@@ -262,11 +262,12 @@ public interface VidMapExtensions {
 	else {
 	    //Why 3? VCF header can have FILTER/INFO/FORMAT fields of the same name
 	    List<DuplicateFieldInfoTrackClass> init = new ArrayList(3);
-	    for(int i=0;i<init.size();++i)
-		init.set(i, new DuplicateFieldInfoTrackClass());
+	    for(int i=0;i<3;++i)
+		init.add(new DuplicateFieldInfoTrackClass());
 	    fieldNameToDuplicateCheckInfo.put(vcfFieldName, init);
 	    currList = init;
 	}
+	assert (currList.size() == 3);
 	DuplicateFieldInfoTrackClass currObj = currList.get(vcfHeaderLineTypeIdx);
 	if(currObj.isInitialized) {
 	    System.err.println("GenomicsDB: "+VidMapExtensions.class.getName()+

--- a/src/main/java/org/genomicsdb/importer/extensions/VidMapExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/VidMapExtensions.java
@@ -9,11 +9,37 @@ import org.genomicsdb.GenomicsDBUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
+import java.util.HashMap;
 
 import static com.googlecode.protobuf.format.JsonFormat.*;
 import static org.genomicsdb.GenomicsDBUtils.readEntireFile;
 
 public interface VidMapExtensions {
+
+    public static String[] vcfHeaderLineTypeString = new String[] {
+      "FILTER", "INFO", "FORMAT" };
+    public static int vcfHeaderLineFilterIdx = 0;
+    public static int vcfHeaderLineInfoIdx = 1;
+    public static int vcfHeaderLineFormatIdx = 2;
+
+    public class DuplicateFieldInfoTrackClass {
+      public String vcfType;
+      public String vcfLengthDescriptor;
+      public boolean isInitialized = false;
+      public int idxInGenomicsDBFieldInfoList;
+    }
+
+    public class DuplicateVcfFieldNamesCheckResult {
+	public boolean skipCreatingNewEntry = false;
+	public String fieldName;
+
+	public DuplicateVcfFieldNamesCheckResult(final boolean b, final String s) {
+	    skipCreatingNewEntry = b;
+	    fieldName = s;
+	}
+    }
+
     /**
      * Generate the ProtoBuf data structure for vid mapping
      * Also remember, contigs are 1-based which means
@@ -36,41 +62,65 @@ public interface VidMapExtensions {
         IDFieldBuilder.setName("ID").addType("char").addLength(lengthDescriptorComponentBuilder.build());
         infoFields.add(IDFieldBuilder.build());
 
-        int dpIndex = -1;
         long columnOffset = 0L;
+
+	Map<String, List<DuplicateFieldInfoTrackClass>> fieldNameToDuplicateCheckInfo =
+	    new HashMap<String,List<DuplicateFieldInfoTrackClass>>();
 
         for (VCFHeaderLine headerLine : mergedHeader) {
             GenomicsDBVidMapProto.GenomicsDBFieldInfo.Builder infoBuilder = GenomicsDBVidMapProto.GenomicsDBFieldInfo.newBuilder();
             if (headerLine instanceof VCFFormatHeaderLine) {
                 VCFFormatHeaderLine formatHeaderLine = (VCFFormatHeaderLine) headerLine;
+
+		final String formatFieldName = formatHeaderLine.getID();
                 boolean isGT = formatHeaderLine.getID().equals(VCFConstants.GENOTYPE_KEY);
                 String genomicsDBType = isGT ? "int" : formatHeaderLine.getType().toString();
                 String genomicsDBLength = isGT ? "PP" : (formatHeaderLine.getType() == VCFHeaderLineType.String)
-                        ? "VAR" : getVcfHeaderLength(formatHeaderLine);
+                        ? "var" : getVcfHeaderLength(formatHeaderLine);
                 lengthDescriptorComponentBuilder.setVariableLengthDescriptor(genomicsDBLength);
 
-                infoBuilder.setName(formatHeaderLine.getID())
+		final DuplicateVcfFieldNamesCheckResult dupCheck = checkForDuplicateVcfFieldNames(
+			formatFieldName,
+			vcfHeaderLineFormatIdx,
+			genomicsDBType, genomicsDBLength,
+			infoFields,
+			fieldNameToDuplicateCheckInfo
+			);
+		if(dupCheck.skipCreatingNewEntry)
+		    continue;
+
+                infoBuilder.setName(dupCheck.fieldName)
                         .addType(genomicsDBType)
                         .addLength(lengthDescriptorComponentBuilder.build());
+		if(!formatFieldName.equals(dupCheck.fieldName)) //field renamed due to collisions
+		    infoBuilder.setVcfName(formatFieldName);
 
-                if (formatHeaderLine.getID().equals("DP") && dpIndex != -1) {
-                    GenomicsDBVidMapProto.GenomicsDBFieldInfo prevDPField = removeInfoFields(infoFields, dpIndex);
-                    infoBuilder.addVcfFieldClass(prevDPField.getVcfFieldClass(0)).addVcfFieldClass("FORMAT");
-                } else {
-                    infoBuilder.addVcfFieldClass("FORMAT");
-                }
+		infoBuilder.addVcfFieldClass("FORMAT");
 
                 GenomicsDBVidMapProto.GenomicsDBFieldInfo formatField = infoBuilder.build();
                 infoFields.add(formatField);
-                if (formatHeaderLine.getID().equals("DP")) dpIndex = infoFields.indexOf(formatField);
             } else if (headerLine instanceof VCFInfoHeaderLine) {
                 VCFInfoHeaderLine infoHeaderLine = (VCFInfoHeaderLine) headerLine;
                 final String infoFieldName = infoHeaderLine.getID();
-                infoBuilder.setName(infoFieldName);
+		final String genomicsDBLength = infoHeaderLine.getType() == VCFHeaderLineType.String ?
+		    "var" : getVcfHeaderLength(infoHeaderLine);
+		final DuplicateVcfFieldNamesCheckResult dupCheck = checkForDuplicateVcfFieldNames(
+			infoFieldName,
+			vcfHeaderLineInfoIdx,
+			infoHeaderLine.getType().toString(),
+			genomicsDBLength,
+			infoFields,
+			fieldNameToDuplicateCheckInfo
+			);
+		if(dupCheck.skipCreatingNewEntry)
+		    continue;
+                infoBuilder.setName(dupCheck.fieldName);
+		if(!infoFieldName.equals(dupCheck.fieldName)) //field renamed due to collisions
+		    infoBuilder.setVcfName(infoFieldName);
                 //allele specific annotations
-                if (Constants.R_LENGTH_HISTOGRAM_FIELDS_FLOAT_BINS.contains(infoFieldName)
-                        || Constants.R_LENGTH_TWO_DIM_FLOAT_VECTOR_FIELDS.contains(infoFieldName)
-                        || Constants.R_LENGTH_TWO_DIM_INT_VECTOR_FIELDS.contains(infoFieldName)
+                if (Constants.R_LENGTH_HISTOGRAM_FIELDS_FLOAT_BINS.contains(dupCheck.fieldName)
+                        || Constants.R_LENGTH_TWO_DIM_FLOAT_VECTOR_FIELDS.contains(dupCheck.fieldName)
+                        || Constants.R_LENGTH_TWO_DIM_INT_VECTOR_FIELDS.contains(dupCheck.fieldName)
                         ) {
                     lengthDescriptorComponentBuilder.setVariableLengthDescriptor("R");
                     infoBuilder.addLength(lengthDescriptorComponentBuilder.build());
@@ -78,35 +128,27 @@ public interface VidMapExtensions {
                     infoBuilder.addLength(lengthDescriptorComponentBuilder.build());
                     infoBuilder.addVcfDelimiter("|");
                     infoBuilder.addVcfDelimiter(",");
-                    if (Constants.R_LENGTH_HISTOGRAM_FIELDS_FLOAT_BINS.contains(infoFieldName)) {
+                    if (Constants.R_LENGTH_HISTOGRAM_FIELDS_FLOAT_BINS.contains(dupCheck.fieldName)) {
                         //Each element of the vector is a tuple <float, int>
                         infoBuilder.addType("float");
                         infoBuilder.addType("int");
                         infoBuilder.setVCFFieldCombineOperation("histogram_sum");
                     } else {
                         infoBuilder.setVCFFieldCombineOperation("element_wise_sum");
-                        if (Constants.R_LENGTH_TWO_DIM_FLOAT_VECTOR_FIELDS.contains(infoFieldName)) {
+                        if (Constants.R_LENGTH_TWO_DIM_FLOAT_VECTOR_FIELDS.contains(dupCheck.fieldName)) {
                             infoBuilder.addType("float");
-                        } else if (Constants.R_LENGTH_TWO_DIM_INT_VECTOR_FIELDS.contains(infoFieldName)) {
+                        } else if (Constants.R_LENGTH_TWO_DIM_INT_VECTOR_FIELDS.contains(dupCheck.fieldName)) {
                             infoBuilder.addType("int");
                         }
                     }
                 } else {
-                    lengthDescriptorComponentBuilder.setVariableLengthDescriptor(
-                            infoHeaderLine.getType() == VCFHeaderLineType.String ? "var" : getVcfHeaderLength(infoHeaderLine));
-
+                    lengthDescriptorComponentBuilder.setVariableLengthDescriptor(genomicsDBLength);
                     infoBuilder.addType(infoHeaderLine.getType().toString())
                             .addLength(lengthDescriptorComponentBuilder.build());
                 }
-                if (infoHeaderLine.getID().equals("DP") && dpIndex != -1) {
-                    GenomicsDBVidMapProto.GenomicsDBFieldInfo prevDPield = removeInfoFields(infoFields, dpIndex);
-                    infoBuilder.addVcfFieldClass(prevDPield.getVcfFieldClass(0)).addVcfFieldClass("INFO");
-                } else {
-                    infoBuilder.addVcfFieldClass("INFO");
-                }
+		infoBuilder.addVcfFieldClass("INFO");
                 GenomicsDBVidMapProto.GenomicsDBFieldInfo infoField = infoBuilder.build();
                 infoFields.add(infoField);
-                if (infoHeaderLine.getID().equals("DP")) dpIndex = infoFields.indexOf(infoField);
             } else if (headerLine instanceof VCFFilterHeaderLine) {
                 VCFFilterHeaderLine filterHeaderLine = (VCFFilterHeaderLine) headerLine;
                 infoBuilder.setName(filterHeaderLine.getID());
@@ -190,13 +232,6 @@ public interface VidMapExtensions {
         return length;
     }
 
-    default GenomicsDBVidMapProto.GenomicsDBFieldInfo removeInfoFields(List<GenomicsDBVidMapProto.GenomicsDBFieldInfo> infoFields,
-                                                             final int dpIndex) {
-        GenomicsDBVidMapProto.GenomicsDBFieldInfo dpFormatField = infoFields.get(dpIndex);
-        infoFields.remove(dpIndex);
-        return dpFormatField;
-    }
-
     /**
      * Generate the ProtoBuf data structure for vid mapping
      * from the existing vid file
@@ -215,4 +250,62 @@ public interface VidMapExtensions {
         return vidMapBuilder.build();
     }
 
+    public static DuplicateVcfFieldNamesCheckResult checkForDuplicateVcfFieldNames(final String vcfFieldName,
+	    final int vcfHeaderLineTypeIdx,
+	    final String vcfType, final String vcfLengthDescriptor,
+	    List<GenomicsDBVidMapProto.GenomicsDBFieldInfo> infoFields,
+	    Map<String, List<DuplicateFieldInfoTrackClass>> fieldNameToDuplicateCheckInfo
+	    ) {
+	List<DuplicateFieldInfoTrackClass> currList = null;
+	if(fieldNameToDuplicateCheckInfo.containsKey(vcfFieldName))
+	    currList = fieldNameToDuplicateCheckInfo.get(vcfFieldName);
+	else {
+	    //Why 3? VCF header can have FILTER/INFO/FORMAT fields of the same name
+	    List<DuplicateFieldInfoTrackClass> init = new ArrayList(3);
+	    for(int i=0;i<init.size();++i)
+		init.set(i, new DuplicateFieldInfoTrackClass());
+	    fieldNameToDuplicateCheckInfo.put(vcfFieldName, init);
+	    currList = init;
+	}
+	DuplicateFieldInfoTrackClass currObj = currList.get(vcfHeaderLineTypeIdx);
+	if(currObj.isInitialized) {
+	    System.err.println("GenomicsDB: "+VidMapExtensions.class.getName()+
+		" VCF header has 2 lines with the same field name "+vcfFieldName
+		    +" and header line type <"+vcfHeaderLineTypeString[vcfHeaderLineTypeIdx]+">"
+		    +" -- only the first line is considered by GenomicsDB");
+	    return new DuplicateVcfFieldNamesCheckResult(true, null);
+	}
+	currObj.vcfType = vcfType;
+	currObj.vcfLengthDescriptor = vcfLengthDescriptor;
+	//Check if there are other lines of a different type (FILTER, INFO, FORMAT) with the same name
+	for(int i=0;i<3;++i) {
+	    DuplicateFieldInfoTrackClass otherObj = currList.get(i);
+	    if(otherObj.isInitialized) {
+		//Check if the other line is of same type and length
+		if(otherObj.vcfType.equals(currObj.vcfType) &&
+			otherObj.vcfLengthDescriptor.equals(currObj.vcfLengthDescriptor)) {
+		    //Simply update the PB object corresponding to the field
+		    GenomicsDBVidMapProto.GenomicsDBFieldInfo fieldInfo =
+			infoFields.get(otherObj.idxInGenomicsDBFieldInfoList);
+		    infoFields.set(otherObj.idxInGenomicsDBFieldInfoList,
+			    fieldInfo.toBuilder().
+			    addVcfFieldClass(vcfHeaderLineTypeString[vcfHeaderLineTypeIdx])
+			    .build());
+		    currObj.isInitialized = true;
+		    currObj.idxInGenomicsDBFieldInfoList = otherObj.idxInGenomicsDBFieldInfoList;
+		    return new DuplicateVcfFieldNamesCheckResult(true, null);
+		}
+		else { //this is a different type of field, rename
+		    currObj.isInitialized = true;
+		    currObj.idxInGenomicsDBFieldInfoList = infoFields.size();
+		    return new DuplicateVcfFieldNamesCheckResult(false, vcfFieldName+"_"
+			    +vcfHeaderLineTypeString[vcfHeaderLineTypeIdx]);
+		}
+	    }
+	}
+	currObj.isInitialized = true;
+	currObj.idxInGenomicsDBFieldInfoList = infoFields.size();
+	//Fields of the same name doesn't exist
+	return new DuplicateVcfFieldNamesCheckResult(false, vcfFieldName);
+    }
 }

--- a/src/main/java/org/genomicsdb/importer/extensions/VidMapExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/VidMapExtensions.java
@@ -151,12 +151,23 @@ public interface VidMapExtensions {
                 infoFields.add(infoField);
             } else if (headerLine instanceof VCFFilterHeaderLine) {
                 VCFFilterHeaderLine filterHeaderLine = (VCFFilterHeaderLine) headerLine;
-                infoBuilder.setName(filterHeaderLine.getID());
-                if (!filterHeaderLine.getValue().isEmpty()) {
-                    infoBuilder.addType(filterHeaderLine.getValue());
-                } else {
-                    infoBuilder.addType("int");
-                }
+		final String filterFieldName = filterHeaderLine.getID();
+		final DuplicateVcfFieldNamesCheckResult dupCheck = checkForDuplicateVcfFieldNames(
+			filterFieldName,
+			vcfHeaderLineFilterIdx,
+			"Integer",
+			"1",
+			infoFields,
+			fieldNameToDuplicateCheckInfo
+			);
+		if(dupCheck.skipCreatingNewEntry)
+		    continue;
+                infoBuilder.setName(dupCheck.fieldName);
+		if(!filterFieldName.equals(dupCheck.fieldName)) //field renamed due to collisions
+		    infoBuilder.setVcfName(filterFieldName);
+		lengthDescriptorComponentBuilder.setVariableLengthDescriptor("1");
+		infoBuilder.addType("Integer")
+                            .addLength(lengthDescriptorComponentBuilder.build());
                 infoBuilder.addVcfFieldClass("FILTER");
                 GenomicsDBVidMapProto.GenomicsDBFieldInfo filterField = infoBuilder.build();
                 infoFields.add(filterField);

--- a/src/resources/genomicsdb_vid_mapping.proto
+++ b/src/resources/genomicsdb_vid_mapping.proto
@@ -48,6 +48,9 @@ message GenomicsDBFieldInfo {
   repeated FieldLengthDescriptorComponentPB length = 5;
   repeated string vcf_delimiter = 6;
   optional string VCF_field_combine_operation = 7;
+  //useful when multiple fields of different types/length with the same
+  //name (FILTER, FORMAT, INFO)  are defined in the VCF header
+  optional string vcf_name = 8;
 }
 
 message Chromosome {

--- a/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -32,6 +32,7 @@ import htsjdk.variant.vcf.VCFUtils;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFFormatHeaderLine;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import htsjdk.variant.vcf.VCFFilterHeaderLine;
 
 import org.apache.commons.io.FileUtils;
 
@@ -616,6 +617,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
 	final VCFInfoHeaderLine h4 = new VCFInfoHeaderLine("test_field", 2, VCFHeaderLineType.Float, "");
 	final VCFInfoHeaderLine h5 = new VCFInfoHeaderLine("test_field", 3, VCFHeaderLineType.Float, "");
 	final VCFInfoHeaderLine h6 = new VCFInfoHeaderLine("test_field", 2, VCFHeaderLineType.Integer, "");
+	final VCFFilterHeaderLine h7 = new VCFFilterHeaderLine("test_field");
 
 	{
 	    final Set<VCFHeaderLine> s = new LinkedHashSet<>(Arrays.asList(h1, h2));
@@ -659,6 +661,38 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
 	    Assert.assertEquals(lengthDescriptor.getVariableLengthDescriptor(), "2");
 	}
 	{
+	    final Set<VCFHeaderLine> s = new LinkedHashSet<>(Arrays.asList(h1, h4, h7));
+	    final GenomicsDBVidMapProto.VidMappingPB pb = generateVidMapFromMergedHeader(s);
+	    //first field is ID field
+	    Assert.assertEquals(pb.getFieldsCount(), 3);
+	    {
+	      final GenomicsDBVidMapProto.GenomicsDBFieldInfo fieldInfo = pb.getFieldsList().get(1);
+	      Assert.assertEquals(fieldInfo.getName(), "test_field");
+	      Assert.assertEquals(fieldInfo.getVcfFieldClassCount(), 2);
+	      Assert.assertEquals(fieldInfo.getVcfFieldClass(0), "FORMAT");
+	      Assert.assertEquals(fieldInfo.getVcfFieldClass(1), "INFO");
+	      Assert.assertEquals(fieldInfo.getTypeCount(), 1);
+	      Assert.assertEquals(fieldInfo.getType(0), "Float");
+	      final GenomicsDBVidMapProto.FieldLengthDescriptorComponentPB lengthDescriptor = fieldInfo.getLength(0);
+	      Assert.assertTrue(lengthDescriptor.hasVariableLengthDescriptor());
+	      Assert.assertEquals(lengthDescriptor.getVariableLengthDescriptor(), "2");
+	    }
+	    {
+	      final GenomicsDBVidMapProto.GenomicsDBFieldInfo fieldInfo = pb.getFieldsList().get(2);
+	      Assert.assertEquals(fieldInfo.getName(), "test_field_FILTER");
+	      Assert.assertTrue(fieldInfo.hasVcfName());
+	      Assert.assertEquals(fieldInfo.getVcfName(), "test_field");
+	      Assert.assertEquals(fieldInfo.getVcfFieldClassCount(), 1);
+	      Assert.assertEquals(fieldInfo.getVcfFieldClass(0), "FILTER");
+	      Assert.assertEquals(fieldInfo.getTypeCount(), 1);
+	      Assert.assertEquals(fieldInfo.getType(0), "Integer");
+	      Assert.assertEquals(fieldInfo.getLengthCount(), 1);
+	      final GenomicsDBVidMapProto.FieldLengthDescriptorComponentPB lengthDescriptor = fieldInfo.getLength(0);
+	      Assert.assertTrue(lengthDescriptor.hasVariableLengthDescriptor());
+	      Assert.assertEquals(lengthDescriptor.getVariableLengthDescriptor(), "1");
+	    }
+	}
+	{
 	    final Set<VCFHeaderLine> s = new LinkedHashSet<>(Arrays.asList(h1, h5));
 	    final GenomicsDBVidMapProto.VidMappingPB pb = generateVidMapFromMergedHeader(s);
 	    //first field is ID field
@@ -677,6 +711,8 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
 	    {
 		final GenomicsDBVidMapProto.GenomicsDBFieldInfo fieldInfo = pb.getFieldsList().get(2);
 		Assert.assertEquals(fieldInfo.getName(), "test_field_INFO");
+		Assert.assertTrue(fieldInfo.hasVcfName());
+		Assert.assertEquals(fieldInfo.getVcfName(), "test_field");
 		Assert.assertEquals(fieldInfo.getVcfFieldClassCount(), 1);
 		Assert.assertEquals(fieldInfo.getVcfFieldClass(0), "INFO");
 		Assert.assertEquals(fieldInfo.getTypeCount(), 1);
@@ -705,6 +741,8 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
 	    {
 		final GenomicsDBVidMapProto.GenomicsDBFieldInfo fieldInfo = pb.getFieldsList().get(2);
 		Assert.assertEquals(fieldInfo.getName(), "test_field_INFO");
+		Assert.assertTrue(fieldInfo.hasVcfName());
+		Assert.assertEquals(fieldInfo.getVcfName(), "test_field");
 		Assert.assertEquals(fieldInfo.getVcfFieldClassCount(), 1);
 		Assert.assertEquals(fieldInfo.getVcfFieldClass(0), "INFO");
 		Assert.assertEquals(fieldInfo.getTypeCount(), 1);


### PR DESCRIPTION
* Reduce memory usage when dealing with allele specific annotation fields: this caused the most code changes. If there is an INFO field such that:
  * Its value is dependent on the order of the alleles and
  * Its combine operation is associative and commutative (just sum in this commit)

  , then this PR will cause this fields data to be remapped and the sum to be computed incrementally sample by sample. Earlier, the field would be remapped for all samples first and then the sum computed -- more memory than necessary would be used.
* Fix for https://github.com/broadinstitute/gatk/issues/6158