### PR TITLE
Annotation service created using HTSLib

### DIFF
--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -187,12 +187,9 @@ class GenomicsDBResults {
  public:
   GenomicsDBResults(std::vector<T>* results, std::map<std::string, genomic_field_type_t> genomic_field_types)
       : m_results(results), m_current_pos(0),
-        m_genomic_field_types(std::make_shared<std::map<std::string, genomic_field_type_t>>(std::move(genomic_field_types))) {
-          printf("jDebug 5: GenomicsDBResults::GenomicsDBResults\n");
-        };
+        m_genomic_field_types(std::make_shared<std::map<std::string, genomic_field_type_t>>(std::move(genomic_field_types))) {};
   ~GenomicsDBResults() { free(); };
   const std::shared_ptr<std::map<std::string, genomic_field_type_t>> get_genomic_field_types() const {
-    printf("jDebug 99: GenomicsDBResults::get_genomic_field_types");
     return m_genomic_field_types;
   }
   const genomic_field_type_t get_genomic_field_type(const std::string& name) const {
@@ -282,7 +279,7 @@ class AnnotationService {
 
 /**
  * Experimental Query Interface to GenomicsDB for Arrays partitioned by columns
- * Concurrency support is provided via query json files for now - see
+ * Concurrency support is provided via query json files for now - see 
  *     https://github.com/GenomicsDB/GenomicsDB/wiki/Querying-GenomicsDB#json-configuration-file-for-a-query
  *     https://github.com/GenomicsDB/GenomicsDB/wiki/MPI-with-GenomicsDB
  */
@@ -296,7 +293,7 @@ class GenomicsDB {
    *   callset_mapping_file
    *   vid_mapping_file
    *   reference_genome
-   *   attributes, optional
+   *   attributes, optional 
    *   segment_size, optional
    * Throws GenomicsDBException
    */
@@ -314,7 +311,7 @@ class GenomicsDB {
    *   loader_config_json_file, optional - describe the loader configuration in a JSON file.
    *           If a configuration key exists in both the query and the loader configuration, the query
    *           configuration takes precedence
-   *   concurrency_rank, optional - if greater than 0,
+   *   concurrency_rank, optional - if greater than 0, 
    *           the constraints(workspace, array, column and row ranges) are surmised
    *           using the rank as an index into their corresponding vectors
    * Throws GenomicsDBException
@@ -431,8 +428,8 @@ class GenomicsDB {
 
   //TODO: Get VariantFields to have names instead of indices at the point of building the data structure, so
   //      we don't have to maintain m_query_configs_map
-  // Associate array names with VariantQueryConfig
-  std::map<std::string, VariantQueryConfig> m_query_configs_map;
+  // Associate array names with VariantQueryConfig 
+  std::map<std::string, VariantQueryConfig> m_query_configs_map; 
 };
 
 // genomicsdb_variant_t specialization of GenomicsDBResults template

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -293,7 +293,7 @@ class GenomicsDB {
    *   callset_mapping_file
    *   vid_mapping_file
    *   reference_genome
-   *   attributes, optional 
+   *   attributes, optional
    *   segment_size, optional
    * Throws GenomicsDBException
    */
@@ -311,7 +311,7 @@ class GenomicsDB {
    *   loader_config_json_file, optional - describe the loader configuration in a JSON file.
    *           If a configuration key exists in both the query and the loader configuration, the query
    *           configuration takes precedence
-   *   concurrency_rank, optional - if greater than 0, 
+   *   concurrency_rank, optional - if greater than 0,
    *           the constraints(workspace, array, column and row ranges) are surmised
    *           using the rank as an index into their corresponding vectors
    * Throws GenomicsDBException
@@ -428,8 +428,8 @@ class GenomicsDB {
 
   //TODO: Get VariantFields to have names instead of indices at the point of building the data structure, so
   //      we don't have to maintain m_query_configs_map
-  // Associate array names with VariantQueryConfig 
-  std::map<std::string, VariantQueryConfig> m_query_configs_map; 
+  // Associate array names with VariantQueryConfig
+  std::map<std::string, VariantQueryConfig> m_query_configs_map;
 };
 
 // genomicsdb_variant_t specialization of GenomicsDBResults template

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -44,6 +44,8 @@
 #include <typeinfo>
 #include <vector>
 
+#include "genomicsdb_export_config.pb.h"
+
 // Override project visibility set to hidden for api
 #if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
 #  define GENOMICSDB_EXPORT __attribute__((visibility("default")))
@@ -242,6 +244,21 @@ class VariantCall;
 class VariantQueryConfig;
 
 /**
+  Add vcf variant annotation to the genomic fields
+*/
+class AnnotationService {
+  public:
+    const std::string DATA_SOURCE_FIELD_SEPARATOR = "_AA_";
+    AnnotationService();
+    void read_configuration(const std::string& str);
+    void annotate();
+
+    std::vector<genomicsdb_pb::AnnotationSource> m_annotate_sources;
+
+
+};
+
+/**
  * Experimental Query Interface to GenomicsDB for Arrays partitioned by columns
  * Concurrency support is provided via query json files for now - see 
  *     https://github.com/GenomicsDB/GenomicsDB/wiki/Querying-GenomicsDB#json-configuration-file-for-a-query
@@ -385,6 +402,7 @@ class GenomicsDB {
   void* m_storage_manager = nullptr; // Pointer to VariantStorageManager instance
   void* m_vid_mapper = nullptr;      // Pointer to VidMapper instance
   void* m_query_config = nullptr;    // Pointer to a base VariantQueryConfig instance
+  void* m_annotation_service = nullptr; // Pointer to annotation service instance (see how others like m_storage_manager get cast)
 
   int m_concurrency_rank = 0;
 

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -44,8 +44,6 @@
 #include <typeinfo>
 #include <vector>
 
-#include "genomicsdb_export_config.pb.h"
-
 // Override project visibility set to hidden for api
 #if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
 #  define GENOMICSDB_EXPORT __attribute__((visibility("default")))
@@ -250,36 +248,8 @@ class VariantCall;
 class VariantQueryConfig;
 
 /**
-  Add vcf variant annotation to the genomic fields
-*/
-class AnnotationService {
-  public:
-    // Default constructor
-    AnnotationService();
-
-    // Buffer which associates genomic location with a list of annotation values.
-    // The dataSource and info field which point to this value are stored elsewhere
-    // Example: value_buffer["chr1-123456-A-G"] = { "val1", "val2", val3 };
-    std::map<std::string, std::vector<std::string>> value_buffer;
-
-    // Value which separates dataSource and info field
-    const std::string DATA_SOURCE_FIELD_SEPARATOR = "_AA_";
-
-    // Read configuration from an ExportConfiguration
-    void read_configuration(const std::string& str);
-
-    //
-    void annotate(genomic_interval_t &genomic_interval, std::string& ref, const std::string& alt, std::vector<genomic_field_t>& genomic_fields) const;
-
-    genomic_field_t get_genomic_field(const std::string &data_source, const std::string &info_attribute, const char *value, const int32_t value_length) const;
-
-    // List of configured annotation data sources
-    std::vector<genomicsdb_pb::AnnotationSource> m_annotate_sources;
-};
-
-/**
  * Experimental Query Interface to GenomicsDB for Arrays partitioned by columns
- * Concurrency support is provided via query json files for now - see 
+ * Concurrency support is provided via query json files for now - see
  *     https://github.com/GenomicsDB/GenomicsDB/wiki/Querying-GenomicsDB#json-configuration-file-for-a-query
  *     https://github.com/GenomicsDB/GenomicsDB/wiki/MPI-with-GenomicsDB
  */

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -257,9 +257,6 @@ class VariantQueryConfig;
 */
 class AnnotationService {
   public:
-    const std::string jDebugAttribute = "clinvar_AA_ID";
-    const std::string jDebugValue = "abcdefgh";
-
     // Default constructor
     AnnotationService();
 
@@ -275,12 +272,12 @@ class AnnotationService {
     void read_configuration(const std::string& str);
 
     //
-    void annotate(genomic_interval_t &genomic_interval, std::string& ref, std::string& alt, std::vector<genomic_field_t>& genomic_fields) const;
+    void annotate(genomic_interval_t &genomic_interval, std::string& ref, const std::string& alt, std::vector<genomic_field_t>& genomic_fields) const;
+
+    genomic_field_t get_genomic_field(const std::string &data_source, const std::string &info_attribute, const char *value, const int32_t value_length) const;
 
     // List of configured annotation data sources
     std::vector<genomicsdb_pb::AnnotationSource> m_annotate_sources;
-
-
 };
 
 /**
@@ -416,6 +413,7 @@ class GenomicsDB {
   std::vector<VariantCall>* query_variant_calls(const std::string& array,
                                                 VariantQueryConfig *query_config,
                                                 GenomicsDBVariantCallProcessor& processor);
+
   void generate_vcf(const std::string& array,
                     VariantQueryConfig* query_config,
                     const std::string& output,

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -258,16 +258,26 @@ class VariantQueryConfig;
 class AnnotationService {
   public:
     const std::string jDebugAttribute = "clinvar_AA_ID";
-    std::string jDebugValue = "abcdef";
-    // const void* jDebugValuePtr = reinterpret_cast<void*>(&jDebugValue[0]);
-    void* jDebugValuePtr = reinterpret_cast<void*>(&jDebugValue[0]);
-    // const void* jDebugValuePtr = reinterpret_cast<void*>(&jDebugValue);
+    const std::string jDebugValue = "abcdefgh";
 
-    const std::string DATA_SOURCE_FIELD_SEPARATOR = "_AA_";
+    // Default constructor
     AnnotationService();
-    void read_configuration(const std::string& str);
-    void annotate(std::vector<genomic_field_t>& genomic_fields) const;
 
+    // Buffer which associates genomic location with a list of annotation values.
+    // The dataSource and info field which point to this value are stored elsewhere
+    // Example: value_buffer["chr1-123456-A-G"] = { "val1", "val2", val3 };
+    std::map<std::string, std::vector<std::string>> value_buffer;
+
+    // Value which separates dataSource and info field
+    const std::string DATA_SOURCE_FIELD_SEPARATOR = "_AA_";
+
+    // Read configuration from an ExportConfiguration
+    void read_configuration(const std::string& str);
+
+    //
+    void annotate(genomic_interval_t &genomic_interval, std::string& ref, std::string& alt, std::vector<genomic_field_t>& genomic_fields) const;
+
+    // List of configured annotation data sources
     std::vector<genomicsdb_pb::AnnotationSource> m_annotate_sources;
 
 

--- a/src/main/cpp/include/config/genomicsdb_config_base.h
+++ b/src/main/cpp/include/config/genomicsdb_config_base.h
@@ -67,6 +67,12 @@ class GenomicsDBConfigBase {
   }
   const std::vector<ColumnRange>& get_query_column_ranges(const int rank) const;
   void set_query_column_ranges(const std::vector<ColumnRange>& column_ranges);
+
+	// jDebug: this doesn't work because   AnnotationService  isn't defined. 
+  // const std::vector<AnnotationService>& get_annotation_service(const int rank) const;
+//  void set_annotation_service(const std::vector<AnnotationService>& annotation_service);
+  
+  
   const std::vector<TileDBRowRange>& get_query_row_ranges(const int rank) const;
   void set_query_row_ranges(const std::vector<TileDBRowRange>& row_ranges);
   inline const std::string& get_query_filter() const {

--- a/src/main/cpp/include/config/genomicsdb_config_base.h
+++ b/src/main/cpp/include/config/genomicsdb_config_base.h
@@ -66,13 +66,8 @@ class GenomicsDBConfigBase {
     return m_sorted_column_partitions;
   }
   const std::vector<ColumnRange>& get_query_column_ranges(const int rank) const;
-  void set_query_column_ranges(const std::vector<ColumnRange>& column_ranges);
+  void set_query_column_ranges(const std::vector<ColumnRange>& column_ranges);  
 
-	// jDebug: this doesn't work because   AnnotationService  isn't defined. 
-  // const std::vector<AnnotationService>& get_annotation_service(const int rank) const;
-//  void set_annotation_service(const std::vector<AnnotationService>& annotation_service);
-  
-  
   const std::vector<TileDBRowRange>& get_query_row_ranges(const int rank) const;
   void set_query_row_ranges(const std::vector<TileDBRowRange>& row_ranges);
   inline const std::string& get_query_filter() const {

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -138,10 +138,10 @@ void AnnotationService::annotate(genomic_interval_t& genomic_interval, std::stri
     bcf_hdr_t *hdr = bcf_hdr_read(vcfInFile);
     VERIFY(hdr && "Could not read VCF header");
 
-    // I'm not sure what this does
+    // I'm not sure what this does. Whatever it is, it takes a really long time.
     regidx_t *reg_idx = NULL;
-    reg_idx = regidx_init(annotation_source.filename().c_str(), NULL, NULL, 0, NULL);
-    VERIFY(reg_idx && "Unable to read file");
+    // reg_idx = regidx_init(annotation_source.filename().c_str(), NULL, NULL, 0, NULL);
+    // VERIFY(reg_idx && "Unable to read file");
 
     // Read the tbi index file
     tbx_t *tbx = tbx_index_load3(annotation_source.filename().c_str(), NULL, 0);
@@ -149,14 +149,14 @@ void AnnotationService::annotate(genomic_interval_t& genomic_interval, std::stri
 
     // Query using chromosome and position range
 
-    std::string variantQuery;
+    // std::string variantQuery;
     // jDebug: the test suite doesn't have any positions that match clinvar so I'm remapping one of them:
-    if(ref.compare("G") == 0 && alt.compare("A") == 0) {
-        // printf("jDebug: 5.2: AnnotationService::annotate: remap 1-17385-G-A to 1-865716-G-A\n");
-          variantQuery = "1:865716-865716";
-    } else {
-    /*std::string*/ variantQuery = genomic_interval.contig_name + ":" + std::to_string(genomic_interval.interval.first) + "-" + std::to_string(genomic_interval.interval.second);
-    }
+    // if(ref.compare("G") == 0 && alt.compare("A") == 0) {
+    //     // printf("jDebug: 5.2: AnnotationService::annotate: remap 1-17385-G-A to 1-865716-G-A\n");
+    //       variantQuery = "1:865716-865716";
+    // } else {
+    std::string variantQuery = genomic_interval.contig_name + ":" + std::to_string(genomic_interval.interval.first) + "-" + std::to_string(genomic_interval.interval.second);
+    // }
 
     hts_itr_t *itr = tbx_itr_querys(tbx, variantQuery.c_str());
     VERIFY(itr && "Problem opening iterator");

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -92,140 +92,32 @@ void check(const std::string& workspace,
 }
 
 /**
-Default constructor for AnnotationService
+  Use this service to add annotations from VCF datasources to variant's genomic ields
 */
-AnnotationService::AnnotationService() {
-}
+class AnnotationService {
+  public:
+    // Default constructor
+    AnnotationService();
 
-/**
-  Read annotation configuration from a pointer to the ExportConfiguration. Create copies of the AnnotationSources.
-*/
-void AnnotationService::read_configuration(const std::string& str) {
-  // Read the configuration
-  genomicsdb_pb::ExportConfiguration export_config;
-  export_config.ParseFromString(str);
+    // Buffer which associates genomic location with a list of annotation values.
+    // The dataSource and info field which point to this value are stored elsewhere
+    // Example: value_buffer["chr1-123456-A-G"] = { "val1", "val2", val3 };
+    std::map<std::string, std::vector<std::string>> value_buffer;
 
-  // Create a copy of each AnnotationSource
-  for(auto i=0; i<export_config.annotation_source_size(); ++i) {
-    genomicsdb_pb::AnnotationSource annotation_source = export_config.annotation_source(i);
-    m_annotate_sources.push_back(annotation_source);
-  }
-}
+    // Value which separates dataSource and info field
+    const std::string DATA_SOURCE_FIELD_SEPARATOR = "_AA_";
 
-/**
-  Create a new genomic_field_t
- */
-genomic_field_t AnnotationService::get_genomic_field(const std::string &data_source,
-                                                     const std::string &info_attribute,
-                                                     const char *value,
-                                                     const int32_t value_length) const {
-  std::string genomic_field_name = data_source + DATA_SOURCE_FIELD_SEPARATOR + info_attribute;
-  genomic_field_t genomic_annotation(genomic_field_name, value, value_length);
-  return genomic_annotation;
-}
+    // Read configuration from an ExportConfiguration
+    void read_configuration(const std::string& str);
 
-/**
-  Annotate a genomic location using all of the configured data sources. Annotations
-  are stored in the genomic_fields vector with the name of the field set to the result of
-  concatonating the dataSource (ie ClinVar) with a separator (see AnnotationService.DATA_SOURCE_FIELD_SEPARATOR),
-  and the INFO field label.
- */
-void AnnotationService::annotate(genomic_interval_t& genomic_interval, std::string& ref, const std::string& alt, std::vector<genomic_field_t>& genomic_fields) const {
-  for(genomicsdb_pb::AnnotationSource annotation_source: m_annotate_sources) {
-    // Open the VCF file
-    htsFile * vcfInFile = hts_open(annotation_source.filename().c_str(), "r");
-    VERIFY(vcfInFile != NULL && "Unable to open VCF file");
+    //
+    void annotate(genomic_interval_t &genomic_interval, std::string& ref, const std::string& alt, std::vector<genomic_field_t>& genomic_fields) const;
 
-    // Check file type
-    enum htsExactFormat format = hts_get_format(vcfInFile)->format;
-    VERIFY(format == vcf && "File is not VCF");
+    genomic_field_t get_genomic_field(const std::string &data_source, const std::string &info_attribute, const char *value, const int32_t value_length) const;
 
-    // Read the header
-    bcf_hdr_t *hdr = bcf_hdr_read(vcfInFile);
-    VERIFY(hdr && "Could not read VCF header");
-
-    // I'm not sure what this does. Whatever it is, it takes a really long time.
-    regidx_t *reg_idx = NULL;
-    // reg_idx = regidx_init(annotation_source.filename().c_str(), NULL, NULL, 0, NULL);
-    // VERIFY(reg_idx && "Unable to read file");
-
-    // Read the tbi index file
-    tbx_t *tbx = tbx_index_load3(annotation_source.filename().c_str(), NULL, 0);
-    VERIFY(tbx && "Could not load .tbi index");
-
-    // Query using chromosome and position range
-    std::string variantQuery = genomic_interval.contig_name + ":" + std::to_string(genomic_interval.interval.first) + "-" + std::to_string(genomic_interval.interval.second);
-
-    hts_itr_t *itr = tbx_itr_querys(tbx, variantQuery.c_str());
-    VERIFY(itr && "Problem opening iterator");
-
-    const char **seq = NULL;
-    int nseq;
-    if (reg_idx) {
-      seq = tbx_seqnames(tbx, &nseq);
-    }
-
-    kstring_t str = {0,0,0};
-    bcf1_t *rec    = bcf_init1();
-    int idx = 0;
-    char* infoValue = NULL;
-    int32_t infoValueLength = 0;
-
-    // Iterate over each matching position in the VCF
-    while (tbx_itr_next(vcfInFile, tbx, itr, &str) >= 0)
-    {
-      if ( reg_idx && !regidx_overlap(reg_idx,seq[itr->curr_tid],itr->curr_beg,itr->curr_end-1, NULL) ) {
-        continue;
-      }
-
-      int readResult = vcf_parse1(&str, hdr, rec);
-      VERIFY(readResult==0 && "Problem parsing current line of VCF");
-
-      // The query is constrained by chromosome and position but not by allele.  Need to add code here which
-      // compares the matches alt and ref alleles to see if they match what we are looking for.
-      bcf_unpack((bcf1_t*)rec, BCF_UN_ALL); // Using BCF_UN_INFO is probably a little faster
-
-      if(ref.compare(rec->d.allele[0]) != 0) {
-        // REF doesn't match
-        continue;
-      } else if(alt.compare(rec->d.allele[1])) {
-        // ALT doesn't match
-        // NOTE: This only looks at one allele. If there are multiple alternate alleles you need to update the code.
-        continue;
-      }
-
-      // iteration over the list of INFO fields we are interested in
-      for(auto info_attribute: annotation_source.attributes()) {
-        // bcf_info_t *info = rec->d.info;
-
-          // If the request is for "ID" then give the VCF row ID
-          if(info_attribute == "ID") {
-            genomic_fields.push_back(get_genomic_field(annotation_source.data_source(), info_attribute, rec->d.id, strlen(rec->d.id)));
-          } else {
-            // Look for the info field
-            int res = bcf_get_info_string(hdr, rec, info_attribute.c_str(), &infoValue, &infoValueLength);
-            if(res > 0) {
-              genomic_fields.push_back(get_genomic_field(annotation_source.data_source(), info_attribute, infoValue, infoValueLength));
-            } else if (res == -2) {
-              // "clash between types defined in the header and encountered in the VCF record"
-              // We need to modify this section so it determines the info field type and then uses the correct
-              // bcf_get_info_* method.
-            } else {
-              // info field not found
-            }
-          }
-      }
-   }
-
-   regidx_destroy(reg_idx);
-
-   // jDebug: this function wasn't found so there's probably a leak: regitr_destroy(itr);
-   bcf_itr_destroy(itr);
-
-    int ret = hts_close(vcfInFile);
-    VERIFY(ret == 0 && "Non-zero status when trying to close VCF file");
-  }
-}
+    // List of configured annotation data sources
+    std::vector<genomicsdb_pb::AnnotationSource> m_annotate_sources;
+};
 
 GenomicsDB::GenomicsDB(const std::string& workspace,
                        const std::string& callset_mapping_file,
@@ -463,11 +355,6 @@ GenomicsDBVariantCalls GenomicsDB::query_variant_calls(GenomicsDBVariantCallProc
 
   add_annotation_field_types(genomic_field_types, m_annotation_service);
 
-  // jDebug For debugging: print all the attributres in the genomic_field_types map
-  // for (auto& x: genomic_field_types) {
-  //   printf("jDebug 0: GenomicsDB::query_variant_calls: first=%s\n", x.first.c_str());
-  // }
-
   return GenomicsDBVariantCalls(TO_GENOMICSDB_VARIANT_CALL_VECTOR(query_variant_calls(array, query_config, processor)),
                                 genomic_field_types);
 }
@@ -477,6 +364,146 @@ VidMapper* get_vid_mapper(void* vid_mapper, void* query_config) {
     return TO_VID_MAPPER(vid_mapper);
   } else {
     return const_cast<VidMapper *>(&(TO_VARIANT_QUERY_CONFIG(query_config)->get_vid_mapper()));
+  }
+}
+
+/**
+Default constructor for AnnotationService
+*/
+AnnotationService::AnnotationService() {
+}
+
+/**
+  Read annotation configuration from a pointer to the ExportConfiguration. Create copies of the AnnotationSources.
+*/
+void AnnotationService::read_configuration(const std::string& str) {
+  // Read the configuration
+  genomicsdb_pb::ExportConfiguration export_config;
+  export_config.ParseFromString(str);
+
+  // Create a copy of each AnnotationSource
+  for(auto i=0; i<export_config.annotation_source_size(); ++i) {
+    genomicsdb_pb::AnnotationSource annotation_source = export_config.annotation_source(i);
+    m_annotate_sources.push_back(annotation_source);
+  }
+}
+
+/**
+  Create a new genomic_field_t
+ */
+genomic_field_t AnnotationService::get_genomic_field(const std::string &data_source,
+                                                     const std::string &info_attribute,
+                                                     const char *value,
+                                                     const int32_t value_length) const {
+  std::string genomic_field_name = data_source + DATA_SOURCE_FIELD_SEPARATOR + info_attribute;
+  genomic_field_t genomic_annotation(genomic_field_name, value, value_length);
+  return genomic_annotation;
+}
+
+/**
+  Annotate a genomic location using all of the configured data sources. Annotations
+  are stored in the genomic_fields vector with the name of the field set to the result of
+  concatonating the dataSource (ie ClinVar) with a separator (see AnnotationService.DATA_SOURCE_FIELD_SEPARATOR),
+  and the INFO field label.
+ */
+void AnnotationService::annotate(genomic_interval_t& genomic_interval, std::string& ref, const std::string& alt, std::vector<genomic_field_t>& genomic_fields) const {
+  for(genomicsdb_pb::AnnotationSource annotation_source: m_annotate_sources) {
+    // Open the VCF file
+    htsFile * vcfInFile = hts_open(annotation_source.filename().c_str(), "r");
+    VERIFY(vcfInFile != NULL && "Unable to open VCF file");
+
+    // Check file type
+    enum htsExactFormat format = hts_get_format(vcfInFile)->format;
+    VERIFY(format == vcf && "File is not VCF");
+
+    // Read the header
+    bcf_hdr_t *hdr = bcf_hdr_read(vcfInFile);
+    VERIFY(hdr && "Could not read VCF header");
+
+    // I'm not sure what this does. Whatever it is, it takes a really long time.
+    // Need to look in to how to remove this variable.
+    regidx_t *reg_idx = NULL;
+    // reg_idx = regidx_init(annotation_source.filename().c_str(), NULL, NULL, 0, NULL);
+    // VERIFY(reg_idx && "Unable to read file");
+
+    // Read the tbi index file
+    tbx_t *tbx = tbx_index_load3(annotation_source.filename().c_str(), NULL, 0);
+    VERIFY(tbx && "Could not load .tbi index");
+
+    // Query using chromosome and position range
+    std::string variantQuery = genomic_interval.contig_name + ":" + std::to_string(genomic_interval.interval.first) + "-" + std::to_string(genomic_interval.interval.second);
+
+    hts_itr_t *itr = tbx_itr_querys(tbx, variantQuery.c_str());
+    VERIFY(itr && "Problem opening iterator");
+
+    const char **seq = NULL;
+    int nseq;
+    if (reg_idx) {
+      seq = tbx_seqnames(tbx, &nseq);
+    }
+
+    kstring_t str = {0,0,0};
+    bcf1_t *rec    = bcf_init1();
+    int idx = 0;
+    char* infoValue = NULL;
+    int32_t infoValueLength = 0;
+
+    // Iterate over each matching position in the VCF
+    while (tbx_itr_next(vcfInFile, tbx, itr, &str) >= 0)
+    {
+      if ( reg_idx && !regidx_overlap(reg_idx,seq[itr->curr_tid],itr->curr_beg,itr->curr_end-1, NULL) ) {
+        continue;
+      }
+
+      int readResult = vcf_parse1(&str, hdr, rec);
+      VERIFY(readResult==0 && "Problem parsing current line of VCF");
+
+      // The query is constrained by chromosome and position but not by allele.  Need to add code here which
+      // compares the matches alt and ref alleles to see if they match what we are looking for.
+      bcf_unpack((bcf1_t*)rec, BCF_UN_ALL); // Using BCF_UN_INFO is probably a little faster
+
+      if(ref.compare(rec->d.allele[0]) != 0) {
+        // REF doesn't match
+        continue;
+      } else if(alt.compare(rec->d.allele[1])) {
+        // ALT doesn't match
+        // NOTE: This only looks at one allele. If there are multiple alternate alleles you need to update the code.
+        continue;
+      }
+
+      // iteration over the list of INFO fields we are interested in
+      for(auto info_attribute: annotation_source.attributes()) {
+        // bcf_info_t *info = rec->d.info;
+
+          // If the request is for "ID" then give the VCF row ID
+          if(info_attribute == "ID") {
+            genomic_fields.push_back(get_genomic_field(annotation_source.data_source(), info_attribute, rec->d.id, strlen(rec->d.id)));
+            // printf("jDebug.cc: %s ID=%s\n", annotation_source.data_source().c_str(), rec->d.id);
+          } else {
+            // Look for the info field
+            int res = bcf_get_info_string(hdr, rec, info_attribute.c_str(), &infoValue, &infoValueLength);
+            if(res > 0) {
+              genomic_fields.push_back(get_genomic_field(annotation_source.data_source(), info_attribute, infoValue, infoValueLength));
+              // printf("jDebug.cc: %s %s=%s\n", annotation_source.data_source().c_str(), info_attribute.c_str(), infoValue);
+            } else if (res == -2) {
+              // "clash between types defined in the header and encountered in the VCF record"
+              // We need to modify this section so it determines the info field type and then uses the correct
+              // bcf_get_info_* method.
+            } else {
+              // info field not found
+            }
+          }
+      }
+   }
+
+   regidx_destroy(reg_idx);
+
+   // jDebug: this function wasn't found so there's probably a leak: regitr_destroy(itr);
+   // jDebug: need to find out if the iterator needs to be destroyed.
+   bcf_itr_destroy(itr);
+
+    int ret = hts_close(vcfInFile);
+    VERIFY(ret == 0 && "Non-zero status when trying to close VCF file");
   }
 }
 

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -53,8 +53,7 @@ message SparkConfig {
   optional int64 query_block_size = 1;
   optional int64 query_block_size_margin = 2;
 }
-
-// This name should be changed  (eg AnnotationConfig) since AnnotationService is also a class in genomicsdb.h  
+  
 message AnnotationSource {
   required string filename = 1;
   repeated string attributes = 2;

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -54,6 +54,13 @@ message SparkConfig {
   optional int64 query_block_size_margin = 2;
 }
 
+message AnnotationService {
+  required string filename = 1;
+  repeated string attributes = 2;
+  required string data_source = 3;
+  optional bool is_vcf = 4;
+}
+
 message ExportConfiguration {
   required string workspace = 1;
   oneof array {
@@ -95,4 +102,5 @@ message ExportConfiguration {
   optional uint32 combined_vcf_records_buffer_size_limit = 27;
   optional bool enable_shared_posixfs_optimizations = 28;
   optional SparkConfig spark_config = 29;
+  repeated AnnotationService annotation_service = 30;
 }

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -54,7 +54,8 @@ message SparkConfig {
   optional int64 query_block_size_margin = 2;
 }
 
-message AnnotationService {
+// This name should be changed  (eg AnnotationConfig) since AnnotationService is also a class in genomicsdb.h  
+message AnnotationSource {
   required string filename = 1;
   repeated string attributes = 2;
   required string data_source = 3;
@@ -102,5 +103,5 @@ message ExportConfiguration {
   optional uint32 combined_vcf_records_buffer_size_limit = 27;
   optional bool enable_shared_posixfs_optimizations = 28;
   optional SparkConfig spark_config = 29;
-  repeated AnnotationService annotation_service = 30;
+  repeated AnnotationSource annotation_source = 30;
 }

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -610,6 +610,68 @@ TEST_CASE("api annotate query_variant_calls with protobuf", "[annotate_variant_c
   annotation_source->set_data_source(data_source);
   annotation_source->add_attributes()->assign("ID");
   annotation_source->add_attributes()->assign("CLNSIG");
+  annotation_source->add_attributes()->assign("GENEINFO");
+
+  std::string config_string;
+  CHECK(config->SerializeToString(&config_string));
+
+  config->set_array_name(array);
+  CHECK(config->SerializeToString(&config_string));
+
+  GenomicsDB* gdb = new GenomicsDB(config_string, GenomicsDB::PROTOBUF_BINARY_STRING, loader_json, 0);
+  gdb->query_variant_calls();
+  // OneQueryIntervalProcessor one_query_interval_processor;
+  // gdb->query_variant_calls(one_query_interval_processor);
+  delete gdb;
+}
+
+TEST_CASE("api annotate query_variant_calls with cosmic", "[annotate_variant_calls_with_cosmic]") {
+  using namespace genomicsdb_pb;
+
+  ExportConfiguration *config = new ExportConfiguration();
+
+  config->set_workspace(workspace);
+  config->set_callset_mapping_file(callset_mapping);
+  config->set_vid_mapping_file(vid_mapping);
+
+  // query_row_ranges
+  RowRangeList* row_ranges = config->add_query_row_ranges();
+  RowRange* row_range = row_ranges->add_range_list();
+  row_range->set_low(0);
+  row_range->set_high(3);
+
+  // query_column_ranges
+  GenomicsDBColumnOrIntervalList* column_ranges = config->add_query_column_ranges();
+  GenomicsDBColumnOrInterval* column_range = column_ranges->add_column_or_interval_list();
+
+  TileDBColumnInterval* tiledb_column_interval = new TileDBColumnInterval();
+  tiledb_column_interval->set_begin(0);
+  tiledb_column_interval->set_end(1000000000);
+
+  GenomicsDBColumnInterval* column_interval = new GenomicsDBColumnInterval();
+  column_interval->set_allocated_tiledb_column_interval(tiledb_column_interval);
+
+  column_range->set_allocated_column_interval(column_interval);
+
+  // query_attributes
+  config->add_attributes()->assign("GT");
+  config->add_attributes()->assign("DP");
+
+  config->set_reference_genome("inputs/chr1_10MB.fasta.gz");
+  config->set_segment_size(40);
+  config->set_vcf_header_filename("inputs/template_vcf_header.vcf");
+
+  AnnotationSource* annotation_source = config->add_annotation_source();
+
+  // jDebug: This hard coded path will need to change.
+  const std::string vcf_file("/opt/kdlapplocal/megasus/COSMIC-GRCh37_v91_CosmicCodingMuts.normal.vcf.bgz");
+  const std::string data_source("COSMIC");
+  annotation_source->set_is_vcf(true);
+  annotation_source->set_filename(vcf_file);
+  annotation_source->set_data_source(data_source);
+  annotation_source->add_attributes()->assign("LEGACY_ID");
+  annotation_source->add_attributes()->assign("CNT");
+  annotation_source->add_attributes()->assign("GENE");
 
   std::string config_string;
   CHECK(config->SerializeToString(&config_string));

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -625,7 +625,7 @@ TEST_CASE("api annotate query_variant_calls with protobuf", "[annotate_variant_c
   delete gdb;
 }
 
-TEST_CASE("api annotate query_variant_calls with cosmic", "[annotate_variant_calls_with_cosmic]") {
+TEST_CASE("api annotate query_variant_calls with cosmic", "[annotate_variant_calls_with_gnomad]") {
   using namespace genomicsdb_pb;
 
   ExportConfiguration *config = new ExportConfiguration();
@@ -664,14 +664,21 @@ TEST_CASE("api annotate query_variant_calls with cosmic", "[annotate_variant_cal
   AnnotationSource* annotation_source = config->add_annotation_source();
 
   // jDebug: This hard coded path will need to change.
-  const std::string vcf_file("/opt/kdlapplocal/megasus/COSMIC-GRCh37_v91_CosmicCodingMuts.normal.vcf.bgz");
-  const std::string data_source("COSMIC");
+  const std::string vcf_file("/opt/omics.data/vcf/gnomad.exomes.r2.1.1.sites.1.vcf.bgz");
+  const std::string data_source("gnomAD");
   annotation_source->set_is_vcf(true);
   annotation_source->set_filename(vcf_file);
   annotation_source->set_data_source(data_source);
-  annotation_source->add_attributes()->assign("LEGACY_ID");
-  annotation_source->add_attributes()->assign("CNT");
-  annotation_source->add_attributes()->assign("GENE");
+
+  // ID and variant_type will show up, but the numeric values aren't supported yet
+  annotation_source->add_attributes()->assign("ID");
+  annotation_source->add_attributes()->assign("variant_type");
+  annotation_source->add_attributes()->assign("AC");
+  annotation_source->add_attributes()->assign("AN");
+  annotation_source->add_attributes()->assign("AF");
+  annotation_source->add_attributes()->assign("AF_afr");
+  annotation_source->add_attributes()->assign("AF_female");
+
 
   std::string config_string;
   CHECK(config->SerializeToString(&config_string));

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -560,3 +560,25 @@ TEST_CASE("api generate_vcf with json multiple threads", "[query_generate_with_j
     threads[i].join();
   }
 }
+
+/**
+ * Test case for annotating variants using a VCF data source.
+ */
+TEST_CASE("api annotate_variant_calls with protobuf", "[annotate_variant_calls_with_protobuf]") {
+  using namespace genomicsdb_pb;
+
+  ExportConfiguration *config = new ExportConfiguration();
+  AnnotationService* annotation_service = config->add_annotation_service();
+
+  // jDebug: This hard coded path will need to change.
+  const std::string vcf_file("/opt/omics.data/vcf/clinvar_20200720.vcf.gz");
+  const std::string data_source("clinvar");
+  annotation_service->set_is_vcf(true);
+  annotation_service->set_filename(vcf_file);
+  annotation_service->set_data_source(data_source);
+  annotation_service->add_attributes()->assign("ID");
+  annotation_service->add_attributes()->assign("CLNSIG");
+
+  // jDebug: this test isn't necessary, but it's helpful for me right now.
+  CHECK(annotation_service->attributes_size() == 2);
+}

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -564,7 +564,7 @@ TEST_CASE("api generate_vcf with json multiple threads", "[query_generate_with_j
 /**
  * Test case for annotating variants using a VCF data source.
  */
-TEST_CASE("api annotate query_variant_calls with protobuf II", "[annotate_variant_calls_with_protobuf_2]") {
+TEST_CASE("api annotate query_variant_calls with protobuf", "[annotate_variant_calls_with_protobuf]") {
   using namespace genomicsdb_pb;
 
   ExportConfiguration *config = new ExportConfiguration();
@@ -619,7 +619,7 @@ TEST_CASE("api annotate query_variant_calls with protobuf II", "[annotate_varian
 
   GenomicsDB* gdb = new GenomicsDB(config_string, GenomicsDB::PROTOBUF_BINARY_STRING, loader_json, 0);
   gdb->query_variant_calls();
-  OneQueryIntervalProcessor one_query_interval_processor;
-  gdb->query_variant_calls(one_query_interval_processor);
+  // OneQueryIntervalProcessor one_query_interval_processor;
+  // gdb->query_variant_calls(one_query_interval_processor);
   delete gdb;
 }

--- a/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
+++ b/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
@@ -18,8 +18,20 @@
  */
 package org.genomicsdb.reader;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.genomicsdb.exception.GenomicsDBException;
+import org.genomicsdb.model.Coordinates.GenomicsDBColumnInterval;
+import org.genomicsdb.model.Coordinates.GenomicsDBColumnOrInterval;
+import org.genomicsdb.model.Coordinates.TileDBColumnInterval;
 import org.genomicsdb.model.GenomicsDBExportConfiguration;
+import org.genomicsdb.model.GenomicsDBExportConfiguration.AnnotationSource;
+import org.genomicsdb.model.GenomicsDBExportConfiguration.GenomicsDBColumnOrIntervalList;
 import org.genomicsdb.reader.GenomicsDBQuery.Interval;
 import org.genomicsdb.reader.GenomicsDBQuery.Pair;
 import org.genomicsdb.reader.GenomicsDBQuery.VariantCall;
@@ -27,312 +39,383 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-
 public class GenomicsDBQueryTest {
 
-  static String inputsDir = Paths.get("target", "test", "inputs").toAbsolutePath().toString();
+    static String inputsDir = Paths.get("target", "test", "inputs").toAbsolutePath().toString();
 
-  static String workspace;
-  static String callsetMapping;
-  static String vidMapping;
-  static String referenceGenome;
+    static String workspace;
+    static String callsetMapping;
+    static String vidMapping;
+    static String referenceGenome;
 
-  static String queryJSONFile;
-  static String loaderJSONFile;
+    static String queryJSONFile;
+    static String loaderJSONFile;
 
-  static String arrayName = "t0_1_2";
+    static String arrayName = "t0_1_2";
 
-  @BeforeClass
-  public void setUp() {
-    File inputsDirFile = new File(inputsDir);
-    if (!inputsDirFile.exists() || inputsDirFile.list().length == 0) {
-      inputsDir = Paths.get("build", "target", "test", "inputs").toAbsolutePath().toString();
-      inputsDirFile = new File(inputsDir);
-      if (!inputsDirFile.exists() || inputsDirFile.list().length == 0) {
-        Assert.fail("Aborting GenomicsDBQueryTest. Could not find test inputs folder " + inputsDir);
-      }
-    }
-    workspace = Paths.get(inputsDir, "ws").toAbsolutePath().toString();
-    callsetMapping = Paths.get(inputsDir, "callset_t0_1_2.json").toAbsolutePath().toString();
-    vidMapping = Paths.get(inputsDir, "vid.json").toAbsolutePath().toString();
-    referenceGenome = Paths.get(inputsDir, "chr1_10MB.fasta.gz").toAbsolutePath().toString();
+    @BeforeClass
+    public void setUp() {
+        File inputsDirFile = new File(inputsDir);
+        if (!inputsDirFile.exists() || inputsDirFile.list().length == 0) {
+            inputsDir = Paths.get("build", "target", "test", "inputs").toAbsolutePath().toString();
+            inputsDirFile = new File(inputsDir);
+            if (!inputsDirFile.exists() || inputsDirFile.list().length == 0) {
+                Assert.fail("Aborting GenomicsDBQueryTest. Could not find test inputs folder " + inputsDir);
+            }
+        }
+        workspace = Paths.get(inputsDir, "ws").toAbsolutePath().toString();
+        callsetMapping = Paths.get(inputsDir, "callset_t0_1_2.json").toAbsolutePath().toString();
+        vidMapping = Paths.get(inputsDir, "vid.json").toAbsolutePath().toString();
+        referenceGenome = Paths.get(inputsDir, "chr1_10MB.fasta.gz").toAbsolutePath().toString();
 
-    queryJSONFile = Paths.get(inputsDir, "query.json").toAbsolutePath().toString();
-    loaderJSONFile = Paths.get(inputsDir, "loader.json").toAbsolutePath().toString();
-  }
-
-  @Test
-  public void testGenomicsDBQueryVersion() {
-    Assert.assertNotNull(new GenomicsDBQuery().version());
-  }
-
-  @Test
-  void testGenomicsDBConnectWithEmptyRequiredParams() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    try {
-      query.connect("", "", "", "", new ArrayList<String>());
-      Assert.fail();
-    } catch (GenomicsDBException e) {
-      // Expected Exception
-    }
-    try {
-      query.connect(workspace, "", "", "", new ArrayList<String>());
-      Assert.fail();
-    } catch (GenomicsDBException e) {
-      // Expected Exception
-    }
-    try {
-      query.connect(workspace, vidMapping, "", "", new ArrayList<String>());
-      Assert.fail();
-    } catch (GenomicsDBException e) {
-      // Expected Exception
-    }
-    try {
-      query.connect(workspace, vidMapping, callsetMapping, "", new ArrayList<String>());
-      Assert.fail();
-    } catch (GenomicsDBException e) {
-      // Expected Exception
-    }
-  }
-
-  private long connect() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, new ArrayList<>());
-    Assert.assertTrue(handle > 0);
-    return handle;
-  }
-
-  private long connectWithDPAttribute() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    List<String> attributes = new ArrayList<>();
-    attributes.add("DP");
-    long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, attributes);
-    Assert.assertTrue(handle > 0);
-    return handle;
-  }
-
-  private long connectWithDPandGTAttribute() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    List<String> attributes = new ArrayList<>();
-    attributes.add("DP");
-    attributes.add("GT");
-    long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, attributes);
-    Assert.assertTrue(handle > 0);
-    return handle;
-  }
-
-  private long connectWithSegmentSize() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, new ArrayList<>(), 40);
-    Assert.assertTrue(handle > 0);
-    return handle;
-  }
-
-  private long connectWithJson() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    Assert.assertTrue(new File(queryJSONFile).exists());
-    Assert.assertTrue(new File(loaderJSONFile).exists());
-    long handle = query.connectJSON(queryJSONFile, loaderJSONFile);
-    Assert.assertTrue(handle > 0);
-    return handle;
-  }
-
-  @Test
-  void testGenomicsDBBasicConnectDisconnect() throws GenomicsDBException {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = connect();
-    query.disconnect(genomicsDBHandle);
-
-    genomicsDBHandle = connectWithDPAttribute();
-    query.disconnect(genomicsDBHandle);
-
-    genomicsDBHandle = connectWithSegmentSize();
-    query.disconnect(genomicsDBHandle);
-  }
-
-  void checkVariantCall(VariantCall variantCall) {
-    assert(variantCall != null);
-    assert(variantCall.getRowIndex() >= 0 && variantCall.getRowIndex() <=2);
-    assert(!variantCall.getContigName().isEmpty());
-    assert(variantCall.getGenomic_interval().getStart() > 0);
-    assert(variantCall.getGenomic_interval().getEnd() > 0);
-    assert(variantCall.getGenomicFields().size() > 1);
-    Assert.assertFalse(variantCall.toString().isEmpty());
-  }
-
-  @Test
-  void testGenomicsDBVariantCallQuery() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = connectWithDPAttribute();
-
-    List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, arrayName);
-    assert(intervals.size() == 0);
-
-    List<Pair>columnRanges = new ArrayList<>();
-    columnRanges.add(new Pair(0L, 1000000000L));
-    intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges);
-    assert(intervals.size() == 0);
-
-    List<Pair>rowRanges = new ArrayList<>();
-    rowRanges.add(new Pair(0L, 3L));
-    intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges, rowRanges);
-    assert(intervals.size() == 1);
-
-    Interval interval = intervals.get(0);
-    assert(interval.getInterval().getStart() == 0L);
-    assert(interval.getInterval().getEnd() == 1000000000L);
-    assert(interval.getCalls().size() == 5);
-
-    checkVariantCall(interval.getCalls().get(0));
-
-    query.disconnect(genomicsDBHandle);
-  }
-
-  @Test
-  void testGenomicsDBVariantCallQueryWithMultipleAttributes() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = connectWithDPandGTAttribute();
-
-    List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, arrayName);
-    Assert.assertEquals(intervals.size(), 0);
-
-    List<Pair>columnRanges = new ArrayList<>();
-    columnRanges.add(new Pair(0L, 1000000000L));
-    List<Pair>rowRanges = new ArrayList<>();
-    rowRanges.add(new Pair(0L, 3L));
-
-    intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges, rowRanges);
-    Assert.assertEquals(intervals.size(), 1);
-    Assert.assertFalse(intervals.toString().isEmpty());
-
-    Pair interval = intervals.get(0).getInterval();
-    List<VariantCall> calls = intervals.get(0).getCalls();
-
-    Assert.assertEquals(interval.getStart(), 0L);
-    Assert.assertEquals(interval.getEnd(), 1000000000L);
-
-    Assert.assertEquals(calls.size(), 5);
-
-    boolean foundVariantCall = false;
-    for (VariantCall call : calls) {
-      if (call.sampleName.equals("HG00141") && call.contigName.equals("1") && call.genomic_interval.getStart() == 12141 && call.genomic_interval.getEnd() == 12295) {
-        foundVariantCall = true;
-        Assert.assertEquals(call.genomicFields.size(), 3);
-        Assert.assertEquals(call.genomicFields.get("REF"), "C");
-        Assert.assertEquals(call.genomicFields.get("ALT"), "[<NON_REF>]");
-        Assert.assertEquals(call.genomicFields.get("GT"), "0/0");
-      }
-    }
-    Assert.assertTrue(foundVariantCall, "One Variant Call should have been found");
-  }
-  /* GenomicsDBColumnarField::print_data_in_buffer_at_index  genomicsdb_columnar_field.cc:101*/
-
-  @Test
-  void testGenomicsDBVariantCallQueryWithSegmentSize() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = connectWithSegmentSize();
-
-    List<Pair>columnRanges = new ArrayList<>();
-    columnRanges.add(new Pair(0L, 1000000000L));
-    List<Pair>rowRanges = new ArrayList<>();
-    rowRanges.add(new Pair(0L, 3L));
-
-    List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges, rowRanges);
-    assert(intervals.size() == 1);
-    checkVariantCall(intervals.get(0).getCalls().get(0));
-
-    query.disconnect(genomicsDBHandle);
-  }
-
-  @Test
-  void testGenomicsDBVariantCallQueryWithMultipleIntervals() {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = connectWithSegmentSize();
-
-    List<Pair>columnRanges = new ArrayList<>();
-    columnRanges.add(new Pair(0L, 50000L));
-    columnRanges.add(new Pair(50000L, 1000000000L));
-    List<Pair>rowRanges = new ArrayList<>();
-    rowRanges.add(new Pair(0L, 3L));
-    
-    query.disconnect(genomicsDBHandle);
-  }
-
-  @Test
-  void testGenomicsDBGenerateVCF() throws IOException {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = connectWithSegmentSize();
-
-    List<Pair>columnRanges = new ArrayList<>();
-    columnRanges.add(new Pair(0L, 50000L));
-    columnRanges.add(new Pair(50000L, 1000000000L));
-    List<Pair>rowRanges = new ArrayList<>();
-
-    File vcfFile = File.createTempFile("GenomicsDBQueryTest", "");
-    File vcfIndexFile = new File(vcfFile+".tbi");
-
-    query.generateVCF(genomicsDBHandle, arrayName, columnRanges, new ArrayList<>(), vcfFile.toString(), "z", true);
-
-    Assert.assertTrue(vcfFile.exists());
-    Assert.assertTrue(vcfFile.length() > 0);
-    Assert.assertTrue(vcfIndexFile.exists());
-    Assert.assertTrue(vcfIndexFile.length() > 0);
-
-    try {
-      query.generateVCF(genomicsDBHandle, arrayName, columnRanges, new ArrayList<>(), vcfFile.toString(), "z", false);
-      Assert.fail();
-    } catch (GenomicsDBException e) {
-      // Expected exception
+        queryJSONFile = Paths.get(inputsDir, "query.json").toAbsolutePath().toString();
+        loaderJSONFile = Paths.get(inputsDir, "loader.json").toAbsolutePath().toString();
     }
 
-    vcfFile.delete();
-  }
+    @Test
+    public void testGenomicsDBQueryVersion() {
+        Assert.assertNotNull(new GenomicsDBQuery().version());
+    }
 
-  @Test
-  void testGenomicsDBGenerateVCFWithJson() throws IOException {
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = connectWithJson();
+    @Test
+    void testGenomicsDBConnectWithEmptyRequiredParams() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        try {
+            query.connect("", "", "", "", new ArrayList<String>());
+            Assert.fail();
+        } catch (GenomicsDBException e) {
+            // Expected Exception
+        }
+        try {
+            query.connect(workspace, "", "", "", new ArrayList<String>());
+            Assert.fail();
+        } catch (GenomicsDBException e) {
+            // Expected Exception
+        }
+        try {
+            query.connect(workspace, vidMapping, "", "", new ArrayList<String>());
+            Assert.fail();
+        } catch (GenomicsDBException e) {
+            // Expected Exception
+        }
+        try {
+            query.connect(workspace, vidMapping, callsetMapping, "", new ArrayList<String>());
+            Assert.fail();
+        } catch (GenomicsDBException e) {
+            // Expected Exception
+        }
+    }
 
-    File vcfFile = File.createTempFile("GenomicsDBQueryTest", "");
-    File vcfIndexFile = new File(vcfFile+".tbi");
+    private long connect() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, new ArrayList<>());
+        Assert.assertTrue(handle > 0);
+        return handle;
+    }
 
-    query.generateVCF(genomicsDBHandle, vcfFile.toString(), "z", true);
+    private long connectWithDPAttribute() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        List<String> attributes = new ArrayList<>();
+        attributes.add("DP");
+        long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, attributes);
+        Assert.assertTrue(handle > 0);
+        return handle;
+    }
 
-    Assert.assertTrue(vcfFile.exists());
-    Assert.assertTrue(vcfFile.length() > 0);
-    Assert.assertTrue(vcfIndexFile.exists());
-    Assert.assertTrue(vcfIndexFile.length() > 0);
-  }
+    private long connectWithDPandGTAttribute() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        List<String> attributes = new ArrayList<>();
+        attributes.add("DP");
+        attributes.add("GT");
+        long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, attributes);
+        Assert.assertTrue(handle > 0);
+        return handle;
+    }
 
-  @Test
-  void testGenomicsDBGenerateVCFWithPBExportConfig() throws IOException {
-    GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
-            .setWorkspace(workspace)
-            .setVidMappingFile(vidMapping)
-            .setCallsetMappingFile(callsetMapping)
-            .setReferenceGenome(referenceGenome)
-            .setArrayName(arrayName)
-            .setSegmentSize(40)
-            .setScanFull(true)
-            .build();
+    private long connectWithSegmentSize() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, new ArrayList<>(), 40);
+        Assert.assertTrue(handle > 0);
+        return handle;
+    }
 
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = query.connectExportConfiguration(exportConfiguration);
-    Assert.assertTrue(genomicsDBHandle > 0);
+    private long connectWithJson() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        Assert.assertTrue(new File(queryJSONFile).exists());
+        Assert.assertTrue(new File(loaderJSONFile).exists());
+        long handle = query.connectJSON(queryJSONFile, loaderJSONFile);
+        Assert.assertTrue(handle > 0);
+        return handle;
+    }
 
-    File vcfFile = File.createTempFile("GenomicsDBQueryTest", "");
-    File vcfIndexFile = new File(vcfFile+".tbi");
+    @Test
+    void testGenomicsDBBasicConnectDisconnect() throws GenomicsDBException {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = connect();
+        query.disconnect(genomicsDBHandle);
 
-    query.generateVCF(genomicsDBHandle, vcfFile.toString(), "z", true);
+        genomicsDBHandle = connectWithDPAttribute();
+        query.disconnect(genomicsDBHandle);
 
-    Assert.assertTrue(vcfFile.exists());
-    Assert.assertTrue(vcfFile.length() > 0);
-    Assert.assertTrue(vcfIndexFile.exists());
-    Assert.assertTrue(vcfIndexFile.length() > 0);
-  }
+        genomicsDBHandle = connectWithSegmentSize();
+        query.disconnect(genomicsDBHandle);
+    }
+
+    void checkVariantCall(VariantCall variantCall) {
+        assert(variantCall != null);
+        assert(variantCall.getRowIndex() >= 0 && variantCall.getRowIndex() <=2);
+        assert(!variantCall.getContigName().isEmpty());
+        assert(variantCall.getGenomic_interval().getStart() > 0);
+        assert(variantCall.getGenomic_interval().getEnd() > 0);
+        assert(variantCall.getGenomicFields().size() > 1);
+        Assert.assertFalse(variantCall.toString().isEmpty());
+    }
+
+    @Test
+    void testGenomicsDBVariantCallQuery() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = connectWithDPAttribute();
+
+        List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, arrayName);
+        assert(intervals.size() == 0);
+
+        List<Pair>columnRanges = new ArrayList<>();
+        columnRanges.add(new Pair(0L, 1000000000L));
+        intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges);
+        assert(intervals.size() == 0);
+
+        List<Pair>rowRanges = new ArrayList<>();
+        rowRanges.add(new Pair(0L, 3L));
+        intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges, rowRanges);
+        assert(intervals.size() == 1);
+
+        Interval interval = intervals.get(0);
+        assert(interval.getInterval().getStart() == 0L);
+        assert(interval.getInterval().getEnd() == 1000000000L);
+        assert(interval.getCalls().size() == 5);
+
+        checkVariantCall(interval.getCalls().get(0));
+
+        query.disconnect(genomicsDBHandle);
+    }
+
+    @Test
+    void testGenomicsDBVariantCallQueryWithMultipleAttributes() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = connectWithDPandGTAttribute();
+
+        List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, arrayName);
+        Assert.assertEquals(intervals.size(), 0);
+
+        List<Pair>columnRanges = new ArrayList<>();
+        columnRanges.add(new Pair(0L, 1000000000L));
+        List<Pair>rowRanges = new ArrayList<>();
+        rowRanges.add(new Pair(0L, 3L));
+
+        intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges, rowRanges);
+        Assert.assertEquals(intervals.size(), 1);
+        Assert.assertFalse(intervals.toString().isEmpty());
+
+        Pair interval = intervals.get(0).getInterval();
+        List<VariantCall> calls = intervals.get(0).getCalls();
+
+        Assert.assertEquals(interval.getStart(), 0L);
+        Assert.assertEquals(interval.getEnd(), 1000000000L);
+
+        Assert.assertEquals(calls.size(), 5);
+
+        boolean foundVariantCall = false;
+        for (VariantCall call : calls) {
+            if (call.sampleName.equals("HG00141") && call.contigName.equals("1") && call.genomic_interval.getStart() == 12141 && call.genomic_interval.getEnd() == 12295) {
+                foundVariantCall = true;
+                Assert.assertEquals(call.genomicFields.size(), 3);
+                Assert.assertEquals(call.genomicFields.get("REF"), "C");
+                Assert.assertEquals(call.genomicFields.get("ALT"), "[<NON_REF>]");
+                Assert.assertEquals(call.genomicFields.get("GT"), "0/0");
+            }
+        }
+        Assert.assertTrue(foundVariantCall, "One Variant Call should have been found");
+    }
+    /* GenomicsDBColumnarField::print_data_in_buffer_at_index  genomicsdb_columnar_field.cc:101*/
+
+    @Test
+    void testGenomicsDBVariantCallQueryWithSegmentSize() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = connectWithSegmentSize();
+
+        List<Pair>columnRanges = new ArrayList<>();
+        columnRanges.add(new Pair(0L, 1000000000L));
+        List<Pair>rowRanges = new ArrayList<>();
+        rowRanges.add(new Pair(0L, 3L));
+
+        List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges, rowRanges);
+        assert(intervals.size() == 1);
+        checkVariantCall(intervals.get(0).getCalls().get(0));
+
+        query.disconnect(genomicsDBHandle);
+    }
+
+    @Test
+    void testGenomicsDBVariantCallQueryWithMultipleIntervals() {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = connectWithSegmentSize();
+
+        List<Pair>columnRanges = new ArrayList<>();
+        columnRanges.add(new Pair(0L, 50000L));
+        columnRanges.add(new Pair(50000L, 1000000000L));
+        List<Pair>rowRanges = new ArrayList<>();
+        rowRanges.add(new Pair(0L, 3L));
+
+        query.disconnect(genomicsDBHandle);
+    }
+
+    @Test
+    void testGenomicsDBGenerateVCF() throws IOException {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = connectWithSegmentSize();
+
+        List<Pair>columnRanges = new ArrayList<>();
+        columnRanges.add(new Pair(0L, 50000L));
+        columnRanges.add(new Pair(50000L, 1000000000L));
+        List<Pair>rowRanges = new ArrayList<>();
+
+        File vcfFile = File.createTempFile("GenomicsDBQueryTest", "");
+        File vcfIndexFile = new File(vcfFile+".tbi");
+
+        query.generateVCF(genomicsDBHandle, arrayName, columnRanges, new ArrayList<>(), vcfFile.toString(), "z", true);
+
+        Assert.assertTrue(vcfFile.exists());
+        Assert.assertTrue(vcfFile.length() > 0);
+        Assert.assertTrue(vcfIndexFile.exists());
+        Assert.assertTrue(vcfIndexFile.length() > 0);
+
+        try {
+            query.generateVCF(genomicsDBHandle, arrayName, columnRanges, new ArrayList<>(), vcfFile.toString(), "z", false);
+            Assert.fail();
+        } catch (GenomicsDBException e) {
+            // Expected exception
+        }
+
+        vcfFile.delete();
+    }
+
+    @Test
+    void testGenomicsDBGenerateVCFWithJson() throws IOException {
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = connectWithJson();
+
+        File vcfFile = File.createTempFile("GenomicsDBQueryTest", "");
+        File vcfIndexFile = new File(vcfFile+".tbi");
+
+        query.generateVCF(genomicsDBHandle, vcfFile.toString(), "z", true);
+
+        Assert.assertTrue(vcfFile.exists());
+        Assert.assertTrue(vcfFile.length() > 0);
+        Assert.assertTrue(vcfIndexFile.exists());
+        Assert.assertTrue(vcfIndexFile.length() > 0);
+    }
+
+    @Test
+    void testGenomicsDBGenerateVCFWithPBExportConfig() throws IOException {
+        GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
+                .setWorkspace(workspace)
+                .setVidMappingFile(vidMapping)
+                .setCallsetMappingFile(callsetMapping)
+                .setReferenceGenome(referenceGenome)
+                .setArrayName(arrayName)
+                .setSegmentSize(40)
+                .setScanFull(true)
+                .build();
+
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = query.connectExportConfiguration(exportConfiguration);
+        Assert.assertTrue(genomicsDBHandle > 0);
+
+        File vcfFile = File.createTempFile("GenomicsDBQueryTest", "");
+        File vcfIndexFile = new File(vcfFile+".tbi");
+
+        query.generateVCF(genomicsDBHandle, vcfFile.toString(), "z", true);
+
+        Assert.assertTrue(vcfFile.exists());
+        Assert.assertTrue(vcfFile.length() > 0);
+        Assert.assertTrue(vcfIndexFile.exists());
+        Assert.assertTrue(vcfIndexFile.length() > 0);
+    }
+
+    /**
+     * do here what you did in test_genomicsdb_api.cc. This test uses testGenomicsDBGenerateVCFWithPBExportConfig as a template. 
+     */
+    @Test
+    void testGenomicsDbClinVarAnnotation() {
+        GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration
+                .newBuilder()
+                .setWorkspace(workspace)
+                .setVidMappingFile(vidMapping)
+                .setCallsetMappingFile(callsetMapping)
+                .setReferenceGenome(referenceGenome)
+                .setArrayName(arrayName)
+                .setSegmentSize(40)
+                .addQueryColumnRanges(GenomicsDBColumnOrIntervalList.newBuilder()
+                        .addColumnOrIntervalList(GenomicsDBColumnOrInterval.newBuilder()
+                                .setColumnInterval(GenomicsDBColumnInterval.newBuilder()
+                                        .setTiledbColumnInterval(TileDBColumnInterval.newBuilder()
+                                                .setBegin(0)
+                                                .setEnd(1000000000)))))
+                .addAnnotationSource(AnnotationSource.newBuilder()
+                        .addAttributes("ID")
+                        .addAttributes("CLNSIG")
+                        .setIsVcf(true)
+                        .setFilename("/opt/omics.data/vcf/clinvar_20200720.vcf.gz")
+                        .setDataSource("clinvar"))
+                .addAnnotationSource(AnnotationSource.newBuilder()
+                        .addAttributes("CNT")
+                        .addAttributes("LEGACY_ID")
+                        .addAttributes("SNP")
+                        .setIsVcf(true)
+                        .setFilename("/opt/omics.data/vcf/COSMIC.vcf.bgz")
+                        .setDataSource("COSMIC"))
+                .build();
+
+        GenomicsDBQuery query = new GenomicsDBQuery();
+        long genomicsDBHandle = query.connectExportConfiguration(exportConfiguration);
+        Assert.assertTrue(genomicsDBHandle > 0);
+
+        List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, arrayName);
+        assert(intervals.size() == 0);      
+
+        List<Pair>columnRanges = new ArrayList<>();
+        columnRanges.add(new Pair(0L, 1000000000L));
+
+        List<Pair>rowRanges = new ArrayList<>();
+        rowRanges.add(new Pair(0L, 3L));
+
+        intervals = query.queryVariantCalls(genomicsDBHandle, arrayName, columnRanges, rowRanges);
+        assert (intervals.size() == 2);
+
+        //        assert(intervals.get(0)
+        //                .getCalls()
+        //                .get(2)
+        //                .getGenomicFields()
+        //                .get("clinvar_AA_CLNSIG")
+        //                .equals("Uncertain_significance"));
+
+        //        printAllGenomicFields(intervals);
+
+        query.disconnect(genomicsDBHandle);
+    }
+
+    private void printAllGenomicFields(List<Interval> intervals) {
+        int intervalNumber = 0;
+        int callNumber = 0;
+        for (Interval interval : intervals) {
+            intervalNumber++;
+            for (VariantCall call : interval.getCalls()) {
+                callNumber++;
+                for (Map.Entry<String, Object> field : call.getGenomicFields().entrySet()) {
+                    System.out.println(String.format("%d.%d: %s=%s", intervalNumber, callNumber, field.getKey(),
+                            field.getValue()));
+                }
+            }
+        }
+    }
 }

--- a/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
+++ b/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
@@ -362,18 +362,26 @@ public class GenomicsDBQueryTest {
                                                 .setBegin(0)
                                                 .setEnd(1000000000)))))
                 .addAnnotationSource(AnnotationSource.newBuilder()
+                        .setDataSource("clinvar")
+                        .setFilename("/opt/omics.data/vcf/clinvar_20200720.vcf.gz")
                         .addAttributes("ID")
                         .addAttributes("CLNSIG")
-                        .setIsVcf(true)
-                        .setFilename("/opt/omics.data/vcf/clinvar_20200720.vcf.gz")
-                        .setDataSource("clinvar"))
+                        .setIsVcf(true))
                 .addAnnotationSource(AnnotationSource.newBuilder()
+                        .setDataSource("COSMIC")
+                        .setFilename("/opt/omics.data/vcf/COSMIC.vcf.bgz")
                         .addAttributes("CNT")
                         .addAttributes("LEGACY_ID")
                         .addAttributes("SNP")
-                        .setIsVcf(true)
-                        .setFilename("/opt/omics.data/vcf/COSMIC.vcf.bgz")
-                        .setDataSource("COSMIC"))
+                        .setIsVcf(true))
+                .addAnnotationSource(AnnotationSource.newBuilder()
+                        .setDataSource("gnomAD")
+                        .setFilename("/opt/omics.data/vcf/gnomad.exomes.r2.1.1.sites.1.vcf.bgz")
+                        .addAttributes("ID")
+                        .addAttributes("variant_type")
+                        .addAttributes("AF_afr")
+                        .addAttributes("AF_female")
+                        .setIsVcf(true))
                 .build();
 
         GenomicsDBQuery query = new GenomicsDBQuery();
@@ -399,9 +407,17 @@ public class GenomicsDBQueryTest {
         //                .get("clinvar_AA_CLNSIG")
         //                .equals("Uncertain_significance"));
 
-        //        printAllGenomicFields(intervals);
+        printAllGenomicFields(intervals);
 
         query.disconnect(genomicsDBHandle);
+    }
+
+    private String[] getVariantAlts(String alt) {
+        if (alt == null) {
+            return null;
+        } else {
+            return alt.substring(1, alt.length() - 1).split(",");
+        }
     }
 
     private void printAllGenomicFields(List<Interval> intervals) {
@@ -411,8 +427,14 @@ public class GenomicsDBQueryTest {
             intervalNumber++;
             for (VariantCall call : interval.getCalls()) {
                 callNumber++;
+
+                System.out.println(String.format("Variant call: %s-%d-%s-%s", call.getContigName(),
+                        call.getGenomic_interval().getStart(),
+                        call.getGenomicFields().get("REF"),
+                        getVariantAlts((String) call.getGenomicFields().get("ALT"))[0]));
+
                 for (Map.Entry<String, Object> field : call.getGenomicFields().entrySet()) {
-                    System.out.println(String.format("%d.%d: %s=%s", intervalNumber, callNumber, field.getKey(),
+                    System.out.println(String.format("  %d.%d:  %s=%s", intervalNumber, callNumber, field.getKey(),
                             field.getValue()));
                 }
             }


### PR DESCRIPTION
These changes add the vcf annotation service to GenomicsDB. 
* I modified the signature of a few functions in genomicsdb.h. Seems like that may not be ok. 
* I didn't end up implementing the map we discussed for storing/cacheing annotation values. 
* When I view the VariantCall.genomicFields map from within GenomicsDB the annotation values are there, but when I look at the map in Java the annotation values aren't there. Could this be because the string values are out of scope and this will be resolved by creating the map for storing string values?