### PR TITLE
Move to Hadoop 2.9.2 for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: required
-dist: trusty
 
 language: python
-python: "3.4"
+python: "3.6"
 
 env:
     global:
@@ -20,6 +19,7 @@ matrix:
     include:
       - name: "Basic build Linux"
         os: linux
+        dist: trusty
         env: INSTALL_TYPE=basic
         services: postgres
         cache:
@@ -51,6 +51,7 @@ matrix:
 
       - name: "Spark/HDFS Linux"
         os: linux
+        dist: trusty
         env: INSTALL_TYPE=hdfs
         services: postgres
         cache:

--- a/.travis/resources/hadoop/hadoop-env.sh
+++ b/.travis/resources/hadoop/hadoop-env.sh
@@ -22,7 +22,7 @@
 # remote nodes.
 
 # The java implementation to use.
-export JAVA_HOME=${JAVA_HOME:-"/usr/latest/java"}
+export JAVA_HOME=${JAVA_HOME:-"/usr/java/latest"}
 
 # The jsvc implementation to use. Jsvc is required to run secure datanodes
 # that bind to privileged ports to provide authentication of data transfer

--- a/.travis/scripts/install_hadoop.sh
+++ b/.travis/scripts/install_hadoop.sh
@@ -6,7 +6,7 @@
 INSTALL_DIR=${INSTALL_DIR:-/usr}
 USER=`whoami`
 
-HADOOP=hadoop-${HADOOP_VER:-2.7.7}
+HADOOP=hadoop-${HADOOP_VER:-2.9.2}
 HADOOP_DIR=${INSTALL_DIR}/$HADOOP
 
 install_prereqs() {
@@ -63,6 +63,7 @@ setup_paths() {
 }
 
 install_hadoop() {
+  echo "Installing Hadoop..."
   install_prereqs &&
   download_hadoop &&
   configure_hadoop &&

--- a/.travis/scripts/install_hadoop.sh
+++ b/.travis/scripts/install_hadoop.sh
@@ -30,8 +30,10 @@ download_gcs_connector() {
 }
 
 download_hadoop() {
-  wget -nv --trust-server-names "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/$HADOOP/$HADOOP.tar.gz" &&
-  sudo tar -xzf $HADOOP.tar.gz --directory $INSTALL_DIR &&
+  if [[ ! -f $CACHE_DIR/$HADOOP.tar.gz ]]; then
+    wget -nv --trust-server-names "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/$HADOOP/$HADOOP.tar.gz" -O $CACHE_DIR/$HADOOP.tar.gz
+  fi
+  sudo tar -xzf $CACHE_DIR/$HADOOP.tar.gz --directory $INSTALL_DIR &&
   sudo chown -R $USER:$USER $HADOOP_DIR &&
   download_gcs_connector &&
   echo "download_hadoop successful" 

--- a/.travis/scripts/install_spark.sh
+++ b/.travis/scripts/install_spark.sh
@@ -32,8 +32,10 @@ retry() {
 }
 
 download_spark() {
-  retry wget -nv --trust-server-names "https://archive.apache.org/dist/spark/spark-$SPARK_VER/$SPARK.tgz"
-  sudo tar -zxf $SPARK.tgz --directory $INSTALL_DIR &&
+  if [[ ! -f $CACHE_DIR/$SPARK.tgz ]]; then
+    retry wget -nv --trust-server-names "https://archive.apache.org/dist/spark/spark-$SPARK_VER/$SPARK.tgz" -O $CACHE_DIR/$SPARK.tgz
+  fi
+  sudo tar -zxf $CACHE_DIR/$SPARK.tgz --directory $INSTALL_DIR &&
   sudo chown -R $USER:$USER $SPARK_DIR &&
   sudo ln -s $INSTALL_DIR/$SPARK $SPARK_LOCAL_DIR &&
   get_gcs_connector &&

--- a/.travis/scripts/install_spark.sh
+++ b/.travis/scripts/install_spark.sh
@@ -60,6 +60,7 @@ configure_spark() {
 }
 
 install_spark() {
+  echo "Installing Spark..."
   download_spark &&
   configure_spark &&
   echo "Install Spark successful"


### PR DESCRIPTION
Hadoop 2.7.7 is no longer generally available, so move to 2.9.2 for now as a first stop. We will eventually have to move to Hadoop 3.x, but need to be sure that spark operates fine first.