### PR TITLE
Download hadoop from archive.apache.org

### DIFF
--- a/.github/scripts/install_hadoop.sh
+++ b/.github/scripts/install_hadoop.sh
@@ -27,7 +27,7 @@ install_prereqs() {
 }
 
 download_hadoop() {
-  wget -q http://www-eu.apache.org/dist/hadoop/common/$HADOOP/$HADOOP.tar.gz &&
+  wget -q https://archive.apache.org/dist/hadoop/common/$HADOOP/$HADOOP.tar.gz &&
   tar -xzf $HADOOP.tar.gz --directory $INSTALL_DIR &&
   echo "download_hadoop successful"
 }


### PR DESCRIPTION
Download Hadoop from the archives so we don't keep changing versions in the build when they are pulled off the main download sites. 