### PR TITLE
Move to using latest dependencies and replace travis with GitHub action badges

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,6 +1,14 @@
-name: Basic workflow to build and test GenomicsDB
+name: build
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
 
 env:
   PREREQS_ENV: ${{github.workspace}}/prereqs.sh

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -164,6 +164,7 @@ jobs:
     - name: Test
       shell: bash
       working-directory: ${{env.GENOMICSDB_BUILD_DIR}}
+      if: matrix.type == 'basic'
       run: |
         if [[ $OS_TYPE == 'ubuntu-18.04' ]]; then
           export JAVA_HOME=$JAVA_LINUX

--- a/.github/workflows/spark2.yml
+++ b/.github/workflows/spark2.yml
@@ -1,4 +1,4 @@
-name: Workflow to build and test GenomicsDB Spark API with Spark2
+name: Spark2 compatibility
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 | Master | Develop |
 | --- | --- |
-| [![Travis](https://travis-ci.org/GenomicsDB/GenomicsDB.svg?branch=master)](https://travis-ci.org/GenomicsDB/GenomicsDB) | [![Travis](https://travis-ci.org/GenomicsDB/GenomicsDB.svg?branch=develop)](https://travis-ci.org/GenomicsDB/GenomicsDB?branch=develop) |
+| [![actions](https://github.com/GenomicsDB/GenomicsDB/workflows/build/badge.svg?branch=master)](https://github.com/GenomicsDB/GenomicsDB/actions?query=branch%3Amaster) | [![actions](https://github.com/GenomicsDB/GenomicsDB/workflows/build/badge.svg?branch=develop)](https://github.com/GenomicsDB/GenomicsDB/actions?query=branch%3Adevelop) |
 | [![codecov](https://codecov.io/gh/GenomicsDB/GenomicsDB/branch/master/graph/badge.svg)](https://codecov.io/gh/GenomicsDB/GenomicsDB) | [![codecov](https://codecov.io/gh/GenomicsDB/GenomicsDB/branch/develop/graph/badge.svg)](https://codecov.io/gh/GenomicsDB/GenomicsDB/branch/develop) |
 
 GenomicsDB, originally from [Intel Health and Lifesciences](https://github.com/Intel-HLS/GenomicsDB), is built on top of a fork of [htslib](https://github.com/samtools/htslib) and a tile-based array storage system for importing, querying and transforming variant data. Variant data is sparse by nature (sparse relative to the whole genome) and using sparse array data stores is a perfect fit for storing such data. GenomicsDB is a highly performant scalable data storage written in C++ for importing, querying and transforming genomic variant data.

--- a/src/main/cpp/include/vcf/hfile_genomicsdb.h
+++ b/src/main/cpp/include/vcf/hfile_genomicsdb.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 /**@}*/
 
-  GENOMICSDB_EXPORT void *genomicsdb_filesystem_init(const char *filename);
+  GENOMICSDB_EXPORT void *genomicsdb_filesystem_init(const char *filename, int mode);
 
   GENOMICSDB_EXPORT size_t genomicsdb_filesize(void *context, const char *filename);
   

--- a/src/main/cpp/src/vcf/hfile_genomicsdb.c
+++ b/src/main/cpp/src/vcf/hfile_genomicsdb.c
@@ -20,8 +20,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "assert.h"
-
 #include "hfile_internal.h"
 #include "hfile_genomicsdb.h"
 
@@ -40,7 +38,6 @@ static ssize_t genomicsdb_read(hFILE* fpv, void *buffer, size_t nbytes) {
   if (nbytes > avail) nbytes = avail;
   if (nbytes) {
     ssize_t length = genomicsdb_filesystem_read(fp->context, fp->filename, fp->offset, buffer, nbytes);
-    assert(length == nbytes);
   }
   fp->offset += nbytes;
   return nbytes;
@@ -92,7 +89,7 @@ static hFILE *genomicsdb_open(const char *uri, const char *mode) {
     // TODO: error handling
     return NULL;
   }
-  fp->context = genomicsdb_filesystem_init(uri);
+  fp->context = genomicsdb_filesystem_init(uri, hfile_oflags(mode));
   if (fp->context == NULL) {
     free(fp);
     return NULL;

--- a/src/main/cpp/src/vcf/htslib_fs_adapter.cc
+++ b/src/main/cpp/src/vcf/htslib_fs_adapter.cc
@@ -25,6 +25,7 @@
 #include "tiledb.h"
 #include "tiledb_storage.h"
 
+#include <fcntl.h>
 #include <mutex>
 
 std::once_flag initialize_once;
@@ -41,7 +42,7 @@ void genomicsdb_htslib_plugin_initialize(const char* filename) {
   }
 }
 
-void *genomicsdb_filesystem_init(const char *filename) {
+void *genomicsdb_filesystem_init(const char *filename, int mode) {
   if (filename && filename[0] != '\0') {
     TileDB_CTX* tiledb_ctx;
     TileDB_Config tiledb_config;
@@ -53,14 +54,24 @@ void *genomicsdb_filesystem_init(const char *filename) {
     }
     // htslib plugins support only read/write of files
     if (!is_dir(tiledb_ctx, filename)) {
-      return tiledb_ctx;
+      if ((mode & O_ACCMODE) == O_RDONLY) {
+        if (is_file(tiledb_ctx, filename)) {
+          return tiledb_ctx;
+        } else {
+          tiledb_ctx_finalize(tiledb_ctx);
+          return NULL;
+        }
+      } else {
+        return tiledb_ctx;
+      }
     }
   }
   return NULL;
 }
 
 size_t genomicsdb_filesize(void *context, const char *filename) {
-  return file_size(reinterpret_cast<TileDB_CTX *>(context), filename);
+  auto size = file_size(reinterpret_cast<TileDB_CTX *>(context), filename);
+  return (size==-1)?0:size;
 }
 
 ssize_t genomicsdb_filesystem_read(void *context, const char *filename, off_t offset, void *buffer, size_t length) {

--- a/src/main/cpp/src/vcf/htslib_fs_adapter.cc
+++ b/src/main/cpp/src/vcf/htslib_fs_adapter.cc
@@ -55,6 +55,7 @@ void *genomicsdb_filesystem_init(const char *filename, int mode) {
     // htslib plugins support only read/write of files
     if (!is_dir(tiledb_ctx, filename)) {
       if ((mode & O_ACCMODE) == O_RDONLY) {
+        // Assuming file exists for O_RDONLY, otherwise return NULL
         if (is_file(tiledb_ctx, filename)) {
           return tiledb_ctx;
         } else {
@@ -70,8 +71,8 @@ void *genomicsdb_filesystem_init(const char *filename, int mode) {
 }
 
 size_t genomicsdb_filesize(void *context, const char *filename) {
-  auto size = file_size(reinterpret_cast<TileDB_CTX *>(context), filename);
-  return (size==-1)?0:size;
+  auto tiledb_ctx = reinterpret_cast<TileDB_CTX *>(context);
+  return is_file(tiledb_ctx, filename)?file_size(tiledb_ctx, filename):0;
 }
 
 ssize_t genomicsdb_filesystem_read(void *context, const char *filename, off_t offset, void *buffer, size_t length) {

--- a/src/test/cpp/src/test_htslib_plugin.cc
+++ b/src/test/cpp/src/test_htslib_plugin.cc
@@ -35,6 +35,7 @@
 #include "hfile_genomicsdb.h"
 #include "test_base.h"
 
+#include <fcntl.h>
 
 TEST_CASE_METHOD(TempDir, "test htslib plugin", "[test_htslib_plugin]") {
   // No exceptions should be thrown in genomicsdb_htslib_plugin_initialize
@@ -44,13 +45,15 @@ TEST_CASE_METHOD(TempDir, "test htslib plugin", "[test_htslib_plugin]") {
   genomicsdb_htslib_plugin_initialize("az://fdfd");  // Supported by genomicsdb via htslib plugin
   genomicsdb_htslib_plugin_initialize("dfdfd://fdfd/f"); // No support
 
-  CHECK(genomicsdb_filesystem_init(NULL) == NULL);
-  CHECK(genomicsdb_filesystem_init("") == NULL);
-  CHECK(genomicsdb_filesystem_init(get().c_str()) == NULL); // Directories not supported
-  CHECK(genomicsdb_filesystem_init("dfdfd://ddd") == NULL);
+  CHECK(genomicsdb_filesystem_init(NULL, 0) == NULL);
+  CHECK(genomicsdb_filesystem_init("", 0) == NULL);
+  CHECK(genomicsdb_filesystem_init(get().c_str(), 0) == NULL); // Directories not supported
+  CHECK(genomicsdb_filesystem_init("dfdfd://ddd", 0) == NULL);
 
   std::string filename = get()+"/foo";
-  void* ctx = genomicsdb_filesystem_init(filename.c_str());
+  CHECK(genomicsdb_filesystem_init(filename.c_str(), 0) == NULL);
+  CHECK(genomicsdb_filesystem_init(filename.c_str(), O_RDONLY) == NULL);
+  void* ctx = genomicsdb_filesystem_init(filename.c_str(), O_RDWR);
   CHECK(ctx != NULL);
 
   char buffer[16];


### PR DESCRIPTION
Moving to the latest TileDB introduced one api change with `file_size()` returning a `ssize_t` as compared to `size_t` before. Got the genomicsdb htslib plugin to react to this change and also cleaned up the initialization phase to factor in file modes and checking if the file exists to remove unnecessary TileDB warnings.

Added badges and cleaned up the basic workflow a little. 

One question, should we run MacOS tests only for PRs as the junits/jacoco are taking an inordinate amount of time? We could also just run the C/C++ tests for MacOS pushes and the entire gamut for PRs. Thoughts?