### PR TITLE
bug fix and test for spark partitioning issue

### DIFF
--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
@@ -280,8 +280,9 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
   	    // can use the same ArrayList of queries since each inputsplit will only care
   	    // about the section that is relevant to its partition
             glomQuerys.add(queryRange);
-            partition = addSplitsIfQuerySpansPartitions(inputPartitions, pIndex, 
+            pIndex = addSplitsIfQuerySpansPartitions(inputPartitions, pIndex, 
                     queryRange.getEndPosition(), partitionsList, glomQuerys);
+            partition = (pIndex < partitionsList.size()) ? partitionsList.get(pIndex) : null;
             glomQuerys.clear();
           }
           else {
@@ -313,8 +314,9 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
   	    inputPartitions.add(getInputInstance(partition, glomQuerys));
   
   	    // if this queryBlock spans multiple partitions, need to add those as splits as well
-  	    partition = addSplitsIfQuerySpansPartitions(inputPartitions, pIndex,
+  	    pIndex = addSplitsIfQuerySpansPartitions(inputPartitions, pIndex,
                     queryBlockStart+blockSize-1, partitionsList, glomQuerys);
+            partition = (pIndex < partitionsList.size()) ? partitionsList.get(pIndex) : null;
             glomQuerys.clear();
   	    queryBlockStart += blockSize;
   	    queryBlockSize -= blockSize;
@@ -338,7 +340,7 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
             queryEnd >= list.get(index).getBeginPosition();
   }
 
-  private GenomicsDBPartitionInfo addSplitsIfQuerySpansPartitions(
+  private int addSplitsIfQuerySpansPartitions(
           ArrayList<T> list, int index,
           final long queryEnd,
           final ArrayList<GenomicsDBPartitionInfo> partitionList, 
@@ -349,7 +351,7 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
       partition = partitionList.get(index);
       list.add(getInputInstance(partition, queryList));
     }
-    return partition;
+    return index;
   }
 
   /**

--- a/src/test/java/org/genomicsdb/GenomicsDBTestUtils.java
+++ b/src/test/java/org/genomicsdb/GenomicsDBTestUtils.java
@@ -283,4 +283,42 @@ public final class GenomicsDBTestUtils {
 
     return new Object[][] { { tmpQFile.getAbsolutePath(), tmpLFile.getAbsolutePath(), tmpHFile.getAbsolutePath() } };
   }
+
+  // test query range bigger than query block size
+  @DataProvider(name="loaderQueryHostFilesTest6")
+  public static Object[][] loaderQueryHostFilesTest6() throws IOException {
+    String queryPreamble = "{\n\"workspace\": \"hdfs://tmp/ws\",\n\"array\": \"part\",\n \"query_block_size\":5000, \"query_block_size_margin\":1000,";
+    String loaderPreamble = "{\n\"row_based_partitioning\": false,\n\"column_partitions\" : [\n";
+    String loaderEpilogue = "\n],\n\"vid_mapping_file\" : \"tests/inputs/vid.json\"\n}";
+    String loaderPartEpilogue = "\"workspace\": \"hdfs://tmp/ws\", \"vcf_output_filename\": \"/tmp/test0.vcf.gz\"}";
+
+    String queryCol = "\"query_column_ranges\" : [ [ [ 9000, 24500]";
+    String loaderPart = "";
+    for(int i=0; i<3; i++) {
+       loaderPart += "{\"begin\": "+String.valueOf(i*10000)+", \"array\": \"part"+i+"\","+loaderPartEpilogue;
+       if (i<2) {
+         loaderPart += ",\n";
+       }
+    }
+    String query = queryPreamble + queryCol + " ] ]\n}"; 
+    String loader = loaderPreamble + loaderPart + loaderEpilogue;
+    File tmpQFile = File.createTempFile("query", ".json");
+    tmpQFile.deleteOnExit();
+    FileWriter fQ = new FileWriter(tmpQFile);
+    fQ.write(query);
+    fQ.close();
+    File tmpLFile = File.createTempFile("loader", ".json");
+    tmpLFile.deleteOnExit();
+    FileWriter fL = new FileWriter(tmpLFile);
+    fL.write(loader);
+    fL.close();
+    File tmpHFile = File.createTempFile("hostfile", "");
+    tmpHFile.deleteOnExit();
+    FileWriter fH = new FileWriter(tmpHFile);
+    fH.write("localhost");
+    fH.close();
+
+    return new Object[][] { { tmpQFile.getAbsolutePath(), tmpLFile.getAbsolutePath(), tmpHFile.getAbsolutePath() } };
+  }
+
 }

--- a/src/test/java/org/genomicsdb/spark/GenomicsDBInputFormatTest.java
+++ b/src/test/java/org/genomicsdb/spark/GenomicsDBInputFormatTest.java
@@ -234,4 +234,45 @@ public class GenomicsDBInputFormatTest {
       Assert.assertEquals(gSplit.getQueryInfoList().get(i), qList.get(i));
     }
   }
+
+  @Test(testName = "Test query larger than query block size",
+      dataProvider = "loaderQueryHostFilesTest6",
+      dataProviderClass = GenomicsDBTestUtils.class)
+  public void testQueryLargerThanQueryBlockSize(String queryPath, 
+              String loaderPath, String hostPath) 
+              throws IOException, FileNotFoundException, InterruptedException {
+    Job job = Job.getInstance();
+    Configuration conf = job.getConfiguration();
+    conf.set(GenomicsDBConfiguration.LOADERJSON, loaderPath);
+    conf.set(GenomicsDBConfiguration.QUERYJSON, queryPath);
+    conf.set(GenomicsDBConfiguration.MPIHOSTFILE, hostPath);
+    ArrayList<GenomicsDBPartitionInfo> pList = new ArrayList<>(3);
+    for(int i=0; i<3; i++) {
+      GenomicsDBPartitionInfo p = new GenomicsDBPartitionInfo(i*10000, "hdfs://tmp/ws", "part"+i, "/tmp/test0.vcf.gz");
+      pList.add(p);
+    }
+    int qstart = 9000;
+    int qend = 24500;
+    GenomicsDBQueryInfo q = new GenomicsDBQueryInfo(qstart, qend);
+
+    GenomicsDBInputFormat format = new GenomicsDBInputFormat();
+    format.setConf(conf);
+    List<InputSplit> splits = format.getSplits(job);
+    Assert.assertEquals(splits.size(), 5);
+    // check first partition
+    Assert.assertEquals(((GenomicsDBInputSplit)splits.get(0)).getPartitionInfo().getBeginPosition(), 0);
+    // check that query chunks span the original query range
+    Assert.assertEquals(((GenomicsDBInputSplit)splits.get(0)).getQueryInfoList().get(0).getBeginPosition(), 9000);
+    Assert.assertEquals(((GenomicsDBInputSplit)splits.get(4)).getQueryInfoList().get(0).getEndPosition(), 24500);
+    for(int i=0; i<splits.size()-1; i++) {
+      GenomicsDBInputSplit gSplit = (GenomicsDBInputSplit)splits.get(i);
+      GenomicsDBInputSplit gSplitNext = (GenomicsDBInputSplit)splits.get(i+1);
+      // check that query ranges do not overlap, OR if they do they are targetting different partitions
+      // the latter check is because we sometimes send the same query range to differnt partitions. Genomicsdb can handle this
+      // and each array only worries about the column ranges it owns
+      Assert.assertTrue((gSplit.getQueryInfoList().get(0).getEndPosition()+1 == gSplitNext.getQueryInfoList().get(0).getBeginPosition()) ||
+                           gSplit.getPartitionInfo().getBeginPosition() < gSplitNext.getPartitionInfo().getBeginPosition());
+    }
+  }
+
 }


### PR DESCRIPTION
Found a bug with the spark partitioning that kicks in when we try to create queries that are larger than arrays. Added a test as well