### PR TITLE
Refine GenomicsDB API with support for Protobuf and JSON strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,8 @@
                 <copy file="${test_source_directory}/../inputs/test.tgz" tofile="${genomicsdb_build_directory}/test/test.tar.gz" />
                 <gunzip src="${genomicsdb_build_directory}/test/test.tar.gz" />
                 <untar src="${genomicsdb_build_directory}/test/test.tar" dest="${genomicsdb_build_directory}/test/"/>
+                <replace file="${genomicsdb_build_directory}/test/inputs/query.json" token="inputs/" value="${genomicsdb_build_directory}/test/inputs/" />
+                <replace file="${genomicsdb_build_directory}/test/inputs/loader.json" token="inputs/" value="${genomicsdb_build_directory}/test/inputs/" />
               </target>
             </configuration>
             <goals>

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -247,6 +247,8 @@ class VariantQueryConfig;
  */
 class GenomicsDB {
  public:
+  enum GENOMICSDB_EXPORT query_config_type_t { JSON_FILE=0, JSON_STRING=1, PROTOBUF_BINARY_STRING=2 };
+
   /**
    * Constructor to the GenomicsDB Query API
    *   workspace
@@ -266,17 +268,20 @@ class GenomicsDB {
 
   /**
    * Constructor to the GenomicsDB Query API with configuration json files
-   *   query_config_json_file
-   *   loader_config_json_file, optional
+   *   query_configuration - describe the query configuration in either a JSON file or string
+   *   query_configuration_type - type of query configuration, could be a JSON_FILE or JSON_STRING
+   *   loader_config_json_file, optional - describe the loader configuration in a JSON file.
+   *           If a configuration key exists in both the query and the loader configuration, the query
+   *           configuration takes precedence
    *   concurrency_rank, optional - if greater than 0, 
    *           the constraints(workspace, array, column and row ranges) are surmised
-   *           using the rank as an index into their corresponding vectors.
+   *           using the rank as an index into their corresponding vectors
    * Throws GenomicsDBException
    */
-  GENOMICSDB_EXPORT GenomicsDB(const std::string& query_config_json_file,
-             const std::string& loader_config_json_file = std::string(),
-             const int concurrency_rank=0);
-
+  GENOMICSDB_EXPORT GenomicsDB(const std::string& query_configuration,
+                               const query_config_type_t query_configuration_type = JSON_FILE,
+                               const std::string& loader_configuration_json_file = std::string(),
+                               const int concurrency_rank=0);
   /**
    * Destructor
    */

--- a/src/main/cpp/include/config/genomicsdb_config_base.h
+++ b/src/main/cpp/include/config/genomicsdb_config_base.h
@@ -143,8 +143,8 @@ class GenomicsDBConfigBase {
     m_vid_mapping_file = vid_mapping_file;
   }
   //Sometimes information is present in the loader - copy over
-  void update_from_loader(const GenomicsDBImportConfig& loader_config, const int rank);
-  void subset_query_column_ranges_based_on_partition(const GenomicsDBImportConfig& loader_config, const int rank);
+  void update_from_loader(const GenomicsDBImportConfig& loader_config, const int rank=0);
+  void subset_query_column_ranges_based_on_partition(const GenomicsDBImportConfig& loader_config, const int rank=0);
   inline TileDBRowRange get_row_bounds() const {
     return TileDBRowRange(m_lb_callset_row_idx, m_ub_callset_row_idx);
   }

--- a/src/main/cpp/include/config/variant_query_config.h
+++ b/src/main/cpp/include/config/variant_query_config.h
@@ -340,6 +340,10 @@ class VariantQueryConfig : public GenomicsDBConfigBase {
    */
   void read_from_file(const std::string& filename, const int rank=0);
   /*
+   * Read configuration from JSON string
+   */
+  void read_from_JSON_string(const std::string& str, const int rank=0);
+  /*
    * Validates and intializes variant query configuration. GenomicsDBConfigException is thrown on failed checks.
    */
   void validate(const int rank=0);

--- a/src/main/cpp/src/config/variant_query_config.cc
+++ b/src/main/cpp/src/config/variant_query_config.cc
@@ -206,6 +206,11 @@ void VariantQueryConfig::read_from_file(const std::string& filename, const int r
   validate(rank);
 }
 
+void VariantQueryConfig::read_from_JSON_string(const std::string& str, const int rank) {
+  GenomicsDBConfigBase::read_from_JSON_string(str, rank);
+  validate(rank);
+}
+
 void VariantQueryConfig::validate(const int rank) {
   //Workspace
   VERIFY_OR_THROW(m_workspaces.size() && "No workspace specified");

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBQuery.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBQuery.java
@@ -24,6 +24,7 @@ package org.genomicsdb.reader;
 
 import org.genomicsdb.GenomicsDBLibLoader;
 import org.genomicsdb.exception.GenomicsDBException;
+import org.genomicsdb.model.GenomicsDBExportConfiguration;
 
 import java.util.*;
 
@@ -143,6 +144,14 @@ public class GenomicsDBQuery {
     return jniConnectJSON(queryJSONFile, loaderJSONFile);
   }
 
+  public long connectExportConfiguration(GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration) {
+    return connectExportConfiguration(exportConfiguration, "");
+  }
+
+  public long connectExportConfiguration(GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration, final String loaderJSONFile) {
+    return jniConnectPBBinaryString(exportConfiguration.toByteArray(), loaderJSONFile);
+  }
+
   public void disconnect(long handle) {
     jniDisconnect(handle);
   }
@@ -211,6 +220,9 @@ public class GenomicsDBQuery {
 
   private static native long jniConnectJSON(final String queryJSONFile,
                                             final String loaderJSONFile);
+
+  private static native long jniConnectPBBinaryString(final byte[] pbBinaryString,
+                                                      final String loaderJSONFile);
 
   private static native void jniDisconnect(long handle);
 

--- a/src/main/jni/include/genomicsdb_GenomicsDBQuery.h
+++ b/src/main/jni/include/genomicsdb_GenomicsDBQuery.h
@@ -36,10 +36,18 @@ JNIEXPORT jlong JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniConnect
 /*
  * Class:     org_genomicsdb_reader_GenomicsDBQuery
  * Method:    jniConnectJSON
- * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;J)J
+ * Signature: (Ljava/lang/String;Ljava/lang/String;)J
  */
 JNIEXPORT jlong JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniConnectJSON
   (JNIEnv *, jclass, jstring, jstring);
+
+/*
+ * Class:     org_genomicsdb_reader_GenomicsDBQuery
+ * Method:    jniConnectPBBinaryString
+ * Signature: ([BLjava/lang/String;)J
+ */
+JNIEXPORT jlong JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniConnectPBBinaryString
+  (JNIEnv *, jclass, jbyteArray, jstring);
 
 /*
  * Class:     org_genomicsdb_reader_GenomicsDBQuery
@@ -62,18 +70,16 @@ JNIEXPORT jobject JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniQueryVar
  * Method:    jniGenerateVCF
  * Signature: (JLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Z)V
  */
-JNIEXPORT void JNICALL
-Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF
-(JNIEnv *, jclass, jlong, jstring, jobject, jobject, jstring, jstring, jboolean);
+JNIEXPORT void JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF
+  (JNIEnv *, jclass, jlong, jstring, jobject, jobject, jstring, jstring, jboolean);
 
 /*
  * Class:     org_genomicsdb_reader_GenomicsDBQuery
- * Method:    jniGenerateVCF
+ * Method:    jniGenerateVCF1
  * Signature: (JLjava/lang/String;Ljava/lang/String;Z)V
  */
-JNIEXPORT void JNICALL
-Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF1
-(JNIEnv *, jclass, jlong, jstring, jstring, jboolean);
+JNIEXPORT void JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF1
+  (JNIEnv *, jclass, jlong, jstring, jstring, jboolean);
 
 #ifdef __cplusplus
 }

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ include_directories(${PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS})
 
 set(CPP_TEST_SOURCES
   src/ctest_main.cc
+  src/test_config.cc
   src/test_non_diploid_mapper.cc
   src/test_multid_vector.cc
   src/test_pb.cc

--- a/src/test/cpp/include/test_base.h
+++ b/src/test/cpp/include/test_base.h
@@ -1,0 +1,68 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2020 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * this software and associated documentation files (the "Software"), to deal in 
+ * the Software without restriction, including without limitation the rights to 
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+ * the Software, and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef GENOMICSDB_TEST_BASE_H
+#define GENOMICSDB_TEST_BASE_H
+
+#include "tiledb_utils.h"
+
+class TempDir {
+ public:
+  TempDir() {
+    create_temp_directory();
+  }
+
+  ~TempDir() {
+    TileDBUtils::delete_dir(tmp_dirname_);
+  }
+
+  const std::string& get() {
+    return tmp_dirname_;
+  }
+
+  const std::string append(const std::string path) {
+    return append_slash(tmp_dirname_) + path;
+  }
+
+ private:
+  std::string tmp_dirname_;
+
+  const std::string append_slash(const std::string path) {
+    if (path[path.length()-1] == '/') {
+      return path;
+    } else {
+      return path + "/";
+    }
+  }
+
+  void create_temp_directory() {
+    std::string dirname_pattern("ImageDSXXXXXX");
+    const char *tmp_dir = getenv("TMPDIR");
+    if (tmp_dir == NULL) {
+      tmp_dir = P_tmpdir; // defined in stdio
+    }
+    assert(tmp_dir != NULL);
+    tmp_dirname_ = mkdtemp(const_cast<char *>((append_slash(tmp_dir)+dirname_pattern).c_str()));
+  }
+};
+
+#endif /* GENOMICSDB_TEST_BASE_H */

--- a/src/test/cpp/src/test_config.cc
+++ b/src/test/cpp/src/test_config.cc
@@ -1,0 +1,115 @@
+/**
+ * src/test/cpp/src/test_config.cc
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2020 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * this software and associated documentation files (the "Software"), to deal in 
+ * the Software without restriction, including without limitation the rights to 
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+ * the Software, and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Test GenomicsDBConfig/VariantQueryConfig/... classes
+ *
+ */
+
+#include <catch2/catch.hpp>
+
+#include "genomicsdb_config_base.h"
+#include "tiledb_utils.h"
+#include "variant_query_config.h"
+
+static std::string ctests_input_dir(GENOMICSDB_CTESTS_DIR);
+
+static std::string query_json(ctests_input_dir+"query.json");
+static std::string loader_json(ctests_input_dir+"loader.json");
+
+TEST_CASE("Check configuration with json file", "[basic_config_check]") {
+  GenomicsDBImportConfig loader_config;
+  loader_config.read_from_file(loader_json);
+  
+  VariantQueryConfig query_config_from_file;
+  query_config_from_file.update_from_loader(loader_config);
+  query_config_from_file.read_from_file(query_json);
+  query_config_from_file.subset_query_column_ranges_based_on_partition(loader_config);
+
+  CHECK(query_config_from_file.get_workspace(0) == "inputs/ws");
+  CHECK(query_config_from_file.get_array_name(0) == "t0_1_2");
+  CHECK(query_config_from_file.get_query_column_ranges(0).size() ==  1);
+  CHECK(query_config_from_file.get_query_column_ranges(0)[0].first ==  0);
+  CHECK(query_config_from_file.get_query_column_ranges(0)[0].second ==  1000000000);
+  CHECK(query_config_from_file.get_query_row_ranges(0).size() ==  1);
+  CHECK(query_config_from_file.get_query_row_ranges(0)[0].first ==  0);
+  CHECK(query_config_from_file.get_query_row_ranges(0)[0].second ==  3);
+  CHECK(query_config_from_file.get_query_filter().empty());
+  CHECK(query_config_from_file.get_segment_size() == 40);
+  CHECK(query_config_from_file.get_determine_sites_with_max_alleles() == 0);
+  CHECK(query_config_from_file.get_vcf_output_filename() == "-");
+  CHECK(query_config_from_file.get_reference_genome() ==  "inputs/chr1_10MB.fasta.gz");
+  CHECK(query_config_from_file.produce_GT_field() == false);
+  CHECK(query_config_from_file.produce_FILTER_field() ==  false);
+  CHECK(query_config_from_file.sites_only_query() == false);
+  CHECK(query_config_from_file.index_output_VCF() ==  false);
+  CHECK(query_config_from_file.produce_GT_with_min_PL_value_for_spanning_deletions() == false);
+  CHECK(query_config_from_file.get_vid_mapper().is_initialized() ==  true);
+  CHECK(query_config_from_file.get_vid_mapper().is_callset_mapping_initialized() == true);
+}
+
+TEST_CASE("Compare configuration with json file and string", "[compare_json_types]") {
+  GenomicsDBImportConfig loader_config;
+  loader_config.read_from_file(loader_json);
+  
+  VariantQueryConfig query_config_from_file;
+  query_config_from_file.update_from_loader(loader_config);
+  query_config_from_file.read_from_file(query_json);
+  query_config_from_file.subset_query_column_ranges_based_on_partition(loader_config);
+
+  char *query_json_buffer=NULL, *loader_json_buffer=NULL;
+  size_t query_json_buffer_length, loader_json_buffer_length;
+  CHECK(TileDBUtils::read_entire_file(query_json, (void **)&query_json_buffer, &query_json_buffer_length) == TILEDB_OK);
+  CHECK(query_json_buffer);
+  CHECK(query_json_buffer_length > 0);
+
+  VariantQueryConfig query_config_from_str;
+  query_config_from_str.update_from_loader(loader_config);
+  query_config_from_str.read_from_JSON_string(query_json_buffer);
+  query_config_from_str.subset_query_column_ranges_based_on_partition(loader_config);
+  
+  // Compare configs read as JSON file or JSON string - they should be equivalent
+  CHECK(query_config_from_file.get_workspace(0) == query_config_from_str.get_workspace(0));
+  CHECK(query_config_from_file.get_array_name(0) == query_config_from_str.get_array_name(0));
+  CHECK(query_config_from_file.get_column_partition(0) == query_config_from_str.get_column_partition(0));
+  CHECK(query_config_from_file.get_row_partition(0) == query_config_from_str.get_row_partition(0));
+  CHECK(query_config_from_file.get_query_column_ranges(0).size() ==  query_config_from_str.get_query_column_ranges(0).size());
+  CHECK(query_config_from_file.get_query_column_ranges(0)[0] == query_config_from_str.get_query_column_ranges(0)[0]);
+  CHECK(query_config_from_file.get_query_row_ranges(0).size() ==  query_config_from_str.get_query_row_ranges(0).size());
+  CHECK(query_config_from_file.get_query_row_ranges(0)[0] == query_config_from_str.get_query_row_ranges(0)[0]);
+  CHECK(query_config_from_file.get_query_filter() == query_config_from_str.get_query_filter());
+  CHECK(query_config_from_file.get_segment_size() == query_config_from_str.get_segment_size());
+  CHECK(query_config_from_file.get_determine_sites_with_max_alleles() == query_config_from_str.get_determine_sites_with_max_alleles());
+  CHECK(query_config_from_file.get_max_diploid_alt_alleles_that_can_be_genotyped() == query_config_from_str.get_max_diploid_alt_alleles_that_can_be_genotyped());
+  CHECK(query_config_from_file.get_max_genotype_count() == query_config_from_str.get_max_genotype_count());
+  CHECK(query_config_from_file.get_combined_vcf_records_buffer_size_limit() ==  query_config_from_str.get_combined_vcf_records_buffer_size_limit());
+  CHECK(query_config_from_file.get_vcf_output_filename() == query_config_from_str.get_vcf_output_filename());
+  CHECK(query_config_from_file.get_reference_genome() ==  query_config_from_str.get_reference_genome());
+  CHECK(query_config_from_file.produce_GT_field() == query_config_from_str.produce_GT_field());
+  CHECK(query_config_from_file.produce_FILTER_field() ==  query_config_from_str.produce_FILTER_field());
+  CHECK(query_config_from_file.sites_only_query() == query_config_from_str.sites_only_query());
+  CHECK(query_config_from_file.index_output_VCF() == query_config_from_str.index_output_VCF());
+  CHECK(query_config_from_file.produce_GT_with_min_PL_value_for_spanning_deletions() == query_config_from_str.produce_GT_with_min_PL_value_for_spanning_deletions());
+  CHECK(query_config_from_file.get_vid_mapper().is_initialized() == query_config_from_str.get_vid_mapper().is_initialized());
+  CHECK(query_config_from_file.get_vid_mapper().is_callset_mapping_initialized() == query_config_from_str.get_vid_mapper().is_callset_mapping_initialized());
+}
+


### PR DESCRIPTION
Allow for JSON/JSON strings/Protobuf binary strings to be passed as export configuration to GenomicsDB API
