### PR TITLE
GitHub Actions to build and test GenomicsDB

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,0 +1,83 @@
+name: Basic workflow to build and test GenomicsDB
+
+on: [push, pull_request]
+
+env:
+  PREREQS_ENV: ${{github.workspace}}/prereqs.sh
+  PREREQS_INSTALL_DIR: ${{github.workspace}}/prereqs
+  CMAKE_BUILD_TYPE: Coverage
+  CMAKE_INSTALL_PREFIX: release
+  GENOMICSDB_BUILD_DIR: ${{github.workspace}}/build
+  GENOMICSDB_RELEASE_VERSION: x.y.z.test
+
+jobs:
+  ci_job:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Cache built prerequisite artifacts like protobuf
+      uses: actions/cache@v2
+      with:
+        path: ${{env.PREREQS_INSTALL_DIR}}
+        key: ${{matrix.os}}-cache-prereqs-v1
+
+    - name: Cache Maven artifacts
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{matrix.os}}-cache-m2-v1
+
+    # TODO: See https://github.com/actions/cache/pull/285 using platform-indepenedent "pip cache dir"
+    - name: Cache Python artifacts for Ubuntu 
+      uses: actions/cache@v2
+      if: startsWith(matrix.os, 'ubuntu')
+      with:
+        path: ~/.cache/pip
+        key: ${{matrix.os}}-pip-${{matrix.python-version}}-v1
+
+    - name: Cache Python artifacts for MacOS
+      uses: actions/cache@v2
+      if: startsWith(matrix.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{matrix.os}}-pip-${{matrix.python-version}}-v1
+
+    - name: Install Prerequisites
+      shell: bash
+      working-directory: ${{github.workspace}}/scripts/prereqs
+      run: sudo INSTALL_PREFIX=$PREREQS_INSTALL_DIR PREREQS_ENV=$PREREQS_ENV ./install_prereqs.sh
+
+    - name: Create Build Directory
+      shell: bash
+      run: mkdir -p $GENOMICSDB_BUILD_DIR
+
+    - name: Configure CMake Build
+      shell: bash
+      working-directory: ${{env.GENOMICSDB_BUILD_DIR}}
+      run: |
+        source $PREREQS_ENV
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX -DCMAKE_PREFIX_PATH=$PREREQS_INSTALL_DIR -DBUILD_JAVA=1
+
+    - name: Build and Test
+      working-directory: ${{env.GENOMICSDB_BUILD_DIR}}
+      shell: bash
+      run: |
+        source $PREREQS_ENV
+        make -j4
+        make install
+        python -m pip install --upgrade pip
+        python -m pip install jsondiff
+        make test ARGS=-V
+
+    - name: Upload Coverage to CodeCov
+      uses: codecov/codecov-action@v1

--- a/scripts/prereqs/install_prereqs.sh
+++ b/scripts/prereqs/install_prereqs.sh
@@ -25,7 +25,7 @@ set -e
 
 # Check for the following overriding env variables
 #    $INSTALL_PREFIX allows for dependencies maven/protobuf/etc. that are built to be installed to $INSTALL_PREFIX for user installs
-#    $PRERES_ENV will set up file that can be sourced to set up the ENV for building GenomicsDB
+#    $PREREQS_ENV will set up file that can be sourced to set up the ENV for building GenomicsDB
 if [[ `uname` == "Darwin" || `id -u` -ne 0 ]]; then
   INSTALL_PREFIX=${INSTALL_PREFIX:-$HOME/genomicsdb}
   MAVEN_INSTALL_PREFIX=INSTALL_PREFIX
@@ -35,11 +35,13 @@ if [[ `uname` == "Darwin" || `id -u` -ne 0 ]]; then
   echo "Sleeping for 10 seconds. Ctrl-C if you want to change or setup \$INSTALL_PREFIX or \$PREREQS_ENV"
   sleep 10
 else
-  INSTALL_PREFIX=/usr/local
+  INSTALL_PREFIX=${INSTALL_PREFIX:-/usr/local}
   MAVEN_INSTALL_PREFIX=/opt
   PREREQS_ENV=${PREREQS_ENV:-/etc/profile.d/genomicsdb_prereqs.sh}
 fi
 if [ -f $PREREQS_ENV ]; then
+  echo "Found PREREQS_ENV=$PREREQS_ENV from a previous run"
+  source $PREREQS_ENV
   rm -f $PREREQS_ENV
 fi
 touch $PREREQS_ENV
@@ -76,49 +78,49 @@ add_to_env() {
 }
 
 install_mvn() {
-	MVN=`which mvn`
-	if [ -z $MVN ]; then
-		if [ ! -d $MAVEN_INSTALL_PREFIX/apache-maven-$MAVEN_VERSION ]; then
+  MVN=`which mvn`
+  if [ -z $MVN ]; then
+    if [ ! -d $MAVEN_INSTALL_PREFIX/apache-maven-$MAVEN_VERSION ]; then
       echo "Installing Maven"
-			wget -nv https://www-us.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -P /tmp &&
-			  tar xf /tmp/apache-maven-*.tar.gz -C $MAVEN_INSTALL_PREFIX &&
-			  rm /tmp/apache-maven-*.tar.gz
+      wget -nv https://www-us.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -P /tmp &&
+        tar xf /tmp/apache-maven-*.tar.gz -C $MAVEN_INSTALL_PREFIX &&
+        rm /tmp/apache-maven-*.tar.gz
       echo "Installing Maven DONE"
-		fi
+    fi
     rm -f $MAVEN_INSTALL_PREFIX/maven
-		ln -s $MAVEN_INSTALL_PREFIX/apache-maven-$MAVEN_VERSION $MAVEN_INSTALL_PREFIX/maven &&
-		  MVN=$MAVEN_INSTALL_PREFIX/maven/bin/mvn &&
-		  test -f $MVN
-	fi
-	MVN_BIN_DIR=`dirname ${MVN}`
-	M2_HOME=`dirname ${MVN_BIN_DIR}`
-	test -d $M2_HOME  &&
+    ln -s $MAVEN_INSTALL_PREFIX/apache-maven-$MAVEN_VERSION $MAVEN_INSTALL_PREFIX/maven &&
+      MVN=$MAVEN_INSTALL_PREFIX/maven/bin/mvn &&
+      test -f $MVN
+  fi
+  MVN_BIN_DIR=`dirname ${MVN}`
+  M2_HOME=`dirname ${MVN_BIN_DIR}`
+  test -d $M2_HOME  &&
     add_to_env M2_HOME $M2_HOME &&
     add_to_env PATH "\${M2_HOME}/bin"
 }
 
 PROTOBUF_PREFIX=$INSTALL_PREFIX
 install_protobuf() {
-	if [ ! -f $PROTOBUF_PREFIX/bin/protoc ]; then 
-	  echo "Installing Protobuf"
-	  pushd /tmp
-	  if [[ $BUILD_DISTRIBUTABLE_LIBRARY == true ]]; then
-		  wget -nv https://github.com/protocolbuffers/protobuf/releases/download/v3.0.0-beta-1/protobuf-cpp-3.0.0-beta-1.zip &&
-			  unzip protobuf-cpp-3.0.0-beta-1.zip &&
-			  cp $PARENT_DIR/protobuf-v3.0.0-beta-1.autogen.sh.patch protobuf-3.0.0-beta-1/autogen.sh &&
-			  mv protobuf-3.0.0-beta-1 protobuf
-	  else
-		  git clone -b 3.0.x https://github.com/google/protobuf.git
-	  fi
-	  pushd protobuf &&
-		  ./autogen.sh &&
-		  ./configure --prefix=$INSTALL_PREFIX --with-pic &&
-		  make -j4 && make install &&
- 	    echo "Installing Protobuf DONE"
-	  popd
-	  rm -fr /tmp/protobuf*
-	  popd
-	fi
+  if [ ! -f $PROTOBUF_PREFIX/bin/protoc ]; then 
+    echo "Installing Protobuf"
+    pushd /tmp
+    if [[ $BUILD_DISTRIBUTABLE_LIBRARY == true ]]; then
+      wget -nv https://github.com/protocolbuffers/protobuf/releases/download/v3.0.0-beta-1/protobuf-cpp-3.0.0-beta-1.zip &&
+        unzip protobuf-cpp-3.0.0-beta-1.zip &&
+        cp $PARENT_DIR/protobuf-v3.0.0-beta-1.autogen.sh.patch protobuf-3.0.0-beta-1/autogen.sh &&
+        mv protobuf-3.0.0-beta-1 protobuf
+    else
+      git clone -b 3.0.x https://github.com/google/protobuf.git
+    fi
+    pushd protobuf &&
+      ./autogen.sh &&
+      ./configure --prefix=$INSTALL_PREFIX --with-pic &&
+      make -j4 && make install &&
+        echo "Installing Protobuf DONE"
+    popd
+    rm -fr /tmp/protobuf*
+    popd
+  fi
   add_to_env PATH $PROTOBUF_PREFIX/bin &&
     add_to_env LD_LIBRARY_PATH  $PROTOBUF_PREFIX/lib
 }
@@ -127,14 +129,14 @@ OPENSSL_PREFIX=$INSTALL_PREFIX/ssl
 install_openssl() {
   if [[ ! -d $OPENSSL_PREFIX ]]; then
     echo "Installing OpenSSL"
-	  pushd /tmp
+    pushd /tmp
     wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
-	    tar -xvzf openssl-$OPENSSL_VERSION.tar.gz &&
+      tar -xvzf openssl-$OPENSSL_VERSION.tar.gz &&
       cd openssl-$OPENSSL_VERSION &&
-      if [[ `uname` == "Linux" ]]; then CFLAGS=-fPIC ./config -fPIC -shared --prefix=$OPENSSL_PREFIX; else 	./Configure darwin64-x86_64-cc shared -fPIC --prefix=$OPENSSL_PREFIX; fi &&
+      if [[ `uname` == "Linux" ]]; then CFLAGS=-fPIC ./config -fPIC -shared --prefix=$OPENSSL_PREFIX; else    ./Configure darwin64-x86_64-cc shared -fPIC --prefix=$OPENSSL_PREFIX; fi &&
       make && make install && echo "Installing OpenSSL DONE"
-	  rm -fr /tmp/openssl*
-	  popd
+    rm -fr /tmp/openssl*
+    popd
   fi
   add_to_env OPENSSL_ROOT_DIR $OPENSSL_PREFIX
   add_to_env LD_LIBRARY_PATH $OPENSSL_PREFIX/lib
@@ -147,10 +149,10 @@ install_curl() {
     return 0
   fi
   if [[ ! -f $CURL_PREFIX/libcurl.so ]]; then
-	  echo "Installing CURL"
-	  pushd /tmp
+    echo "Installing CURL"
+    pushd /tmp
     git clone https://github.com/curl/curl.git &&
-	    cd curl &&
+      cd curl &&
       autoreconf -i &&
       ./configure --enable-lib-only --with-pic  --with-ssl=$OPENSSL_PREFIX --prefix $CURL_PREFIX &&
       make && make install && echo "Installing CURL DONE"
@@ -167,9 +169,9 @@ install_uuid() {
     return 0
   fi
   if [[ ! -f $UUID_PREFIX/libuuid.a ]]; then
-	  echo "Installing libuuid"
-	  pushd /tmp
-	  wget https://sourceforge.net/projects/libuuid/files/libuuid-1.0.3.tar.gz &&
+    echo "Installing libuuid"
+    pushd /tmp
+    wget https://sourceforge.net/projects/libuuid/files/libuuid-1.0.3.tar.gz &&
       tar -xvzf libuuid-1.0.3.tar.gz &&
       cd libuuid-1.0.3 &&
       sed -i s/2.69/2.63/ configure.ac &&
@@ -178,7 +180,7 @@ install_uuid() {
       ./configure --with-pic CFLAGS="-I/usr/include/x86_64-linux-gnu" --disable-shared --enable-static --prefix $UUID_PREFIX &&
       autoreconf -i -f &&
       make && make install && echo "Installing libuuid DONE"
-	  rm -fr /tmp/libuuid*
+    rm -fr /tmp/libuuid*
     popd
   fi
   add_to_env LD_LIBRARY_PATH $UUID_PREFIX/lib
@@ -193,41 +195,39 @@ centos_version() {
     fi
   fi
   if grep -q "release 6" $CENTOS_RELEASE_FILE; then
-		CENTOS_VERSION=6
-	elif grep -q "release 7" $CENTOS_RELEASE_FILE; then
-		CENTOS_VERSION=7
-	elif grep -q "release 8" $CENTOS_RELEASE_FILE; then
-		CENTOS_VERSION=8
-	fi
-}
-
-apt_get_install() {
-	apt-get --version && source system/install_ubuntu_prereqs.sh && install_prerequisites_ubuntu
-}
-
-yum_install() {
-	source system/install_centos_prereqs.sh && install_prerequisites_centos
+    CENTOS_VERSION=6
+  elif grep -q "release 7" $CENTOS_RELEASE_FILE; then
+    CENTOS_VERSION=7
+  elif grep -q "release 8" $CENTOS_RELEASE_FILE; then
+    CENTOS_VERSION=8
+  fi
 }
 
 install_os_prerequisites() {
-	case `uname` in
-		Linux )
-			apt_get_install || yum_install
-			;;
-		Darwin )
+  case `uname` in
+    Linux )
+      if apt-get --version >/dev/null 2>&1; then
+        source system/install_ubuntu_prereqs.sh
+      else
+        source system/install_centos_prereqs.sh
+      fi
+      install_system_prerequisites
+      ;;
+    Darwin )
       system/install_macos_prereqs.sh
       ;;
     * )
-			echo "OS=`uname` not supported"
-			exit 1
-	esac
+      echo "OS=`uname` not supported"
+      exit 1
+  esac
 }
 
 install_prerequisites() {
-	install_os_prerequisites &&
-	  source $PREREQS_ENV &&
-	  install_mvn &&
-	  install_protobuf
+  echo "1 PREREQS_ENV=$PREREQS_ENV"
+  install_os_prerequisites &&
+    source $PREREQS_ENV &&
+    install_mvn &&
+    install_protobuf
 }
 
 finalize() {
@@ -244,16 +244,16 @@ finalize() {
 
 centos_version
 if [[ $BUILD_DISTRIBUTABLE_LIBRARY == false && $CENTOS_VERSION -eq 6 ]]; then
-	echo "Centos 6 is supported only when build-arg distributable_jar=true"
-	exit 1
+  echo "Centos 6 is supported only when build-arg distributable_jar=true"
+  exit 1
 fi
 
 RC=1
 install_prerequisites $2 &&
   if [[ $BUILD_DISTRIBUTABLE_LIBRARY == true ]]; then
-	  echo "Installing static libraries"
-	  install_openssl &&
-	    install_curl &&
-	    install_uuid
+    echo "Installing static libraries"
+    install_openssl &&
+      install_curl &&
+      install_uuid
   fi && RC=0
 finalize $RC

--- a/scripts/prereqs/system/install_centos_prereqs.sh
+++ b/scripts/prereqs/system/install_centos_prereqs.sh
@@ -70,7 +70,7 @@ install_test_prerequisites() {
   fi
 }
 
-install_prerequisites_centos() {
+install_system_prerequisites() {
 	yum update -y -q &&
 	  yum install -y sudo &&
 	  yum install -y -q which wget git make &&

--- a/scripts/prereqs/system/install_ubuntu_prereqs.sh
+++ b/scripts/prereqs/system/install_ubuntu_prereqs.sh
@@ -23,23 +23,64 @@
 
 set -e
 
-install_openjdk8() {
-	apt-get -y install openjdk-8-jdk icedtea-plugin &&
-		apt-get update -q &&
-		pushd $HOME &&
-		git clone https://github.com/michaelklishin/jdk_switcher.git &&
-		source jdk_switcher/jdk_switcher.sh && jdk_switcher use openjdk8 &&
-		echo "export JAVA_HOME=$JAVA_HOME" >> $PREREQS_ENV &&
-		popd
+install_jdk8() {
+  if type -p javac; then
+    JAVAC=java
+  elif [[ -n $JAVA_HOME ]] && [[ -x $JAVA_HOME/bin/javac ]];  then
+    JAVAC="$JAVA_HOME/bin/java"
+  fi
+  if [[ ! -z $JAVAC ]]; then
+    JDK_VERSION=$($JAVAC -version 2>&1 | awk '/version/{print $2}')
+  fi
+	if [[ -z $JDK_VERSION || $JDK_VERSION < "1.8" ]]; then 
+	  apt-get -y install openjdk-8-jdk icedtea-plugin &&
+		  apt-get update -q &&
+		  pushd $HOME &&
+		  git clone https://github.com/michaelklishin/jdk_switcher.git &&
+		  source jdk_switcher/jdk_switcher.sh && jdk_switcher use openjdk8 &&
+		  echo "export JAVA_HOME=$JAVA_HOME" >> $PREREQS_ENV &&
+		  popd
+  fi
 }
 
 install_cmake3() {
-	wget -nv https://github.com/Kitware/CMake/releases/download/v3.4.0/cmake-3.4.0-Linux-x86_64.sh -P /tmp &&
-		chmod +x /tmp/cmake-3.4.0-Linux-x86_64.sh &&
-		/tmp/cmake-3.4.0-Linux-x86_64.sh --prefix=/usr/local --skip-license
+  CMAKE=`which cmake`
+  if [[ ! -z $CMAKE ]]; then
+    CMAKE_VERSION=$($CMAKE -version | awk '/version/{print $3}')
+  fi
+  if [[ -z $CMAKE_VERSION || CMAKE_VERSION < "3.6" ]]; then
+    echo "Installing cmake..."
+	  wget -nv https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-Linux-x86_64.sh -P /tmp &&
+		  chmod +x /tmp/cmake-3.19.1-Linux-x86_64.sh &&
+		  /tmp/cmake-3.19.1-Linux-x86_64.sh --prefix=/usr/local --skip-license
+  fi
+}
+
+install_gcc() {
+  GCC=`which gcc`
+  GPLUSPLUS=`which g++`
+  if [[ -z $GCC || -z $GPLUSPLUS ]]; then
+    apt-get -y install build-essential software-properties-common
+  fi
+}
+
+install_package() {
+  if [[ $# -ne 2 ]]; then
+    dpkg -s $1 &> /dev/null
+  else
+    echo "Checking if executable exists"
+    which $1
+  fi
+  if [ $? -ne 0 ]; then
+    echo "Installing $1..."
+    apt-get install $1
+    echo "Installing DONE"
+  fi
 }
 
 install_R() {
+  echo "NYI: install R functionality"
+  return 0
   apt-get -y install gnupg &&
   apt-get install -y software-properties-common &&
   apt-get update -q &&
@@ -50,35 +91,34 @@ install_R() {
 	apt-get -y install r-base
 }
 
-install_prerequisites_ubuntu() {
+install_system_prerequisites() {
 	apt-get update -q &&
-    apt-get install -y tzdata &&
-		apt-get -y install \
-						lcov \
-						mpich \
-						zlib1g-dev \
-						libssl-dev \
-						rsync \
-						libidn11 \
-						uuid-dev \
-						libcurl4-openssl-dev \
-						build-essential \
-						software-properties-common \
-						wget \
-						git \
-						autoconf \
-						automake \
-						libtool \
-						zip \
-						unzip \
-						curl \
-						sudo &&
+    install_package tzdata &&
+		install_package install 1 &&
+    install_package lcov 1 &&
+    install_package mpich &&
+    install_package zlib1g-dev &&
+    install_package libssl-dev &&
+    install_package rsync 1 &&
+		install_package	libidn11 &&
+    install_package uuid-dev &&
+    install_package libcurl4-openssl-dev &&
+    install_package wget 1 &&
+    install_package autoconf 1 &&
+    install_package automake 1 &&
+    install_package libtool 1 &&
+    install_package zip 1 &&
+    install_package unzip 1 &&
+    install_package curl 1 &&
+    install_package git &&
+    install_package libcsv-dev &&
+    install_package sudo 1 &&
 		apt-get update -q &&
-		apt-get update -q &&
-		install_openjdk8 &&
+    install_gcc &&
+		install_jdk8 &&
+    install_cmake3 &&
 		install_R &&
 		apt-get clean &&
 		apt-get purge -y &&
-		install_cmake3 &&
-		rm -rf /var/lib/apt/lists*
+    rm -rf /var/lib/apt/lists*
 }

--- a/scripts/prereqs/system/install_ubuntu_prereqs.sh
+++ b/scripts/prereqs/system/install_ubuntu_prereqs.sh
@@ -32,14 +32,14 @@ install_jdk8() {
   if [[ ! -z $JAVAC ]]; then
     JDK_VERSION=$($JAVAC -version 2>&1 | awk '/version/{print $2}')
   fi
-	if [[ -z $JDK_VERSION || $JDK_VERSION < "1.8" ]]; then 
-	  apt-get -y install openjdk-8-jdk icedtea-plugin &&
-		  apt-get update -q &&
-		  pushd $HOME &&
-		  git clone https://github.com/michaelklishin/jdk_switcher.git &&
-		  source jdk_switcher/jdk_switcher.sh && jdk_switcher use openjdk8 &&
-		  echo "export JAVA_HOME=$JAVA_HOME" >> $PREREQS_ENV &&
-		  popd
+  if [[ -z $JDK_VERSION || $JDK_VERSION < "1.8" ]]; then
+    apt-get -y install openjdk-8-jdk icedtea-plugin &&
+      apt-get update -q &&
+      pushd $HOME &&
+      git clone https://github.com/michaelklishin/jdk_switcher.git &&
+      source jdk_switcher/jdk_switcher.sh && jdk_switcher use openjdk8 &&
+      echo "export JAVA_HOME=$JAVA_HOME" >> $PREREQS_ENV &&
+      popd
   fi
 }
 
@@ -50,9 +50,9 @@ install_cmake3() {
   fi
   if [[ -z $CMAKE_VERSION || CMAKE_VERSION < "3.6" ]]; then
     echo "Installing cmake..."
-	  wget -nv https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-Linux-x86_64.sh -P /tmp &&
-		  chmod +x /tmp/cmake-3.19.1-Linux-x86_64.sh &&
-		  /tmp/cmake-3.19.1-Linux-x86_64.sh --prefix=/usr/local --skip-license
+    wget -nv https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-Linux-x86_64.sh -P /tmp &&
+      chmod +x /tmp/cmake-3.19.1-Linux-x86_64.sh &&
+      /tmp/cmake-3.19.1-Linux-x86_64.sh --prefix=/usr/local --skip-license
   fi
 }
 
@@ -84,23 +84,23 @@ install_R() {
   apt-get -y install gnupg &&
   apt-get install -y software-properties-common &&
   apt-get update -q &&
-	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 &&
-	add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' &&
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 &&
+  add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' &&
   apt-get -y install libxml2-dev &&
-	apt-get update -q &&
-	apt-get -y install r-base
+  apt-get update -q &&
+  apt-get -y install r-base
 }
 
 install_system_prerequisites() {
-	apt-get update -q &&
+  apt-get update -q &&
     install_package tzdata &&
-		install_package install 1 &&
+    install_package install 1 &&
     install_package lcov 1 &&
     install_package mpich &&
     install_package zlib1g-dev &&
     install_package libssl-dev &&
     install_package rsync 1 &&
-		install_package	libidn11 &&
+    install_package libidn11 &&
     install_package uuid-dev &&
     install_package libcurl4-openssl-dev &&
     install_package wget 1 &&
@@ -113,12 +113,12 @@ install_system_prerequisites() {
     install_package git &&
     install_package libcsv-dev &&
     install_package sudo 1 &&
-		apt-get update -q &&
+    apt-get update -q &&
     install_gcc &&
-		install_jdk8 &&
+    install_jdk8 &&
     install_cmake3 &&
-		install_R &&
-		apt-get clean &&
-		apt-get purge -y &&
+    install_R &&
+    apt-get clean &&
+    apt-get purge -y &&
     rm -rf /var/lib/apt/lists*
 }


### PR DESCRIPTION
This implements the basic build-test workflow for Ubuntu. What is left to be on par with travis are the following -

1. Install bcftools for checking generated vcfs with run.py
2. MacOS support

Also, we should refactor the `ci-job` currently implemented into 3 jobs
1. setup (will install system and python prereqs and cache them for further use, not sure on caching .m2 without serializing basic and spark jobs)
2. basic
3. spark
Both `basic` and `spark` jobs can run in parallel, but they will be dependent on `setup`. See [Github Docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds) for expressing job dependencies.