### PR TITLE
Add test for GenomicsDB api protobuf bytes support

### DIFF
--- a/src/main/cpp/include/config/variant_query_config.h
+++ b/src/main/cpp/include/config/variant_query_config.h
@@ -344,6 +344,14 @@ class VariantQueryConfig : public GenomicsDBConfigBase {
    */
   void read_from_JSON_string(const std::string& str, const int rank=0);
   /*
+   * Read configuration from protobuf based export configuration
+   */
+  void read_from_PB(const genomicsdb_pb::ExportConfiguration* export_config, const int rank=0);
+  /*
+   * Read configuration from bytes that can be parsed by protobuf's export configuration
+   */
+  void read_from_PB_binary_string(const std::string& str, const int rank=0);
+  /*
    * Validates and intializes variant query configuration. GenomicsDBConfigException is thrown on failed checks.
    */
   void validate(const int rank=0);

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -286,8 +286,6 @@ GenomicsDBVariantCalls GenomicsDB::query_variant_calls() {
 GenomicsDBVariantCalls GenomicsDB::query_variant_calls(GenomicsDBVariantCallProcessor& processor) {
   VariantQueryConfig* query_config = TO_VARIANT_QUERY_CONFIG(m_query_config);
   const std::string& array = query_config->get_array_name(m_concurrency_rank);
-  genomicsdb_ranges_t column_ranges = query_config->get_query_column_ranges(m_concurrency_rank);
-  genomicsdb_ranges_t row_ranges = query_config->get_query_row_ranges(m_concurrency_rank);
   return GenomicsDBVariantCalls(TO_GENOMICSDB_VARIANT_CALL_VECTOR(query_variant_calls(array, query_config, processor)),
                                 create_genomic_field_types(*query_config));
 }

--- a/src/main/cpp/src/config/variant_query_config.cc
+++ b/src/main/cpp/src/config/variant_query_config.cc
@@ -211,6 +211,16 @@ void VariantQueryConfig::read_from_JSON_string(const std::string& str, const int
   validate(rank);
 }
 
+void VariantQueryConfig::read_from_PB(const genomicsdb_pb::ExportConfiguration* export_config, const int rank) {
+  GenomicsDBConfigBase::read_from_PB(export_config, rank);
+  validate(rank);
+}
+
+void VariantQueryConfig::read_from_PB_binary_string(const std::string& str, const int rank) {
+  GenomicsDBConfigBase::read_from_PB_binary_string(str, rank);
+  validate(rank);
+}
+
 void VariantQueryConfig::validate(const int rank) {
   //Workspace
   VERIFY_OR_THROW(m_workspaces.size() && "No workspace specified");

--- a/src/main/cpp/src/vcf/genomicsdb_bcf_generator.cc
+++ b/src/main/cpp/src/vcf/genomicsdb_bcf_generator.cc
@@ -48,7 +48,6 @@ GenomicsDBBCFGenerator::GenomicsDBBCFGenerator(const std::string& loader_config_
   }
   //Parse query protobuf - ensures that vid, callset may be obtained from loader (if exists)
   m_query_config.read_from_PB(query_config_pb, my_rank);
-  m_query_config.validate();
   if (!(loader_config_file.empty()))
     m_query_config.subset_query_column_ranges_based_on_partition(loader_config, my_rank);
   m_query_config.set_vcf_output_format(output_format);


### PR DESCRIPTION
Note that while adding a unit test for GenomicsDB api with protobuf bytes, `read_from_PB...` has been added to VariantQueryConfig for the config to get validated similar to `read_from_file` and `read_from_JSON_string`. 