### PR TITLE
Fix issues with propagating polymorphic std::exception code

### DIFF
--- a/src/main/cpp/include/utils/logger.h
+++ b/src/main/cpp/include/utils/logger.h
@@ -38,9 +38,12 @@
 #include <spdlog/fmt/fmt.h>
 
 #include <exception>
+#include <execinfo.h>
 #include <list>
 #include <mutex>
 #include <sstream>
+
+#include <dlfcn.h>
 
 class Logger {
  public:
@@ -61,32 +64,59 @@ class Logger {
   void info(const char* fmt, const Args &... args) {
     m_logger->info(fmt, args...);
   }
+
   template<typename... Args>
   void debug(const char* fmt, const Args &... args) {
     m_logger->debug(fmt, args...);
   }
+
   template<typename... Args>
   void debug_only(const char* fmt, const Args &... args) {
 #ifdef DEBUG
     m_logger->debug(fmt, args...);
 #endif
   }
+
   template<typename... Args>
   void warn(const char* fmt, const Args &... args) {
     m_logger->warn(fmt, args...);
   }
+
   template<typename... Args>
   void error(const char* fmt, const Args &... args) {
     m_logger->error(fmt, args...);
   }
-  template<typename... Args>
-  void fatal(const std::exception& exception, const char* fmt, const Args &... args) {
+
+#define BACKTRACE_LENGTH 10
+  void print_backtrace() {
+    void *buffer[BACKTRACE_LENGTH];
+    int nptrs = backtrace(buffer, BACKTRACE_LENGTH);
+    char **strings = backtrace_symbols(buffer, nptrs);
+    m_logger->error("Native Stack Trace:");
+    for (auto i = 1; i < nptrs; i++) {
+        Dl_info info;
+        if (dladdr(buffer[i], &info) && info.dli_sname) {
+          m_string_logger->error(std::string("\t")+strings[i]);
+        } else {
+          break;
+        }
+    }
+    free(strings);
+  }
+
+  template<typename T, typename... Args>
+  void fatal(const T& exception, const char* fmt, const Args &... args) {
+    static_assert(std::is_base_of<std::exception, T>::value, "Template class to fatal() must derive from std::exception");
     m_logger->error(fmt, args...);
+    print_backtrace();
     throw exception;
   }
 
-  void fatal(const std::exception& exception) {
+  template<typename T>
+  void fatal(const T& exception) {
+    static_assert(std::is_base_of<std::exception, T>::value, "Template class to fatal() must derive from std::exception");
     m_logger->error(exception.what());
+    print_backtrace();
     throw exception;
   }
 
@@ -96,6 +126,7 @@ class Logger {
       m_logger->info(fmt, args...);
     }
   }
+
   template<typename... Args>
   void warn_once(const char* fmt, const Args &... args) {
     if (not_been_logged(format(fmt, args...))) {

--- a/src/main/cpp/include/utils/logger.h
+++ b/src/main/cpp/include/utils/logger.h
@@ -43,7 +43,7 @@
 #include <mutex>
 #include <sstream>
 
-//TODO: Forward declaration from TileDB/utils.h for now.
+//TODO: Prototype from TileDB/utils.h for now.
 bool is_env_set(const std::string& name);
 
 class Logger {

--- a/src/main/jni/src/genomicsdb_GenomicsDBImporter.cc
+++ b/src/main/jni/src/genomicsdb_GenomicsDBImporter.cc
@@ -268,14 +268,8 @@ Java_org_genomicsdb_importer_GenomicsDBImporterJni_jniCopyVidMap
   VidMappingPB vidmap;
   jbyte *vidmap_elements = env->GetByteArrayElements(vidmap_as_bytearray, 0);
   int vidmap_length = env->GetArrayLength(vidmap_as_bytearray);
-  try {
-    vidmap.ParseFromArray(
-      reinterpret_cast<jbyte*>(vidmap_elements), vidmap_length);
-  } catch (std::exception e) {
-    std::cerr << "Parsing error of vid maps. " <<
-        "Please check VCF merged headers\n";
-    throw e;
-  }
+  vidmap.ParseFromArray(
+        reinterpret_cast<jbyte*>(vidmap_elements), vidmap_length);
 
   //Cleanup
   env->ReleaseByteArrayElements(
@@ -302,16 +296,10 @@ Java_org_genomicsdb_importer_GenomicsDBImporterJni_jniCopyCallsetMap
   jbyte *callsetmap_elements =
       env->GetByteArrayElements(callsetmap_as_bytearray, 0);
   int callsetmap_length = env->GetArrayLength(callsetmap_as_bytearray);
-  try {
-    callsetmap.ParseFromArray(
+  callsetmap.ParseFromArray(
         reinterpret_cast<jbyte*>(callsetmap_elements),
         callsetmap_length);
-  } catch (std::exception e) {
-    std::cerr << "Parsing error of callset maps. " <<
-        "Please check VCF merged headers\n";
-    throw e;
-  }
-
+  
   //Cleanup
   env->ReleaseByteArrayElements(
         callsetmap_as_bytearray,

--- a/src/test/cpp/src/test_logger.cc
+++ b/src/test/cpp/src/test_logger.cc
@@ -81,8 +81,8 @@ TEST_CASE("test logger format", "[test_logger_format]") {
   CHECK(logger.format(TEST_STR_FMT, 0, TEST_STR).find(TEST_STR) != std::string::npos);
 
   GenomicsDBException exception("Test Exception");
-  CHECK_THROWS_AS(logger.fatal(exception, TEST_STR_FMT, 1, TEST_STR), std::exception);
-  CHECK_THROWS_AS(logger.fatal(exception), std::exception);
+  CHECK_THROWS_AS(logger.fatal(exception, TEST_STR_FMT, 1, TEST_STR), GenomicsDBException);
+  CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
 }
 
 #define CHECK_LOGGER(X, Y)                      \

--- a/src/test/cpp/src/test_logger.cc
+++ b/src/test/cpp/src/test_logger.cc
@@ -36,6 +36,7 @@
 #include "genomicsdb_exception.h"
 
 #include <iostream>
+#include <stdlib.h>
 #include <string>
 #include <sstream>
 #include <streambuf>
@@ -83,6 +84,13 @@ TEST_CASE("test logger format", "[test_logger_format]") {
   GenomicsDBException exception("Test Exception");
   CHECK_THROWS_AS(logger.fatal(exception, TEST_STR_FMT, 1, TEST_STR), GenomicsDBException);
   CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
+  REQUIRE(setenv("GENOMICSDB_STACK_TRACE", "0", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
+  REQUIRE(setenv("GENOMICSDB_STACK_TRACE", "1", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
+  REQUIRE(setenv("GENOMICSDB_STACK_TRACE", "true", 1) == 0);
+  CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
+  CHECK(unsetenv("GENOMICSDB_STACK_TRACE") == 0);
 }
 
 #define CHECK_LOGGER(X, Y)                      \

--- a/src/test/cpp/src/test_logger.cc
+++ b/src/test/cpp/src/test_logger.cc
@@ -84,13 +84,13 @@ TEST_CASE("test logger format", "[test_logger_format]") {
   GenomicsDBException exception("Test Exception");
   CHECK_THROWS_AS(logger.fatal(exception, TEST_STR_FMT, 1, TEST_STR), GenomicsDBException);
   CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
-  REQUIRE(setenv("GENOMICSDB_STACK_TRACE", "0", 1) == 0);
+  REQUIRE(setenv("GENOMICSDB_PRINT_STACKTRACE", "0", 1) == 0);
   CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
-  REQUIRE(setenv("GENOMICSDB_STACK_TRACE", "1", 1) == 0);
+  REQUIRE(setenv("GENOMICSDB_PRINT_STACKTRACE", "1", 1) == 0);
   CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
-  REQUIRE(setenv("GENOMICSDB_STACK_TRACE", "true", 1) == 0);
+  REQUIRE(setenv("GENOMICSDB_PRINT_STACKTRACE", "true", 1) == 0);
   CHECK_THROWS_AS(logger.fatal(exception), GenomicsDBException);
-  CHECK(unsetenv("GENOMICSDB_STACK_TRACE") == 0);
+  CHECK(unsetenv("GENOMICSDB_PRINT_STACKTRACE") == 0);
 }
 
 #define CHECK_LOGGER(X, Y)                      \

--- a/src/test/cpp/src/test_logger.cc
+++ b/src/test/cpp/src/test_logger.cc
@@ -146,3 +146,4 @@ TEST_CASE("test explicit logger", "[test_logger_explicit]") {
   with_string_logger.info(test_str, true);
   CHECK(oss.str() == "");
 }
+


### PR DESCRIPTION
* Change `logger.fatal` to be a template for the std::exception argument as the polymorphic context is lost in subsequent re-throws of std::exception.
* Introduced env variable `GENOMICSDB_PRINT_STACKTRACE` to print a stack trace especially from JNI or other language bindings where the exceptions are caught and propagated into the Java layer as graceful Java Exceptions.
* Also removed code catching ParseFromArray exceptions from [here]( https://github.com/GenomicsDB/GenomicsDB/blob/e701905e0bb54765e22119a71038c0e64c85b9c3/src/main/jni/src/genomicsdb_GenomicsDBImporter.cc#L272) as it suffers from the same polymorphic issue as logger.fatal() and it does not throw exceptions, just returned a Boolean status. These exceptions at some point will have to be rethrown as java exceptions for a more graceful handling - to be done later at some point