### PR TITLE
Change minimum supported cmake version to 3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 #
 
 project(GenomicsDB)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.4)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
 if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
@@ -93,7 +93,6 @@ include(CheckIncludeFileCXX)
 include(CheckCXXSymbolExists)
 
 if(BUILD_DISTRIBUTABLE_LIBRARY)
-    cmake_minimum_required(VERSION 3.4)
     set(DISABLE_MPI True)
     set(DISABLE_OPENMP True)
     #For the GNU compiler, link in static gcc libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ execute_process(
     )
 
 #Build parameters
-set(GENOMICSDB_RELEASE_VERSION "1.2.3-SNAPSHOT" CACHE STRING "GenomicsDB release version") #used in Maven builds
+set(GENOMICSDB_RELEASE_VERSION "1.3.1-SNAPSHOT" CACHE STRING "GenomicsDB release version") #used in Maven builds
 set(GENOMICSDB_VERSION "${GENOMICSDB_RELEASE_VERSION}-${GIT_COMMIT_HASH}" CACHE STRING "GenomicsDB full version string")
 set(DISABLE_MPI False CACHE BOOL "Disable use of any MPI compiler/libraries")
 set(DISABLE_OPENMP False CACHE BOOL "Disable OpenMP")


### PR DESCRIPTION
Change minimum supported cmake version to 3.4, same as support for BUILD_DISTRIBUTABLE_LIBRARY. This is because of incompatibilities introduced in the newer cmake 3 versions with cmake2 . For example, cmake3 requires `find_package(Protobuf)` instead of `include(FindProtobuf)` in FindProtobufWrapper.cmake. See [GenomicsDB-Install](https://github.com/nalinigans/GenomicsDB-Install/commit/894441b6b0cec107131879c73d14bf6751ff31b3) changes that now uses `cmake3` for building.

Also, move to new htslib to pick up changes with GCS authentication.