### PR TITLE
GitHub Actions is very slow for MacOS, so try only sanity checking the C++ parts for non-PR builds or master/develop branches

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -143,10 +143,15 @@ jobs:
           JAVA_HOME=$JAVA_LINUX
           echo $JAVA_LINUX/bin >> $GITHUB_PATH
         fi
+        # java tests take a very long time to run on MacOS, so limit running the tests to PRs and master/develop branches
+        BRANCH=${GITHUB_REF##*/}
+        if [[ ${{matrix.os}} != macos* || ${GITHUB_REF##*/} == master || ${GITHUB_REF##*/} == develop || $GITHUB_BASE_REF == master || $GITHUB_BASE_REF == develop ]]; then
+          echo "cmake BUILD_JAVA set to 1"
+          JAVA_BUILD_ARGS="-DBUILD_JAVA=1 -DGENOMICSDB_MAVEN_PROFILE=$GENOMICSDB_MAVEN_PROFILE"
+        fi
         cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX \
         -DCMAKE_PREFIX_PATH=$PREREQS_INSTALL_DIR -DGENOMICSDB_PROTOBUF_VERSION=$PROTOBUF_VERSION         \
-        -DGENOMICSDB_RELEASE_VERSION=$GENOMICSDB_RELEASE_VERSION -DBUILD_JAVA=1                          \
-        -DGENOMICSDB_MAVEN_PROFILE=$GENOMICSDB_MAVEN_PROFILE
+        -DGENOMICSDB_RELEASE_VERSION=$GENOMICSDB_RELEASE_VERSION $JAVA_BUILD_ARGS
 
     - name: Build
       working-directory: ${{env.GENOMICSDB_BUILD_DIR}}


### PR DESCRIPTION
GitHub Actions is very slow for MacOS especially running java tests, so try only sanity checking the C++ parts for non-PR builds or master/develop branches