### PR TITLE
Cleanup and support GT missing fields in api

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -60,6 +60,7 @@ set(GenomicsDB_library_sources
     cpp/src/config/json_config.cc
     cpp/src/config/pb_config.cc
     cpp/src/api/genomicsdb.cc
+    cpp/src/api/genomicsdb_field.cc
     )
 
 include_directories(${PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS})

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -53,12 +53,6 @@
 
 GENOMICSDB_EXPORT std::string genomicsdb_version();
 
-#define PHASED_ALLELE_SEPARATOR '|';
-#define UNPHASED_ALLELE_SEPARATOR '/';
-#define ALLELE_SEPARATOR '|'
-#define NON_REF_VARIANT "&"
-#define NON_REF "<NON_REF>"
-
 typedef std::pair<uint64_t, uint64_t> interval_t;
 
 typedef struct genomic_interval_t {
@@ -132,43 +126,8 @@ typedef struct genomic_field_t {
   inline std::string str_value() const {
     return std::string(reinterpret_cast<const char *>(ptr)).substr(0, num_elements);
   }
-  std::string recombine_ALT_value(char delim=ALLELE_SEPARATOR, std::string separator=", ") const {
-    std::stringstream ss(str_value());
-    std::string output;
-    std::string item;
-    while (std::getline(ss, item, delim)){
-      if (item.compare(NON_REF_VARIANT) == 0) {
-        output.empty()?output=NON_REF:output=output+separator+NON_REF;
-      } else {
-        output.empty()?output=item:output=output+separator+item;
-      }
-    }
-    return "[" + output + "]";
-  }
-  std::string combine_GT_vector(const genomic_field_type_t& field_type) const {
-    std::string output;
-    if (field_type.contains_phase_information()) {
-      for (auto i=0ul; i<num_elements; i++) {
-        output = output + to_string(i, field_type);
-        if (i+1<num_elements) {
-          if (to_string(i+1, field_type).compare("0") == 0) {
-            output = output + UNPHASED_ALLELE_SEPARATOR;
-          } else {
-            output = output + PHASED_ALLELE_SEPARATOR;
-          }
-          i++;
-        }
-      }
-    } else {
-      for (auto i=0ul; i<num_elements; i++) {
-        output = output + to_string(i, field_type);
-        if (i+1<num_elements) {
-          output = output + UNPHASED_ALLELE_SEPARATOR;
-        }
-      }
-    }
-    return output;
-  }
+  std::string recombine_ALT_value(std::string separator=", ") const;
+  std::string combine_GT_vector(const genomic_field_type_t& field_type) const;
   std::string to_string(uint64_t offset, const genomic_field_type_t& field_type) const {
     if (field_type.is_int()) {
       return std::to_string(int_value_at(offset));

--- a/src/main/cpp/include/utils/gt_common.h
+++ b/src/main/cpp/include/utils/gt_common.h
@@ -31,8 +31,10 @@
 #define CHECK_MISSING_SAMPLE_GIVEN_REF(REF) (((REF).size() == 0) || ((REF)[0] == '$'))
 #define CHECK_UNINITIALIZED_SAMPLE_GIVEN_REF(REF) ((REF).size() == 0 || ((REF) == ""))
 #define CHECK_IN_THE_MIDDLE_REF(REF) ((REF)[0] == 'N')
+
 extern std::string g_vcf_NON_REF;
 extern std::string g_vcf_SPANNING_DELETION;
+
 inline bool IS_NON_REF_ALLELE(const std::string& allele) {
   return allele.length() > 0 && ((allele)[0] == '&');
 }
@@ -43,6 +45,10 @@ inline bool IS_NON_REF_ALLELE(const char allele_char) {
 
 #define TILEDB_NON_REF_VARIANT_REPRESENTATION "&"
 #define TILEDB_ALT_ALLELE_SEPARATOR "|"
+
+#define PHASED_ALLELE_SEPARATOR '|'
+#define UNPHASED_ALLELE_SEPARATOR '/'
+
 #define MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED 50u
 #define MAX_GENOTYPE_COUNT ((unsigned)INT32_MAX) //this is likely larger than what can be handled by the VCF format
 #define DEFAULT_COMBINED_VCF_RECORDS_BUFFER_SIZE 1048576u

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -355,8 +355,6 @@ void GatherVariantCalls::operate_on_columnar_cell(const GenomicsDBColumnarCell& 
   contig_position++;
   genomic_interval_t genomic_interval(std::move(contig_name),
                                       std::make_pair(contig_position, contig_position+end_position-coords[1]));
-  auto ALT_query_idx = query_config.is_defined_query_idx_for_known_field_enum(GVCF_ALT_IDX)
-      ? query_config.get_query_idx_for_known_field_enum(GVCF_ALT_IDX) : UINT64_MAX;
 
   std::vector<genomic_field_t> genomic_fields;
   // Ignore first field as it is "END"

--- a/src/main/cpp/src/api/genomicsdb_field.cc
+++ b/src/main/cpp/src/api/genomicsdb_field.cc
@@ -1,0 +1,82 @@
+/**
+ * @file genomicsdb_field.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Implementation of GenomicsDB field api methods
+ *
+ **/
+
+#include "genomicsdb.h"
+#include "gt_common.h"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#define NON_REF "<NON_REF>"
+
+std::string genomic_field_t::recombine_ALT_value(std::string separator) const {
+  std::stringstream ss(str_value());
+  std::string output;
+  std::string item;
+  while (std::getline(ss, item, PHASED_ALLELE_SEPARATOR)){
+    if (IS_NON_REF_ALLELE(item)) {
+      output.empty()?output=NON_REF:output=output+separator+NON_REF;
+    } else {
+      output.empty()?output=item:output=output+separator+item;
+    }
+  }
+  return "[" + output + "]";
+}
+
+std::string genomic_field_t::combine_GT_vector(const genomic_field_type_t& field_type) const {
+  assert(field_type.is_int());
+  
+  std::string output;
+  if (field_type.contains_phase_information()) {
+    for (auto i=0ul; i<num_elements; i++) {
+      output = output + (int_value_at(i)==get_bcf_gt_no_call_allele_index<int>()?".":to_string(i, field_type));
+      if (i+1<num_elements) {
+        if (int_value_at(i+1) == 0) {
+          output = output + UNPHASED_ALLELE_SEPARATOR;
+        } else {
+          output = output + PHASED_ALLELE_SEPARATOR;
+        }
+        i++;
+      }
+    }
+  } else {
+    for (auto i=0ul; i<num_elements; i++) {
+      std::string gt_element = to_string(i, field_type);
+      output = output + (int_value_at(i)==get_bcf_gt_no_call_allele_index<int>()?".":to_string(i, field_type));
+      if (i+1<num_elements) {
+        output = output + UNPHASED_ALLELE_SEPARATOR;
+      }
+    }
+  }
+  return output;
+}


### PR DESCRIPTION
This PR addresses some of the comments from #86. And also fixes the issue with genomicsdb_field_t::to_string() not handling missing GT fields correctly.

- Remove some duplicated defines and move other commonly used ones to gt_common.h
- Refactor genomicsdb.h by moving the handling of individual genomic fields to genomicsdb_field.cc so there is no direct dependency on gt_common.h from genomicsdb.h.
- What's implemented in this PR is the specialized handling for GT and ALT when `genomicsdb_field_t::to_string()` is invoked.
- Looking at #59 to handle `FILTER` and `ID`. @kgururaj, @mlathara let me know if any other fields need special handling.

Will address making `genomicsdb_field_type_t` a pointer to `FieldInfo` in another PR. There were some issues(mainly assertions getting thrown) with using that with the `Variant/VariantCall` data structures.
 
