### PR TITLE
Cleanup clang warnings and move to new version of dependencies

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,12 @@
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate
+
 coverage:
+  range: 50..100
   status:
     project:
       default:
         target: auto
-        threshold: 0.5%
+        threshold: 1.0%
         branches: null
 
     patch:

--- a/src/main/cpp/include/genomicsdb/genomicsdb_iterators.h
+++ b/src/main/cpp/include/genomicsdb/genomicsdb_iterators.h
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -340,7 +341,6 @@ class SingleCellTileDBIterator {
   //Flag that specifies if this is the first time reading from TileDB
   bool m_first_read_from_TileDB;
   unsigned m_END_query_idx;
-  const VariantArraySchema* m_variant_array_schema;
   const VariantQueryConfig* m_query_config;
   uint64_t m_query_column_interval_idx;
   GenomicsDBColumnarCell* m_cell;

--- a/src/main/cpp/include/genomicsdb/genomicsdb_iterators.h
+++ b/src/main/cpp/include/genomicsdb/genomicsdb_iterators.h
@@ -1,7 +1,6 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016 Intel Corporation
- * Copyright (c) 2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -341,6 +340,7 @@ class SingleCellTileDBIterator {
   //Flag that specifies if this is the first time reading from TileDB
   bool m_first_read_from_TileDB;
   unsigned m_END_query_idx;
+  const VariantArraySchema* m_variant_array_schema;
   const VariantQueryConfig* m_query_config;
   uint64_t m_query_column_interval_idx;
   GenomicsDBColumnarCell* m_cell;

--- a/src/main/cpp/include/genomicsdb/variant_storage_manager.h
+++ b/src/main/cpp/include/genomicsdb/variant_storage_manager.h
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
- * Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -109,7 +109,6 @@ class VariantArrayCellIterator {
   }
  private:
   unsigned m_num_queried_attributes;
-  TileDB_CTX* m_tiledb_ctx;
   const VariantArraySchema* m_variant_array_schema;
   BufferVariantCell m_cell;
   //The actual TileDB array iterator

--- a/src/main/cpp/src/genomicsdb/genomicsdb_iterators.cc
+++ b/src/main/cpp/src/genomicsdb/genomicsdb_iterators.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -43,7 +44,7 @@ SingleCellTileDBIterator::SingleCellTileDBIterator(TileDB_CTX* tiledb_ctx,
     const TileDB_Array* tiledb_array,
     const VidMapper* vid_mapper, const VariantArraySchema& variant_array_schema,
     const std::string& array_path, const VariantQueryConfig& query_config, const size_t buffer_size)
-  : m_variant_array_schema(&variant_array_schema), m_query_config(&query_config),
+  : m_query_config(&query_config),
     m_cell(new GenomicsDBColumnarCell(this)),
     m_tiledb_array(tiledb_array), m_owned_tiledb_array(0),
     m_query_column_interval_idx(0u),

--- a/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
+++ b/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
@@ -64,11 +64,12 @@ VariantArrayCellIterator::VariantArrayCellIterator(TileDB_CTX* tiledb_ctx, const
 						   const std::string& array_path, const int64_t* range,
 						   const std::vector<int>& attribute_ids,
 						   const size_t buffer_size, const std::string& query_filter)
-  : m_num_queried_attributes(attribute_ids.size()), m_tiledb_ctx(tiledb_ctx),
-    m_variant_array_schema(&variant_array_schema), m_cell(variant_array_schema, attribute_ids)
+    : m_num_queried_attributes(attribute_ids.size()),
+      m_variant_array_schema(&variant_array_schema),
+      m_cell(variant_array_schema, attribute_ids)
 #ifdef DO_PROFILING
-  , m_tiledb_timer()
-  , m_tiledb_to_buffer_cell_timer()
+    , m_tiledb_timer()
+    , m_tiledb_to_buffer_cell_timer()
 #endif
 {
   m_buffers.clear();

--- a/src/main/cpp/src/query_operations/broad_combined_gvcf.cc
+++ b/src/main/cpp/src/query_operations/broad_combined_gvcf.cc
@@ -287,7 +287,7 @@ BroadCombinedGVCFOperator::BroadCombinedGVCFOperator(VCFAdapter& vcf_adapter, co
       auto hrec = bcf_hdr_parse_line(m_vcf_hdr, contig_vcf_line.c_str(), &line_length);
       bcf_hdr_add_hrec(m_vcf_hdr, hrec);
       if (bcf_hdr_sync(m_vcf_hdr)) {
-        logger.error("bcf_hdr_sync() failed while {}:{}", "adding missing contig names to template header", __LINE__);
+        logger.fatal(BroadCombinedGVCFException("Possible realloc() failure from bcf_hdr_sync() while adding missing contig names to template header"));
       }
     }
   }
@@ -311,7 +311,7 @@ BroadCombinedGVCFOperator::BroadCombinedGVCFOperator(VCFAdapter& vcf_adapter, co
     }
   }
   if (bcf_hdr_sync(m_vcf_hdr)) {
-    logger.error("bcf_hdr_sync() failed while {}:{}", "adding samples to template header", __LINE__);
+    logger.fatal(BroadCombinedGVCFException("Possible realloc() failure from bcf_hdr_sync() while adding samples to template header"));
   }
   //Map from vid mapper field idx to hdr field idx
   m_global_field_idx_to_hdr_idx.resize(m_vid_mapper->get_num_fields(), -1);

--- a/src/main/cpp/src/query_operations/broad_combined_gvcf.cc
+++ b/src/main/cpp/src/query_operations/broad_combined_gvcf.cc
@@ -286,7 +286,9 @@ BroadCombinedGVCFOperator::BroadCombinedGVCFOperator(VCFAdapter& vcf_adapter, co
       int line_length = 0;
       auto hrec = bcf_hdr_parse_line(m_vcf_hdr, contig_vcf_line.c_str(), &line_length);
       bcf_hdr_add_hrec(m_vcf_hdr, hrec);
-      bcf_hdr_sync(m_vcf_hdr);
+      if (bcf_hdr_sync(m_vcf_hdr)) {
+        logger.error("bcf_hdr_sync() failed while {}:{}", "adding missing contig names to template header", __LINE__);
+      }
     }
   }
   //Get contig info for position 0, store curr contig in next_contig and call switch_contig function to do all the setup
@@ -308,7 +310,9 @@ BroadCombinedGVCFOperator::BroadCombinedGVCFOperator(VCFAdapter& vcf_adapter, co
                                          +callset_name+" to the combined VCF/gVCF header");
     }
   }
-  bcf_hdr_sync(m_vcf_hdr);
+  if (bcf_hdr_sync(m_vcf_hdr)) {
+    logger.error("bcf_hdr_sync() failed while {}:{}", "adding samples to template header", __LINE__);
+  }
   //Map from vid mapper field idx to hdr field idx
   m_global_field_idx_to_hdr_idx.resize(m_vid_mapper->get_num_fields(), -1);
   for (auto i=0u; i<m_vid_mapper->get_num_fields(); ++i) {

--- a/src/main/cpp/src/vcf/vcf2binary.cc
+++ b/src/main/cpp/src/vcf/vcf2binary.cc
@@ -1121,7 +1121,9 @@ void VCF2Binary::write_partition_data(File2TileDBBinaryColumnPartitionBase& part
   //The second parameter is useful if the file handler is open, but the buffer was full in a previous call
   auto has_data = seek_and_fetch_position(partition_info, is_read_buffer_exhausted, m_close_file, false);
   while (has_data) {
-    bcf_write(vcf_partition.m_split_output_fptr, hdr, vcf_reader_ptr->get_line());
+    if (bcf_write(vcf_partition.m_split_output_fptr, hdr, vcf_reader_ptr->get_line())) {
+      logger.fatal(VCF2BinaryException(logger.format("Error writing VCF data for partition at {}", __LINE__)));
+    }
     has_data = seek_and_fetch_position(partition_info, is_read_buffer_exhausted, false, true);
   }
 }

--- a/src/main/cpp/src/vcf/vcf2binary.cc
+++ b/src/main/cpp/src/vcf/vcf2binary.cc
@@ -1122,7 +1122,7 @@ void VCF2Binary::write_partition_data(File2TileDBBinaryColumnPartitionBase& part
   auto has_data = seek_and_fetch_position(partition_info, is_read_buffer_exhausted, m_close_file, false);
   while (has_data) {
     if (bcf_write(vcf_partition.m_split_output_fptr, hdr, vcf_reader_ptr->get_line())) {
-      logger.fatal(VCF2BinaryException(logger.format("Error writing VCF data for partition at {}", __LINE__)));
+      logger.fatal(VCF2BinaryException("Error writing VCF data for partition"));
     }
     has_data = seek_and_fetch_position(partition_info, is_read_buffer_exhausted, false, true);
   }

--- a/src/main/cpp/src/vcf/vcf_adapter.cc
+++ b/src/main/cpp/src/vcf/vcf_adapter.cc
@@ -87,7 +87,7 @@ bool VCFAdapter::add_field_to_hdr_if_missing(bcf_hdr_t* hdr, const VidMapper* id
       description_value = hrec->vals[description_idx];
     bcf_hdr_remove(hdr, field_type_idx, field_name.c_str());
     if (bcf_hdr_sync(hdr)) {
-      logger.error("bcf_hdr_sync() failed while {}:{}", "adding missing field to hdr", __LINE__);
+      logger.fatal(VCFAdapterException("Possible realloc() failure from bcf_hdr_sync() while adding missing field to hdr"));
     }
     field_exists_in_vcf_hdr = false;
     old_field_idx_before_deletion = field_idx;
@@ -186,7 +186,7 @@ bool VCFAdapter::add_field_to_hdr_if_missing(bcf_hdr_t* hdr, const VidMapper* id
     auto hrec = bcf_hdr_parse_line(hdr, header_line.c_str(), &line_length);
     bcf_hdr_add_hrec(hdr, hrec);
     if (bcf_hdr_sync(hdr)) {
-      logger.error("bcf_hdr_sync() failed while {}:{}", "adding missing field to hdr", __LINE__);
+      logger.fatal(VCFAdapterException("Possible realloc() failure from bcf_hdr_sync() while adding missing field to hdr"));
     }
 #ifdef DEBUG
     if (old_field_idx_before_deletion >= 0)
@@ -353,7 +353,7 @@ bcf_hdr_t* VCFAdapter::initialize_default_header() {
   bcf_hdr_append(hdr, "##ALT=<ID=NON_REF,Description=\"Represents any possible alternative allele at this location\">");
   bcf_hdr_append(hdr, "##INFO=<ID=END,Number=1,Type=Integer,Description=\"Stop position of the interval\">");
   if (bcf_hdr_sync(hdr)) {
-    logger.error("bcf_hdr_sync() failed while {}:{}", "initializing default header", __LINE__);
+    logger.fatal(VCFAdapterException("Posssible realloc() failure from bcf_hdr_sync() while initializing default header"));
   }
   return hdr;
 }

--- a/src/main/cpp/src/vcf/vcf_adapter.cc
+++ b/src/main/cpp/src/vcf/vcf_adapter.cc
@@ -86,7 +86,9 @@ bool VCFAdapter::add_field_to_hdr_if_missing(bcf_hdr_t* hdr, const VidMapper* id
     if (description_idx >= 0)
       description_value = hrec->vals[description_idx];
     bcf_hdr_remove(hdr, field_type_idx, field_name.c_str());
-    bcf_hdr_sync(hdr);
+    if (bcf_hdr_sync(hdr)) {
+      logger.error("bcf_hdr_sync() failed while {}:{}", "adding missing field to hdr", __LINE__);
+    }
     field_exists_in_vcf_hdr = false;
     old_field_idx_before_deletion = field_idx;
   }
@@ -183,7 +185,9 @@ bool VCFAdapter::add_field_to_hdr_if_missing(bcf_hdr_t* hdr, const VidMapper* id
     int line_length = 0;
     auto hrec = bcf_hdr_parse_line(hdr, header_line.c_str(), &line_length);
     bcf_hdr_add_hrec(hdr, hrec);
-    bcf_hdr_sync(hdr);
+    if (bcf_hdr_sync(hdr)) {
+      logger.error("bcf_hdr_sync() failed while {}:{}", "adding missing field to hdr", __LINE__);
+    }
 #ifdef DEBUG
     if (old_field_idx_before_deletion >= 0)
       assert(bcf_hdr_id2int(hdr, BCF_DT_ID, field_name.c_str()) == old_field_idx_before_deletion);
@@ -348,20 +352,23 @@ bcf_hdr_t* VCFAdapter::initialize_default_header() {
   auto hdr = bcf_hdr_init("w");
   bcf_hdr_append(hdr, "##ALT=<ID=NON_REF,Description=\"Represents any possible alternative allele at this location\">");
   bcf_hdr_append(hdr, "##INFO=<ID=END,Number=1,Type=Integer,Description=\"Stop position of the interval\">");
-  bcf_hdr_sync(hdr);
+  if (bcf_hdr_sync(hdr)) {
+    logger.error("bcf_hdr_sync() failed while {}:{}", "initializing default header", __LINE__);
+  }
   return hdr;
 }
 
 void VCFAdapter::print_header() {
-  bcf_hdr_write(m_output_fptr, m_template_vcf_hdr);
+  if (bcf_hdr_write(m_output_fptr, m_template_vcf_hdr)) {
+    logger.fatal(VCFAdapterException("bcf_hdr_write() failed while printing header"));
+  }
 }
 
 void VCFAdapter::handoff_output_bcf_line(bcf1_t*& line, const size_t bcf_record_size) {
-  auto write_status = bcf_write(m_output_fptr, m_template_vcf_hdr, line);
-  if (write_status != 0)
-    throw VCFAdapterException(std::string("Failed to write VCF/BCF record at position ")
-                              +bcf_hdr_id2name(m_template_vcf_hdr, line->rid)+", "
-                              +std::to_string(line->pos+1));
+  if (bcf_write(m_output_fptr, m_template_vcf_hdr, line)) {
+    logger.fatal(VCFAdapterException(logger.format("Failed to write VCF/BCF record at position {}, {}",
+                                                   bcf_hdr_id2name(m_template_vcf_hdr, line->rid), line->pos+1)));
+  }
 }
 
 BufferedVCFAdapter::BufferedVCFAdapter(unsigned num_circular_buffers, unsigned max_num_entries)


### PR DESCRIPTION
Checking for `bcf_hdr_sync()` return values to silence clang, just logging the errors for now. Should we throw an exception here?