### PR TITLE
Protobuf as bytearray for spark conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
 
       - name: "Basic build OSX - 1"
         os: osx
+        osx_image: xcode9.3
         language: generic
         env: TOXENV=py34 INSTALL_TYPE=basic OSX_PHASE=1 PROTOBUF_VERSION=3.0.0-beta-1 PROTOBUF_HOME=$TRAVIS_BUILD_DIR/dependencies/protobuf
         cache:
@@ -31,6 +32,7 @@ matrix:
 
       - name: "Basic build OSX - 2"
         os: osx
+        osx_image: xcode9.3
         language: generic
         env: TOXENV=py34 INSTALL_TYPE=basic OSX_PHASE=2 PROTOBUF_VERSION=3.0.0-beta-1 PROTOBUF_HOME=$TRAVIS_BUILD_DIR/dependencies/protobuf
         cache:
@@ -65,7 +67,11 @@ install:
         mkdir -p $CACHE_DIR;
       fi
     # Install dependencies
-    - pip install -r requirements.txt
+    - if [[ $TRAVIS_OS_NAME == linux ]]; then
+        pip install -r requirements.txt;
+      elif [[ $TRAVIS_OS_NAME == osx ]]; then
+        pip install --user -r requirements.txt;
+      fi
     - sudo pip2 install jsondiff
     - if [[ $TRAVIS_OS_NAME == linux ]]; then
         sudo apt-get -y install lcov mpich zlib1g-dev libssl-dev rsync cmake uuid-dev libcurl4-openssl-dev;
@@ -118,7 +124,7 @@ before_script:
 
 script:
     #- pylint $TRAVIS_BUILD_DIR/docker/vcf_combiner/usr/bin/combine_vcf.py
-    - pytest $TRAVIS_BUILD_DIR/docker/vcf_combiner/usr/bin/combine_vcf.py
+    - python -m pytest $TRAVIS_BUILD_DIR/docker/vcf_combiner/usr/bin/combine_vcf.py
     - cd $GENOMICSDB_BUILD_DIR
     - if [[ $TRAVIS_OS_NAME == linux ]]; then
         cmake $TRAVIS_BUILD_DIR -DBUILD_JAVA=1 -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_INSTALL_PREFIX=$GENOMICSDB_INSTALL_DIR -DLIBCSV_DIR=$TRAVIS_BUILD_DIR/dependencies/libcsv -DGENOMICSDB_RELEASE_VERSION=$GENOMICSDB_RELEASE_VERSION -DMAVEN_QUIET=True -DENABLE_LIBCURL=True;

--- a/example/java/TestGenomicsDBDataSourceV2.java
+++ b/example/java/TestGenomicsDBDataSourceV2.java
@@ -213,7 +213,8 @@ public final class TestGenomicsDBDataSourceV2 {
       GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
       String jsonString = readFile(queryFile, Charset.defaultCharset());
       JsonFormat.merge(jsonString, builder);
-      String pbString = JsonFormat.printToString(builder.build());
+      byte[] pb = builder.build().toByteArray();
+      String pbString = Base64.getEncoder().encodeToString(pb);
 
       reader = reader.option("genomicsdb.input.queryprotobuf", pbString);
     } else {

--- a/example/java/TestGenomicsDBSparkHDFS.java
+++ b/example/java/TestGenomicsDBSparkHDFS.java
@@ -45,6 +45,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Base64;
 
 import com.googlecode.protobuf.format.JsonFormat;
 
@@ -139,7 +140,8 @@ public final class TestGenomicsDBSparkHDFS {
           GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
       String jsonString = readFile(queryFile, Charset.defaultCharset());
       JsonFormat.merge(jsonString, builder);
-      String pbString = JsonFormat.printToString(builder.build());
+      byte[] pb = builder.build().toByteArray();
+      String pbString = Base64.getEncoder().encodeToString(pb);
       hadoopConf.set(GenomicsDBConfiguration.QUERYPB, pbString);
     }
     if(!hostfile.isEmpty()) {

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>0.8.5</version>
         <executions>
           <!--
             Prepares the property pointing to the JaCoCo runtime agent which
@@ -338,6 +338,7 @@
         <configuration>
           <show>private</show>
           <nohelp>true</nohelp>
+          <source>8</source>
           <sourceFileExcludes>
             <exclude>**/Coordinates.java</exclude>
             <exclude>**/GenomicsDBVidMapProto.java</exclude>

--- a/src/main/java/org/genomicsdb/importer/extensions/CallSetMapExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/CallSetMapExtensions.java
@@ -157,7 +157,6 @@ public interface CallSetMapExtensions {
      * @param validateSampleToReaderMap If True, check i) whether sample names are consistent
      *                                  with headers and ii) feature readers are valid
      *                                  in sampleToReaderMap
-     * @param useSamplesInOrderProvided use samples in order provided in the map
      * @return Mappings of callset (sample) names to TileDB rows
      */
     default GenomicsDBCallsetsMapProto.CallsetMappingPB generateSortedCallSetMap(

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureIterator.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureIterator.java
@@ -84,6 +84,7 @@ public class GenomicsDBFeatureIterator<T extends Feature, SOURCE> implements Clo
      * @param featureCodecHeader htsjdk Feature codec header
      * @param codec              FeatureCodec, currently only {@link htsjdk.variant.bcf2.BCF2Codec}
      *                           and {@link htsjdk.variant.vcf.VCFCodec} are tested
+     * @throws IOException       when data cannot be read from the stream
      */
     GenomicsDBFeatureIterator(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB,
@@ -106,6 +107,7 @@ public class GenomicsDBFeatureIterator<T extends Feature, SOURCE> implements Clo
      * @param chr                contig name
      * @param start              start position (1-based)
      * @param end                end position, inclusive (1-based)
+     * @throws IOException       when data cannot be read from the stream
      */
     GenomicsDBFeatureIterator(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB,

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBQueryStream.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBQueryStream.java
@@ -58,6 +58,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * Constructor
      * @param loaderJSONFile GenomicsDB loader JSON configuration file
      * @param queryPB GenomicsDB query protobuf
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB) throws IOException {
@@ -69,6 +70,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * @param loaderJSONFile GenomicsDB loader JSON configuration file
      * @param queryPB GenomicsDB query protobuf
      * @param readAsBCF serialize-deserialize VCF records as BCF2 records
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB, final boolean readAsBCF) throws IOException {
@@ -81,6 +83,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * @param queryPB GenomicsDB query protobuf
      * @param readAsBCF serialize-deserialize VCF records as BCF2 records
      * @param produceHeaderOnly produce only the header
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB, final boolean readAsBCF,
@@ -96,6 +99,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * @param chr contig name
      * @param start start position (1-based)
      * @param end end position, inclusive (1-based)
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB, final String chr,
@@ -111,6 +115,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * @param start start position (1-based)
      * @param end end position, inclusive (1-based)
      * @param readAsBCF serialize-deserialize VCF records as BCF2 records
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, 
            final GenomicsDBExportConfiguration.ExportConfiguration queryPB, final String chr,
@@ -127,6 +132,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * @param start start position (1-based)
      * @param end end position, inclusive (1-based)
      * @param rank rank of this object if launched from within an MPI context (not used)
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB, final String chr,
@@ -145,6 +151,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * @param bufferCapacity size of buffer in bytes to be used by the native layer
      *                       to store combined BCF2 records
      * @param segmentSize buffer to be used for querying TileDB
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB, final String chr,
@@ -166,6 +173,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * @param segmentSize buffer to be used for querying TileDB
      * @param readAsBCF serialize-deserialize VCF records as BCF2 records
      * @param produceHeaderOnly produce VCF/BCF header only - no records (minor optimization)
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, 
             final GenomicsDBExportConfiguration.ExportConfiguration queryPB, final String chr,
@@ -190,6 +198,7 @@ public class GenomicsDBQueryStream extends InputStream {
      * @param produceHeaderOnly produce VCF/BCF header only - no records (minor optimization)
      * @param useMissingValuesOnlyNotVectorEnd don't add BCF2.2 vector end values
      * @param keepIDXFieldsInHeader keep BCF IDX fields in header
+     * @throws IOException when data cannot be read from the stream
      */
     public GenomicsDBQueryStream(final String loaderJSONFile,
                                  final GenomicsDBExportConfiguration.ExportConfiguration queryPB, final String chr,

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBConfiguration.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBConfiguration.java
@@ -44,11 +44,9 @@ import java.lang.RuntimeException;
 
 /**
  * The configuration class enables users to use Java/Scala
- * to populate the input parameters of GenomicsDB. The first
- * version of the input format are JSON files. Through this
- * class, we provide a programmable interface. Note, that once
- * fully coded, this configuration object can be directly
- * passed from GATK4.0
+ * to populate the input parameters of GenomicsDB. 
+ * Input parameters can be passed in as json files or 
+ * base64 encoded protobuf byte data
  */
 public class GenomicsDBConfiguration extends Configuration implements Serializable {
 

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBConfiguration.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBConfiguration.java
@@ -39,9 +39,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Iterator;
+import java.util.Base64;
 import java.lang.RuntimeException;
-
-import com.googlecode.protobuf.format.JsonFormat;
 
 /**
  * The configuration class enables users to use Java/Scala
@@ -267,10 +266,11 @@ public class GenomicsDBConfiguration extends Configuration implements Serializab
   }
 
   private void readColumnPartitionsPB(String pb) throws
-        com.googlecode.protobuf.format.JsonFormat.ParseException {
+        com.google.protobuf.InvalidProtocolBufferException {
     GenomicsDBImportConfiguration.ImportConfiguration.Builder importConfigurationBuilder = 
              GenomicsDBImportConfiguration.ImportConfiguration.newBuilder();
-    JsonFormat.merge(pb, importConfigurationBuilder);
+    byte[] pbDecoded = Base64.getDecoder().decode(pb);
+    importConfigurationBuilder.mergeFrom(pbDecoded);
     GenomicsDBImportConfiguration.ImportConfiguration loaderPB = importConfigurationBuilder.build();
 
     if (partitionInfoList==null) {
@@ -291,10 +291,11 @@ public class GenomicsDBConfiguration extends Configuration implements Serializab
   }
 
   private void readQueryRangesPB(String pb) throws 
-        com.googlecode.protobuf.format.JsonFormat.ParseException {
+        com.google.protobuf.InvalidProtocolBufferException {
     GenomicsDBExportConfiguration.ExportConfiguration.Builder exportConfigurationBuilder = 
              GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
-    JsonFormat.merge(pb, exportConfigurationBuilder);
+    byte[] pbDecoded = Base64.getDecoder().decode(pb);
+    exportConfigurationBuilder.mergeFrom(pbDecoded);
     GenomicsDBExportConfiguration.ExportConfiguration queryPB = exportConfigurationBuilder.build();
 
     if (queryInfoList==null) {

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
@@ -31,7 +31,6 @@ import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import java.util.Map;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.FileReader;
@@ -42,8 +41,6 @@ import java.lang.RuntimeException;
 import java.lang.InstantiationException;
 import java.lang.IllegalAccessException;
 import java.lang.ClassNotFoundException;
-
-import com.googlecode.protobuf.format.JsonFormat;
 
 /**
  * The input class represents all the data being queried from GenomicsDB.
@@ -359,10 +356,10 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
    * Creates export configuration protobuf object 
    * based on partition, query and existing query file or protobuf
    *
-   * @param queryFileOrPB Existing query json file or protobuf string
+   * @param queryFileOrPB Existing query json file or protobuf 
    * @param partition used to populate array
    * @param queryList used to bound query column ranges
-   * @param isPB boolean parameter that denotes if queryFileOrPB is protobuf string
+   * @param isPB boolean parameter that denotes if queryFileOrPB is protobuf
    * @return  Returns export configuration protobuf object
    * @throws IOException  Thrown if other IO exception while handling file operations
    * @throws ParseException  Thrown if JSON parsing fails
@@ -379,7 +376,8 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
     if (isPB) {
       exportConfigurationBuilder = 
           GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
-      JsonFormat.merge(queryFileOrPB, exportConfigurationBuilder);
+      byte[] queryPB = Base64.getDecoder().decode(queryFileOrPB);
+      exportConfigurationBuilder.mergeFrom(queryPB);
     }
     else {
       exportConfigurationBuilder = 

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
@@ -356,7 +356,7 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
    * Creates export configuration protobuf object 
    * based on partition, query and existing query file or protobuf
    *
-   * @param queryFileOrPB Existing query json file or protobuf 
+   * @param queryFileOrPB Existing query json file or base64 encoded protobuf byte data
    * @param partition used to populate array
    * @param queryList used to bound query column ranges
    * @param isPB boolean parameter that denotes if queryFileOrPB is protobuf

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInputFormat.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInputFormat.java
@@ -92,7 +92,7 @@ public class GenomicsDBInputFormat<VCONTEXT extends Feature, SOURCE>
       throws IOException, InterruptedException {
 
     String loaderJson;
-    String queryJson;
+    String query;
 
     GenomicsDBFeatureReader<VCONTEXT, SOURCE> featureReader;
     GenomicsDBRecordReader<VCONTEXT, SOURCE> recordReader;
@@ -103,11 +103,11 @@ public class GenomicsDBInputFormat<VCONTEXT extends Feature, SOURCE>
       Configuration configuration = taskAttemptContext.getConfiguration();
       loaderJson = configuration.get(GenomicsDBConfiguration.LOADERJSON);
       if (configuration.get(GenomicsDBConfiguration.QUERYPB) != null) {
-        queryJson = configuration.get(GenomicsDBConfiguration.QUERYPB);
+        query = configuration.get(GenomicsDBConfiguration.QUERYPB);
         isPB = true;
       }
       else {
-        queryJson = configuration.get(GenomicsDBConfiguration.QUERYJSON);
+        query = configuration.get(GenomicsDBConfiguration.QUERYJSON);
         isPB = false;
       }
     } else {
@@ -118,11 +118,11 @@ public class GenomicsDBInputFormat<VCONTEXT extends Feature, SOURCE>
       assert(configuration!=null);
       loaderJson = configuration.get(GenomicsDBConfiguration.LOADERJSON);
       if (configuration.get(GenomicsDBConfiguration.QUERYPB) != null) {
-        queryJson = configuration.get(GenomicsDBConfiguration.QUERYPB);
+        query = configuration.get(GenomicsDBConfiguration.QUERYPB);
         isPB = true;
       }
       else {
-        queryJson = configuration.get(GenomicsDBConfiguration.QUERYJSON);
+        query = configuration.get(GenomicsDBConfiguration.QUERYJSON);
         isPB = false;
       }
     }
@@ -132,7 +132,7 @@ public class GenomicsDBInputFormat<VCONTEXT extends Feature, SOURCE>
     GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration;
     try {
       exportConfiguration = 
-              GenomicsDBInput.createTargetExportConfigurationPB(queryJson, 
+              GenomicsDBInput.createTargetExportConfigurationPB(query, 
               gSplit.getPartitionInfo(),
               gSplit.getQueryInfoList(), isPB);
     }

--- a/tests/common.py
+++ b/tests/common.py
@@ -71,7 +71,7 @@ def setup_jacoco(build_dir, build_type):
         jacoco_cli_jar = os.path.join(build_dir,'lib/jacococli.jar')
         jacoco_agent_jar = os.path.join(build_dir,'lib/jacocoagent.jar')
         if (not os.path.isfile(jacoco_cli_jar) or not os.path.isfile(jacoco_agent_jar)):
-            jacoco_zip_file = os.path.join(build_dir, "jacoco-0.8.2.zip")
+            jacoco_zip_file = os.path.join(build_dir, "jacoco-0.8.5.zip")
             urllib.urlretrieve ("https://github.com/jacoco/jacoco/releases/download/v0.8.2/jacoco-0.8.2.zip", 
                                 jacoco_zip_file)
             with zipfile.ZipFile(jacoco_zip_file, 'r') as zip_ref:


### PR DESCRIPTION
We were passing in protobuf as json string in for spark. It turns out that Google's python protobuf sends in int64 as string (for reasons specified in many places, for instance [here)](https://github.com/protocolbuffers/protobuf/issues/2679)

So this moves us to expect protobuf bytestream instead. Since we use hadoop configuration to pass the config, it gets encoded as a base64 string on the sender side - so the receiver decodes that first before ingesting the protobuf object.

Also, a few annoying travis Mac OS changes.