### PR TITLE
Fix htslib cmake Module to not have lib curl dependencies and factor in trailing slash while appending file paths

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -175,8 +175,8 @@ jobs:
           export JAVA_HOME=$JAVA_LINUX
           echo $JAVA_LINUX/bin >> $GITHUB_PATH
         fi
-        python2 -m pip install --upgrade pip
-        python2 -m pip install jsondiff
+        python -m pip install --upgrade pip
+        python -m pip install jsondiff
         make test ARGS=-V
 
     - name: Test - Distributed FileSystems

--- a/.github/workflows/spark2.yml
+++ b/.github/workflows/spark2.yml
@@ -122,8 +122,8 @@ jobs:
       shell: bash
       working-directory: ${{env.GENOMICSDB_BUILD_DIR}}
       run: |
-        python2 -m pip install --upgrade pip
-        python2 -m pip install jsondiff
+        python -m pip install --upgrade pip
+        python -m pip install jsondiff
         make test ARGS=-V
 
     - name: Test - Distributed FileSystems with Spark2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,7 +564,7 @@ if(BUILD_JAVA)
 
     if(NOT DISABLE_MPI)
         add_test(NAME CI_tests
-            COMMAND python2 ${CMAKE_SOURCE_DIR}/tests/run.py
+            COMMAND python ${CMAKE_SOURCE_DIR}/tests/run.py
             ${CMAKE_BINARY_DIR}
             ${CMAKE_INSTALL_PREFIX}
             ${CMAKE_BUILD_TYPE})

--- a/cmake/Modules/Findhtslib.cmake
+++ b/cmake/Modules/Findhtslib.cmake
@@ -64,11 +64,8 @@ if(HTSLIB_SOURCE_DIR)
     if((NOT (CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME)) AND APPLE)
         set(HTSLIB_OSXCROSS_COMPILE_FLAGS LIBS=${OSXCROSS_LIBS} CPPFLAGS=${OSXCROSS_CPPFLAGS} --host=${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM})
     endif()
-    set(HTSLIB_CURL_FLAGS --enable-libcurl)
+    set(HTSLIB_CURL_FLAGS --disable-s3 --disable-gcs)
     set(HTSLIB_${CMAKE_BUILD_TYPE}_CFLAGS "${HTSLIB_${CMAKE_BUILD_TYPE}_CFLAGS} -I${OPENSSL_INCLUDE_DIR} -I${CURL_INCLUDE_DIRS}")
-    get_filename_component(LIBCURL_DIR ${CURL_LIBRARIES} DIRECTORY)
-    get_filename_component(LIBOPENSSL_DIR ${OPENSSL_SSL_LIBRARY} DIRECTORY)
-    set(HTSLIB_LIBS "-L${LIBOPENSSL_DIR} -Wl,-rpath,${LIBOPENSSL_DIR} -L${LIBCURL_DIR} -lcurl")
     ExternalProject_Add(
         htslib
         DOWNLOAD_COMMAND ""
@@ -78,8 +75,7 @@ if(HTSLIB_SOURCE_DIR)
         CONFIGURE_COMMAND ${HTSLIB_SOURCE_DIR}/configure CFLAGS=${HTSLIB_${CMAKE_BUILD_TYPE}_CFLAGS} LDFLAGS=${HTSLIB_${CMAKE_BUILD_TYPE}_LDFLAGS}
             CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR} RANLIB=${CMAKE_RANLIB}
             ${HTSLIB_OSXCROSS_COMPILE_FLAGS}
-	    LIBS=${HTSLIB_LIBS}
-            --disable-lzma --disable-bz2 --enable-s3=0 --enable-gcs=0
+            --disable-lzma --disable-bz2
             ${HTSLIB_CURL_FLAGS}
         BUILD_COMMAND ${CMAKE_COMMAND} -E make_directory cram
             COMMAND ${CMAKE_COMMAND} -E make_directory test

--- a/scripts/prereqs/install_prereqs.sh
+++ b/scripts/prereqs/install_prereqs.sh
@@ -133,7 +133,11 @@ install_openssl() {
     wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
       tar -xvzf openssl-$OPENSSL_VERSION.tar.gz &&
       cd openssl-$OPENSSL_VERSION &&
-      if [[ `uname` == "Linux" ]]; then CFLAGS=-fPIC ./config -fPIC -shared --prefix=$OPENSSL_PREFIX; else    ./Configure darwin64-x86_64-cc shared -fPIC --prefix=$OPENSSL_PREFIX; fi &&
+      if [[ `uname` == "Linux" ]]; then
+	  CFLAGS=-fPIC ./config -fPIC no-shared --prefix=$OPENSSL_PREFIX --openssldir=$OPENSSL_PREFIX
+      else
+	  ./Configure darwin64-x86_64-cc no-shared -fPIC --prefix=$OPENSSL_PREFIX
+      fi
       make && make install && echo "Installing OpenSSL DONE"
     rm -fr /tmp/openssl*
     popd
@@ -154,7 +158,7 @@ install_curl() {
     git clone https://github.com/curl/curl.git &&
       cd curl &&
       autoreconf -i &&
-      ./configure --enable-lib-only --with-pic -without-zstd --with-ssl=$OPENSSL_PREFIX --prefix $CURL_PREFIX &&
+      ./configure --disable-shared --with-pic -without-zstd --with-ssl=$OPENSSL_PREFIX --prefix $CURL_PREFIX &&
       make && make install && echo "Installing CURL DONE"
     rm -fr /tmp/curl
     popd

--- a/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
+++ b/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
- * Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ * Copyright (c) 2018-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -35,8 +35,9 @@
 #define VERIFY_OR_THROW(X) if(!(X)) throw VariantStorageManagerException(#X);
 #define METADATA_FILE_PREFIX "genomicsdb_meta"
 #define COLUMN_METADATA_FILENAME "genomicsdb_column_bounds.json"
-#define GET_OLD_METADATA_PATH(workspace, array) ((workspace)+'/'+(array)+'/' + METADATA_FILE_PREFIX + ".json")
-#define GET_METADATA_DIRECTORY(workspace, array) ((workspace)+'/'+(array)+"/genomicsdb_meta_dir")
+#define SLASHIFY(path) (path.back()!='/'?path+'/':path)
+#define GET_OLD_METADATA_PATH(workspace, array) (SLASHIFY(workspace) + SLASHIFY(array) + METADATA_FILE_PREFIX + ".json")
+#define GET_METADATA_DIRECTORY(workspace, array) (SLASHIFY(workspace) + SLASHIFY(array) +"genomicsdb_meta_dir/")
 bool is_genomicsdb_meta_file(const TileDB_CTX* tiledb_ctx, const std::string& filepath) {
   if (!filepath.empty() && filepath.back() != '/' && is_file(tiledb_ctx, filepath)) {
     std::size_t found = filepath.find_last_of("/");
@@ -331,8 +332,7 @@ int VariantArrayInfo::get_array_column_bounds(const std::string& workspace, cons
   // initialize ctx, and ensure that we've an existing workspace
   if (TileDBUtils::initialize_workspace(&ctx, workspace, false) != 1)
     return -1;
-  auto column_filepath = GET_METADATA_DIRECTORY(workspace, array)
-                           + '/' + COLUMN_METADATA_FILENAME;
+  auto column_filepath = GET_METADATA_DIRECTORY(workspace, array) + COLUMN_METADATA_FILENAME;
   char *buffer;
   rapidjson::Document json_doc;
   if (read_dim_bounds_kernel(ctx, &json_doc, &buffer, column_filepath))
@@ -449,8 +449,7 @@ void VariantArrayInfo::update_row_bounds_in_array(
     uuid_generate(value);
     char uuid_str[40];
     uuid_unparse(value, uuid_str);
-    auto metadata_filepath = GET_METADATA_DIRECTORY(m_workspace, m_name)
-                             + '/' + METADATA_FILE_PREFIX
+    auto metadata_filepath = GET_METADATA_DIRECTORY(m_workspace, m_name) + METADATA_FILE_PREFIX
                              + '_' + uuid_str +  ".json";
 
     if (write_file(m_tiledb_ctx, metadata_filepath, buffer.GetString(), strlen(buffer.GetString()))) {
@@ -507,7 +506,7 @@ void VariantArrayInfo::close_array(const bool consolidate_tiledb_array) {
       auto max_valid_row_idx_in_array = m_max_valid_row_idx_in_array;
       m_max_valid_row_idx_in_array = -1;
       update_row_bounds_in_array(lb_row_idx, max_valid_row_idx_in_array);
-      auto status = tiledb_array_consolidate(m_tiledb_ctx, (m_workspace + '/' + m_name).c_str());
+      auto status = tiledb_array_consolidate(m_tiledb_ctx, (SLASHIFY(m_workspace) + m_name).c_str());
       if (status != TILEDB_OK)
         logger.fatal(VariantStorageManagerException(
             logger.format("Error while consolidating TileDB array {}\nTileDB error message : {}",
@@ -536,13 +535,13 @@ int VariantStorageManager::open_array(const std::string& array_name, const VidMa
   auto mode_iter = VariantStorageManager::m_mode_string_to_int.find(mode);
   VERIFY_OR_THROW(mode_iter != VariantStorageManager::m_mode_string_to_int.end() && "Unknown mode of opening an array");
   auto mode_int = (*mode_iter).second;
-  if (is_array(m_tiledb_ctx, m_workspace + '/' + array_name)) {
+  if (is_array(m_tiledb_ctx, SLASHIFY(m_workspace) + array_name)) {
     //Try to open the array
     TileDB_Array* tiledb_array;
     auto status = tiledb_array_init(
                     m_tiledb_ctx,
                     &tiledb_array,
-                    (m_workspace+'/'+array_name).c_str(),
+                    (SLASHIFY(m_workspace)+array_name).c_str(),
                     mode_int, NULL,
                     0, 0);
     if (status == TILEDB_OK && mode_int == TILEDB_ARRAY_READ && query_filter.size() != 0) {
@@ -644,7 +643,7 @@ int VariantStorageManager::define_array(const VariantArraySchema* variant_array_
     // The array schema struct
     &array_schema,
     // Array name
-    (m_workspace+'/'+variant_array_schema->array_name()).c_str(),
+    (SLASHIFY(m_workspace)+variant_array_schema->array_name()).c_str(),
     // Attributes
     &(attribute_names[0]),
     // Number of attributes
@@ -693,7 +692,7 @@ int VariantStorageManager::define_array(const VariantArraySchema* variant_array_
 }
 
 void VariantStorageManager::delete_array(const std::string& array_name) {
-  if (is_array(m_tiledb_ctx, m_workspace + '/' + array_name)) {
+  if (is_array(m_tiledb_ctx, SLASHIFY(m_workspace) + array_name)) {
     if (is_file(m_tiledb_ctx, GET_OLD_METADATA_PATH(m_workspace, array_name)))
       delete_file(m_tiledb_ctx, GET_OLD_METADATA_PATH(m_workspace, array_name));
 
@@ -734,7 +733,7 @@ int VariantStorageManager::get_array_schema(const std::string& array_name, Varia
   // Get array schema
   TileDB_ArraySchema tiledb_array_schema;
   memset(&tiledb_array_schema, 0, sizeof(TileDB_ArraySchema));
-  auto status = tiledb_array_load_schema(m_tiledb_ctx, (m_workspace+'/'+array_name).c_str(),
+  auto status = tiledb_array_load_schema(m_tiledb_ctx, (SLASHIFY(m_workspace)+array_name).c_str(),
                                          &tiledb_array_schema);
   if (status != TILEDB_OK)
     return -1;
@@ -786,7 +785,7 @@ VariantArrayCellIterator* VariantStorageManager::begin(int ad, const int64_t* ra
   VERIFY_OR_THROW(static_cast<size_t>(ad) < m_open_arrays_info_vector.size() &&
                   m_open_arrays_info_vector[ad].get_array_name().length());
   auto& curr_elem = m_open_arrays_info_vector[ad];
-  return new VariantArrayCellIterator(m_tiledb_ctx, curr_elem.get_schema(), m_workspace+'/'+curr_elem.get_array_name(),
+  return new VariantArrayCellIterator(m_tiledb_ctx, curr_elem.get_schema(), SLASHIFY(m_workspace)+curr_elem.get_array_name(),
                                       range, attribute_ids, m_segment_size, query_filter);
 }
 
@@ -798,7 +797,7 @@ SingleCellTileDBIterator* VariantStorageManager::begin_columnar_iterator(
   return new SingleCellTileDBIterator(m_tiledb_ctx,
                                       use_common_array_object ? curr_elem.get_tiledb_array() : 0,
                                       curr_elem.get_vid_mapper(), curr_elem.get_schema(),
-                                      m_workspace+'/'+curr_elem.get_array_name(),
+                                      SLASHIFY(m_workspace)+curr_elem.get_array_name(),
                                       query_config, m_segment_size);
 }
 
@@ -810,7 +809,7 @@ GenomicsDBGVCFIterator* VariantStorageManager::begin_gvcf_iterator(
   return new GenomicsDBGVCFIterator(m_tiledb_ctx,
                                       use_common_array_object ? curr_elem.get_tiledb_array() : 0,
                                       curr_elem.get_vid_mapper(), curr_elem.get_schema(),
-                                      m_workspace+'/'+curr_elem.get_array_name(),
+                                      SLASHIFY(m_workspace)+curr_elem.get_array_name(),
                                       query_config, m_segment_size);
 }
 
@@ -842,7 +841,7 @@ void VariantStorageManager::write_column_bounds_to_array(const int ad, const int
   assert(static_cast<size_t>(ad) < m_open_arrays_info_vector.size() &&
          m_open_arrays_info_vector[ad].get_array_name().length());
   auto column_filepath = GET_METADATA_DIRECTORY(m_workspace, m_open_arrays_info_vector[ad].get_array_name())
-                           + '/' + COLUMN_METADATA_FILENAME;
+                         + COLUMN_METADATA_FILENAME;
   if (!is_file(m_tiledb_ctx, column_filepath)) {
     rapidjson::Document json_doc;
     json_doc.SetObject();

--- a/tests/run.py
+++ b/tests/run.py
@@ -278,7 +278,7 @@ def test_with_java_options(tmpdir, lib_path, jacoco):
     os.remove(compatDir+'/ws/__tiledb_workspace.tdb')
     query_java_options_success, stdout_string, stderr_string = run_cmd(query_command, False,
         '', print_if_error=False)
-    if (stderr_string.find('Native Stack Trace:') < 0):
+    if (str(stderr_string).find('Native Stack Trace:') < 0):
         sys.stderr.write('Query with java options did not throw expected exception: '+query_command+' failed\n')
         cleanup_and_exit(None, -1)
     sys.stdout.write("Successful\n")


### PR DESCRIPTION
After including GCS, AWS and Azure SDKs for cloud support in TileDB, remove -lcurl while building htslib as GenomicsDB relies on hts plugins and the sdks to support all gs://, s3:// and az:// paths.

Also, clean up appending cloud file paths by first checking whether the path has a trailing slash as `/` can be an object(folder or file) by itself under any folder.