### PR TITLE
Move to protobuf 3.8.0 to match gatk's version and also for use with the genomicsdb tools

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -28,14 +28,11 @@ jobs:
       matrix:
         os: [ubuntu-18.04,macos-10.15]
         type: [basic]
-        java: [8,11]
+        java: [8]
         include:
           - os: ubuntu-18.04
             type: hdfs
             java: 8
-          - os: ubuntu-18.04
-            type: hdfs
-            java: 11
 
     env: 
       OS_TYPE: ${{matrix.os}} 

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -29,7 +29,8 @@ jobs:
       matrix:
         os: [ubuntu-18.04,macos-10.15]
         type: [basic]
-        java: [8,11]
+        # java: [8,11]
+        java: [8]
         include:
           - os: ubuntu-18.04
             type: hdfs

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -28,11 +28,15 @@ jobs:
       matrix:
         os: [ubuntu-18.04,macos-10.15]
         type: [basic]
-        java: [8]
+        java: [8,11]
         include:
           - os: ubuntu-18.04
             type: hdfs
             java: 8
+          - os: ubuntu-18.04
+            type: hdfs
+            java: 11
+     fail-fast: false
 
     env: 
       OS_TYPE: ${{matrix.os}} 

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -35,9 +35,9 @@ jobs:
           - os: ubuntu-18.04
             type: hdfs
             java: 8
-          - os: ubuntu-18.04
-            type: hdfs
-            java: 11
+            #- os: ubuntu-18.04
+            #  type: hdfs
+            #  java: 11
 
     env: 
       OS_TYPE: ${{matrix.os}} 

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04,macos-10.15]
         type: [basic]
@@ -36,7 +37,6 @@ jobs:
           - os: ubuntu-18.04
             type: hdfs
             java: 11
-     fail-fast: false
 
     env: 
       OS_TYPE: ${{matrix.os}} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,10 @@ set(BUILD_JAVA False CACHE BOOL "Build Java/JNI interface for combined VCF recor
 
 set(HTSLIB_INSTALL_DIR "" CACHE PATH "Path to htslib install directory")
 
-set(GENOMICSDB_PROTOBUF_VERSION "3.0.2" CACHE STRING "Version of Google Protocol Buffer library")
-set(PROTOBUF_LIBRARY "" CACHE PATH "Path to protobuf headers and library")
-set(PROTOBUF_STATIC_LINKING True CACHE BOOL "Statically link Protobuf libraries")
+#Sync the GENOMICSDB_PROTOBUF_VERSION wirh protobuf.version in pom.xml!
+set(GENOMICSDB_PROTOBUF_VERSION "3.8.0" CACHE STRING "Version of Google Protocol Buffer library")
+set(PROTOBUF_ROOT_DIR "$ENV{HOME}/protobuf-install/${GENOMICSDB_PROTOBUF_VERSION}" CACHE PATH "Path to installed protobuf")
+set(PROTOBUF_URL "https://github.com/protocolbuffers/protobuf/archive/v${GENOMICSDB_PROTOBUF_VERSION}.zip" CACHE STRING "URL to protobuf github release")
 set(PROTOBUF_REGENERATE True CACHE BOOL "Regenerate protocol buffers C++ files")
 set(GENERATE_PROTOBUF_FILES_IN_BUILD_DIR True CACHE BOOL "Generate all protobuf files in build directory")
 
@@ -222,11 +223,6 @@ else()
   set(PROTOBUF_JAVA_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/src/main/java")
 endif()
 include_directories(${PROTOBUF_INCLUDE_DIRS})
-CHECK_IF_USING_PROTOBUF_V_3_0_0_BETA_1(USE_PROTOBUF_V_3_0_0_BETA_1)
-if(USE_PROTOBUF_V_3_0_0_BETA_1)
-  add_definitions(-DUSE_PROTOBUF_V_3_0_0_BETA_1)
-  message(STATUS "Using Protobuf v3.0.0-beta-1")
-endif()
 
 #JNI
 if(BUILD_JAVA)

--- a/cmake/Modules/FindProtobufWrapper.cmake
+++ b/cmake/Modules/FindProtobufWrapper.cmake
@@ -58,6 +58,7 @@ else()
     -Dprotobuf_BUILD_TESTS=OFF
     -DCMAKE_BUILD_TYPE=Release
     -DCMAKE_INSTALL_PREFIX=${PROTOBUF_PREFIX}
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     )
   add_dependencies(protobuf_ep protobuf_build)
 endif()

--- a/cmake/Modules/FindProtobufWrapper.cmake
+++ b/cmake/Modules/FindProtobufWrapper.cmake
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2019-2020 Omics Data Automation, Inc.
+# Copyright (c) 2019-2021 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,43 +24,44 @@
 # THE SOFTWARE.
 #
 
-if(PROTOBUF_STATIC_LINKING OR BUILD_DISTRIBUTABLE_LIBRARY)
-    if(CMAKE_VERSION VERSION_GREATER 3.10.0)
-        set(Protobuf_USE_STATIC_LIBS ON)
-    endif()
-    set(PROTOBUF_WRAPPER_LIBRARY_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
+add_custom_target(protobuf_ep)
+
+message(CHECK_START "Try finding Protobuf Library")
+
+if(PROTOBUF_ROOT_DIR)
+  set(PROTOBUF_PREFIX ${PROTOBUF_ROOT_DIR})
+elseif(DEFINED ENV{PROTOBUF_ROOT_DIR})
+  set(PROTOBUF_PREFIX $ENV{PROTOBUF_ROOT_DIR})
+endif()
+set(PROTOBUF_BIN_DIR ${PROTOBUF_PREFIX}/bin)
+set(PROTOBUF_LIB_DIR ${PROTOBUF_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+set(PROTOBUF_INCLUDE_DIR ${PROTOBUF_PREFIX}/include)
+
+if(EXISTS ${PROTOBUF_BIN_DIR}/protoc AND EXISTS ${PROTOBUF_LIB_DIR} AND EXISTS ${PROTOBUF_LIB_DIR} AND EXISTS ${PROTOBUF_INCLUDE_DIR})
+  find_package(Protobuf PATHS ${PROTOBUF_PREFIX})
+endif()
+
+if(NOT Protobuf_FOUND AND NOT PROTOBUF_PREFIX)
+  message(CHECK_FAIL "not found")
+  message(FATAL_ERROR "Try invoking cmake with -DPROTOBUF_ROOT_DIR=/path/to/protobuf or -DCMAKE_INSTALL_PREFIX=/path/to/protobuf or set environment variable PROTOBUF_ROOT_DIR before invoking cmake")
+elseif(Protobuf_FOUND)
+  message(CHECK_PASS "found ${Protobuf_VERSION}")
 else()
-    set(PROTOBUF_WRAPPER_LIBRARY_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX}) 
-endif()
-
-if (PROTOBUF_LIBRARY)
-    find_path(Protobuf_INCLUDE_DIR google/protobuf/service.h REQUIRED NO_DEFAULT_PATH PATHS "${PROTOBUF_LIBRARY}/include")
-    find_library(Protobuf_LIBRARY libprotobuf${PROTOBUF_WRAPPER_LIBRARY_SUFFIX} REQUIRED NO_DEFAULT_PATH PATHS "${PROTOBUF_LIBRARY}/lib64" "${PROTOBUF_LIBRARY}/lib")
-    find_library(Protobuf_PROTOC_LIBRARY libprotoc${PROTOBUF_WRAPPER_LIBRARY_SUFFIX} REQUIRED NO_DEFAULT_PATH PATHS "${PROTOBUF_LIBRARY}/lib64" "${PROTOBUF_LIBRARY}/lib")
-    find_program(Protobuf_PROTOC_EXECUTABLE protoc REQUIRED NO_DEFAULT_PATH PATHS "${PROTOBUF_LIBRARY}/bin")
-    include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(ProtobufWrapper "Check PROTOBUF_LIBRARY option, could not find Protobuf headers and/or binaries at ${PROTOBUF_LIBRARY}${DEFAULT_MSG}" Protobuf_INCLUDE_DIR Protobuf_LIBRARY Protobuf_PROTOC_LIBRARY Protobuf_PROTOC_EXECUTABLE)
-endif()
-
-find_package(Protobuf REQUIRED)
-
-include(CheckCXXSourceCompiles)
-function(CHECK_IF_USING_PROTOBUF_V_3_0_0_BETA_1 FLAG_VAR_NAME)
-  set(PB_test_source
-    "
-    #include <google/protobuf/util/json_util.h>
-    int main() {
-      google::protobuf::util::JsonParseOptions parse_opt;
-      parse_opt.ignore_unknown_fields = true;
-      return 0;
-    }
-    "
+   # Try building from source
+  message(CHECK_PASS "not found, building Protobuf ${GENOMICSDB_PROTOBUF_VERSION} as an external project")
+  include(ExternalProject)
+  ExternalProject_Add(protobuf_build
+    PREFIX ${PROTOBUF_PREFIX}
+    URL ${PROTOBUF_URL}
+    SOURCE_SUBDIR cmake
+    CMAKE_ARGS
+    -Dprotobuf_BUILD_TESTS=OFF
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=${PROTOBUF_PREFIX}
     )
-  set(CMAKE_REQUIRED_INCLUDES ${PROTOBUF_INCLUDE_DIRS})
-  check_cxx_source_compiles("${PB_test_source}" PROTOBUF_V3_STABLE_FOUND)
-  if(PROTOBUF_V3_STABLE_FOUND)
-    set(${FLAG_VAR_NAME} False PARENT_SCOPE)
-  else()
-    set(${FLAG_VAR_NAME} True PARENT_SCOPE)
-  endif()
-endfunction()
+  add_dependencies(protobuf_ep protobuf_build)
+endif()
+
+set(PROTOBUF_PROTOC_EXECUTABLE ${PROTOBUF_BIN_DIR}/protoc)
+set(PROTOBUF_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIR})
+set(PROTOBUF_LIBRARIES ${PROTOBUF_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}protobuf${CMAKE_STATIC_LIBRARY_SUFFIX})

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,6 @@
               <filter>
                 <artifact>*:*</artifact>
                 <excludes>
-                  <exclude>module-info.class</exclude>
                   <exclude>META-INF/*.SF</exclude>
                   <exclude>META-INF/*.DSA</exclude>
                   <exclude>META-INF/*.RSA</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,9 @@
     <htsjdk.version>2.23.0</htsjdk.version>
     <json.simple.version>[1.1.1,)</json.simple.version>
     <log4j.version>[2.13.0,)</log4j.version>
-    <protobuf.version>3.0.2</protobuf.version>
-    <protobuf_shade_version>com.google.protobufv3_0_2</protobuf_shade_version>
+    <!-- Sync the protobuf.version with GENOMICSDB_PROTOBUF_VERSION in CMakeLists.txt -->
+    <protobuf.version>3.8.0</protobuf.version>
+    <protobuf_shade_version>>org.genomicsdb.shaded.com.google.protobuf</protobuf_shade_version>
     <testng.version>6.10</testng.version>
     <gnu.getopt.version>1.0.13</gnu.getopt.version>
     <surefire.plugin.version>2.20</surefire.plugin.version>
@@ -308,6 +309,7 @@
               <filter>
                 <artifact>*:*</artifact>
                 <excludes>
+                  <exclude>module-info.class</exclude>
                   <exclude>META-INF/*.SF</exclude>
                   <exclude>META-INF/*.DSA</exclude>
                   <exclude>META-INF/*.RSA</exclude>

--- a/scripts/prereqs/install_prereqs.sh
+++ b/scripts/prereqs/install_prereqs.sh
@@ -230,8 +230,8 @@ install_prerequisites() {
   echo "1 PREREQS_ENV=$PREREQS_ENV"
   install_os_prerequisites &&
     source $PREREQS_ENV &&
-    install_mvn &&
-    install_protobuf
+    install_mvn
+#    install_protobuf
 }
 
 finalize() {

--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -1,38 +1,76 @@
+#
+# CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2021 Omics Data Automation, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
 set(PROTOBUF_PROTO_FILES
-    genomicsdb_coordinates.proto
-    genomicsdb_callsets_mapping.proto
-    genomicsdb_export_config.proto
-    genomicsdb_import_config.proto
-    genomicsdb_vid_mapping.proto
-    )
+  genomicsdb_coordinates.proto
+  genomicsdb_callsets_mapping.proto
+  genomicsdb_export_config.proto
+  genomicsdb_import_config.proto
+  genomicsdb_vid_mapping.proto
+  )
+
 if(PROTOBUF_REGENERATE)
-    PROTOBUF_GENERATE_CPP(PROTOBUF_GENERATED_CXX_SRCS PROTOBUF_GENERATED_CXX_HDRS ${PROTOBUF_PROTO_FILES})
-    set(PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}
-        CACHE INTERNAL "Path to protocol buffers generated C++ headers")
-    add_custom_target(PROTOBUF_GENERATED_CXX_TARGET DEPENDS ${PROTOBUF_GENERATED_CXX_SRCS} ${PROTOBUF_GENERATED_CXX_HDRS})
-    set(PROTOBUF_GENERATED_JAVA_SRCS
-      ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBColumn.java
-        ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBCallsetsMapProto.java
-        ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBExportConfiguration.java
-        ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBImportConfiguration.java
-        ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBVidMapProto.java
-        )
+  set(PROTO_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR})
 else()
-    set(PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/src/main/protobuf-generated/cpp/include")
-    set(PROTOBUF_GENERATED_CXX_SRCS "")
-    set(PROTOBUF_GENERATED_CXX_HDRS "")
-    foreach(PROTO_FILE ${PROTOBUF_PROTO_FILES})
-        get_filename_component(CURR_FILENAME ${PROTO_FILE} NAME_WE)
-        list(APPEND PROTOBUF_GENERATED_CXX_SRCS "protobuf-generated/cpp/src/${CURR_FILENAME}.pb.cc")
-        list(APPEND PROTOBUF_GENERATED_CXX_HDRS "${PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS}/${CURR_FILENAME}.pb.h")
-    endforeach()
-    set(PROTOBUF_GENERATED_JAVA_SRCS
-        src/main/protobuf-generated/java/org/genomicsdb/GenomicsDBCallsetsMapProto.java
-        src/main/protobuf-generated/java/org/genomicsdb/GenomicsDBExportConfiguration.java
-        src/main/protobuf-generated/java/org/genomicsdb/GenomicsDBImportConfiguration.java
-        src/main/protobuf-generated/java/org/genomicsdb/GenomicsDBVidMapProto.java
-        )
+  set(PROTO_SRC_DIR ${CMAKE_SOURCE_DIR}/src/main/protobuf-generated/cpp/src)
 endif()
+
+unset(PROTOBUF_GENERATED_CXX_SRCS)
+unset(PROTOBUF_GENERATED_CXX_HDRS )
+foreach(PROTO_FILE ${PROTOBUF_PROTO_FILES})
+  get_filename_component(CURR_FILENAME ${PROTO_FILE} NAME_WE)
+  list(APPEND PROTOBUF_GENERATED_CXX_SRCS ${PROTO_SRC_DIR}/${CURR_FILENAME}.pb.cc)
+  list(APPEND PROTOBUF_GENERATED_CXX_HDRS ${PROTO_SRC_DIR}/${CURR_FILENAME}.pb.h)
+endforeach()
+
+if(PROTOBUF_REGENERATE)
+  set(PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR})
+  add_custom_command(OUTPUT ${PROTOBUF_GENERATED_CXX_SRCS} ${PROTOBUF_GENERATED_CXX_HDRS}
+    COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --cpp_out=${CMAKE_CURRENT_BINARY_DIR} ${PROTOBUF_PROTO_FILES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Generating source/header files from .proto files"
+    DEPENDS protobuf_ep ${PROTOBUF_PROTO_FILES})
+  add_custom_target(PROTOBUF_GENERATED_CXX_TARGET DEPENDS ${PROTOBUF_GENERATED_CXX_SRCS} ${PROTOBUF_GENERATED_CXX_HDRS})
+  set(PROTOBUF_GENERATED_JAVA_SRCS
+    ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBColumn.java
+    ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBCallsetsMapProto.java
+    ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBExportConfiguration.java
+    ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBImportConfiguration.java
+    ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/org/genomicsdb/GenomicsDBVidMapProto.java
+    )
+else()
+  set(PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/src/main/protobuf-generated/cpp/include")
+  set(PROTOBUF_GENERATED_JAVA_SRCS
+    src/main/protobuf-generated/java/org/genomicsdb/GenomicsDBCallsetsMapProto.java
+    src/main/protobuf-generated/java/org/genomicsdb/GenomicsDBExportConfiguration.java
+    src/main/protobuf-generated/java/org/genomicsdb/GenomicsDBImportConfiguration.java
+    src/main/protobuf-generated/java/org/genomicsdb/GenomicsDBVidMapProto.java
+    )
+endif()
+
 set(PROTOBUF_GENERATED_CXX_SRCS ${PROTOBUF_GENERATED_CXX_SRCS} CACHE INTERNAL "Protocol buffers generated C++ sources")
 set(PROTOBUF_GENERATED_CXX_HDRS ${PROTOBUF_GENERATED_CXX_HDRS} CACHE INTERNAL "Protocol buffers generated C++ headers")
 set(PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS ${PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS} CACHE INTERNAL "Directory containing Protocol buffers generated C++ headers")


### PR DESCRIPTION
Move to protobuf 3.8.0. This features 
1. Building of protobuf from within GenomicsDB, once per version and is stored in `$HOME/protobuf-install/<Version>`, e.g. `/home/nalini/protobuf-install/3.8.0`. The protobuf version and url to the protobuf zips are cmake cache variables and can be overridden with cmake. Will also solve issues like that reported in #62.
2. Move the GitHub builds to `fail-fast=off`, so all builds get run even with build failures.
3. Turned off building Java 11 for now because of shaded protobuf package issues. [gatk builds ](https://travis-ci.com/github/broadinstitute/gatk/builds/226469302)with the published snapshot jar from this branch seem to be fine.