### PR TITLE
Better GenomicsDB s3 and gs url support

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -65,17 +65,15 @@ jobs:
         sudo apt install -yq openjdk-${{matrix.java}}-jdk
         echo $JAVA_LINUX/bin >> $GITHUB_PATH
 
-    - name: Cache built prerequisite artifacts like protobuf
+    - name: Cache built prerequisites
       uses: actions/cache@v2
       with:
-        path: ${{env.PREREQS_INSTALL_DIR}}
-        key: ${{matrix.os}}-cache-prereqs-v1
-
-    - name: Cache Maven artifacts
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{matrix.os}}-cache-m2-v1
+        path: |
+          ${{env.PREREQS_INSTALL_DIR}}
+           ~/.m2/repository
+          ~/awssdk-install
+          ~/gcssdk-install
+        key: ${{matrix.os}}-cache-prereqs-v2
 
     # TODO: See https://github.com/actions/cache/pull/285 using platform-indepenedent "pip cache dir"
     - name: Cache Python artifacts for Ubuntu 
@@ -99,21 +97,21 @@ jobs:
         path: ${{runner.workspace}}/hadoop-${{env.HADOOP_VER}}
         key: dfs-${{env.HADOOP_VER}}-v2
 
-    - name: Install Prerequisites ubuntu
+    - name: Install Prerequisites
       shell: bash
-      if: startsWith(matrix.os, 'ubuntu')
       working-directory: ${{github.workspace}}/scripts/prereqs
-      run: sudo INSTALL_PREFIX=$PREREQS_INSTALL_DIR PREREQS_ENV=$PREREQS_ENV ./install_prereqs.sh
-
-    - name: Install Prerequisites macos
-      shell: bash
-      if: startsWith(matrix.os, 'macos')
-      working-directory: ${{github.workspace}}/scripts/prereqs
-      run: INSTALL_PREFIX=$PREREQS_INSTALL_DIR PREREQS_ENV=$PREREQS_ENV ./install_prereqs.sh true
-
-    - name: Create Build Directory
-      shell: bash
-      run: mkdir -p $GENOMICSDB_BUILD_DIR
+      run: |
+        echo "matrix.os = ${{matrix.os}}"
+        if [[ ${{matrix.os}} == macos* ]]; then
+          echo "Installing Prerequistes for MacOS..."
+          INSTALL_PREFIX=$PREREQS_INSTALL_DIR PREREQS_ENV=$PREREQS_ENV ./install_prereqs.sh true
+        else
+          echo "Install Prerequisites for Linux.."
+          sudo INSTALL_PREFIX=$PREREQS_INSTALL_DIR PREREQS_ENV=$PREREQS_ENV ./install_prereqs.sh
+        fi
+        echo "cat prereqs env..."
+        cat $PREREQS_ENV
+        echo "cat prereqs env DONE"
 
     - name: Install spark and hadoop dependencies
       if: matrix.type == 'hdfs'
@@ -124,6 +122,10 @@ jobs:
         JAVA_HOME=$JAVA_LINUX SPARK_ENV=$SPARK_ENV source $GITHUB_WORKSPACE/.github/scripts/install_spark.sh
       env:
         INSTALL_DIR: ${{runner.workspace}}
+
+    - name: Create Build Directory
+      shell: bash
+      run: mkdir -p $GENOMICSDB_BUILD_DIR
 
     - name: Configure CMake Build ubuntu
       shell: bash
@@ -158,6 +160,9 @@ jobs:
           echo $JAVA_LINUX/bin >> $GITHUB_PATH
         fi
         source $PREREQS_ENV
+        if [[ $OS_TYPE == macos* ]]; then
+          export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
+        fi
         make -j4
         make install
 

--- a/.github/workflows/spark2.yml
+++ b/.github/workflows/spark2.yml
@@ -1,6 +1,16 @@
 name: Spark2 compatibility
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main and develop branches
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
 
 env:
   PREREQS_ENV: ${{github.workspace}}/prereqs.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2019-2020 Omics Data Automation, Inc.
+# Copyright (c) 2019-2021 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -81,8 +81,6 @@ set(GPG_PASSPHRASE "" CACHE STRING "Gpg passphrase for deploying to maven")
 set(IPPROOT "" CACHE PATH "Path to IPP libraries - used when intel optimized zlib is required")
 
 set(LIBDBI_DIR "" CACHE PATH "Path to libdbi install directory")
-
-set(ENABLE_LIBCURL True CACHE BOOL "Enable libcurl for use in htslib to read VCF files directly off S3/GCS/http(s) URLs")
 
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -186,10 +184,7 @@ if(BUILD_DISTRIBUTABLE_LIBRARY)
   set(OPENSSL_USE_STATIC_LIBS TRUE)
 endif()
 find_package(OpenSSL REQUIRED)
-
-if(ENABLE_LIBCURL)
-  find_package(CURL REQUIRED)
-endif()
+find_package(CURL REQUIRED)
 
 #RapidJSON
 find_package(RapidJSON REQUIRED)

--- a/cmake/Modules/Findhtslib.cmake
+++ b/cmake/Modules/Findhtslib.cmake
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2020 Omics Data Automation, Inc.
+# Copyright (c) 2020-2021 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -64,15 +64,11 @@ if(HTSLIB_SOURCE_DIR)
     if((NOT (CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME)) AND APPLE)
         set(HTSLIB_OSXCROSS_COMPILE_FLAGS LIBS=${OSXCROSS_LIBS} CPPFLAGS=${OSXCROSS_CPPFLAGS} --host=${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM})
     endif()
-    if(CURL_FOUND)
-      set(HTSLIB_CURL_FLAGS --enable-libcurl --enable-gcs --enable-s3)
-      set(HTSLIB_${CMAKE_BUILD_TYPE}_CFLAGS "${HTSLIB_${CMAKE_BUILD_TYPE}_CFLAGS} -I${OPENSSL_INCLUDE_DIR} -I${CURL_INCLUDE_DIRS}")
-      get_filename_component(LIBCURL_DIR ${CURL_LIBRARIES} DIRECTORY)
-      get_filename_component(LIBOPENSSL_DIR ${OPENSSL_SSL_LIBRARY} DIRECTORY)
-      set(HTSLIB_LIBS "-L${LIBOPENSSL_DIR} -Wl,-rpath,${LIBOPENSSL_DIR} -L${LIBCURL_DIR} -lcurl")
-    else()
-      set(HTSLIB_CURL_FLAGS --disable-libcurl)
-    endif()
+    set(HTSLIB_CURL_FLAGS --enable-libcurl)
+    set(HTSLIB_${CMAKE_BUILD_TYPE}_CFLAGS "${HTSLIB_${CMAKE_BUILD_TYPE}_CFLAGS} -I${OPENSSL_INCLUDE_DIR} -I${CURL_INCLUDE_DIRS}")
+    get_filename_component(LIBCURL_DIR ${CURL_LIBRARIES} DIRECTORY)
+    get_filename_component(LIBOPENSSL_DIR ${OPENSSL_SSL_LIBRARY} DIRECTORY)
+    set(HTSLIB_LIBS "-L${LIBOPENSSL_DIR} -Wl,-rpath,${LIBOPENSSL_DIR} -L${LIBCURL_DIR} -lcurl")
     ExternalProject_Add(
         htslib
         DOWNLOAD_COMMAND ""
@@ -83,7 +79,7 @@ if(HTSLIB_SOURCE_DIR)
             CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR} RANLIB=${CMAKE_RANLIB}
             ${HTSLIB_OSXCROSS_COMPILE_FLAGS}
 	    LIBS=${HTSLIB_LIBS}
-            --disable-lzma --disable-bz2
+            --disable-lzma --disable-bz2 --enable-s3=0 --enable-gcs=0
             ${HTSLIB_CURL_FLAGS}
         BUILD_COMMAND ${CMAKE_COMMAND} -E make_directory cram
             COMMAND ${CMAKE_COMMAND} -E make_directory test

--- a/src/main/cpp/src/vcf/hfile_genomicsdb.c
+++ b/src/main/cpp/src/vcf/hfile_genomicsdb.c
@@ -1,6 +1,6 @@
 /**
  * The MIT License (MIT)
- * Copyright (c) 2020 Omics Data Automation, Inc.
+ * Copyright (c) 2020-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -38,8 +38,9 @@ static ssize_t genomicsdb_read(hFILE* fpv, void *buffer, size_t nbytes) {
   if (nbytes > avail) nbytes = avail;
   if (nbytes) {
     ssize_t length = genomicsdb_filesystem_read(fp->context, fp->filename, fp->offset, buffer, nbytes);
+    fp->offset += length;
+    return length;
   }
-  fp->offset += nbytes;
   return nbytes;
 }
 
@@ -104,12 +105,14 @@ static hFILE *genomicsdb_open(const char *uri, const char *mode) {
 
 int hfile_plugin_init(struct hFILE_plugin *self) {
    static const struct hFILE_scheme_handler genomicsdb_handler =
-       { genomicsdb_open, hfile_always_remote, "GenomicsDB Storage", 10 };
+       { genomicsdb_open, hfile_always_remote, "GenomicsDB Storage", 99 };
    
   if (self) {
     self->name = "GenomicsDB Storage";
   }
   hfile_add_scheme_handler("az", &genomicsdb_handler);
   hfile_add_scheme_handler("hdfs", &genomicsdb_handler);
+  hfile_add_scheme_handler("s3", &genomicsdb_handler);
+  hfile_add_scheme_handler("gs", &genomicsdb_handler);
   return 0;
 }


### PR DESCRIPTION
1. Move to TileDB version using native client support for aws and gcs to allow for native handling of s3 and gs urls instead of piggybacking on HDFS/JNI.
2. Direct GenomicsDB support to handle `s3://`and `gs://` urls for samples instead of htslib. This allows GenomicsDB to use the standard aws/gcs sdk paradigms via TileDB to help with authentication, retries with exponential backoff, configuring credentials, endpoints, profiles, etc.
3. Github Action changes to help with building `aws` and `gcs` sdks as a prerequisite and caching them for future builds. Also, moved spark2 compatibility builds for only `master` and `develop` branches on push and pull requests.