### PR TITLE
Address the annotation buffer issue for storing the annotation field values

### DIFF
--- a/src/main/cpp/include/api/annotation_service.h
+++ b/src/main/cpp/include/api/annotation_service.h
@@ -129,7 +129,7 @@ typedef struct annotation_source_t {
 } annotation_source_t;
 
 /**
-  Use this service to add annotations from VCF datasources to variant's genomic ields
+  Use this service to add annotations from VCF datasources to variant's genomic fields
 */
 class AnnotationService {
  public:
@@ -148,7 +148,7 @@ class AnnotationService {
   // List of configured annotation data sources
   std::vector<annotation_source_t> m_annotation_sources;
 
-  // Buffer for annotation values
+  // Buffer to store annotated field values
   std::vector<uint8_t> m_annotation_buffer;
   size_t m_annotation_buffer_size = 0;
   size_t m_annotation_buffer_remaining = 0;

--- a/src/main/cpp/include/api/annotation_service.h
+++ b/src/main/cpp/include/api/annotation_service.h
@@ -35,7 +35,6 @@
 
 #include "htslib/hts.h"
 #include "htslib/vcf.h"
-
 #include "htslib/regidx.h"
 #include "htslib/tbx.h"
 
@@ -150,6 +149,7 @@ class AnnotationService {
   std::vector<annotation_source_t> m_annotation_sources;
 
   // Buffer for annotation values
-  // TODO: This could be per attribute/field
-  std::vector<std::string> m_annotation_buffer;
+  std::vector<uint8_t> m_annotation_buffer;
+  size_t m_annotation_buffer_size = 0;
+  size_t m_annotation_buffer_remaining = 0;
 };

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -103,4 +103,5 @@ message ExportConfiguration {
   optional bool enable_shared_posixfs_optimizations = 28;
   optional SparkConfig spark_config = 29;
   repeated AnnotationSource annotation_source = 30;
+  optional uint32 annotation_buffer_size = 31 [default = 10240];
 }

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -756,10 +756,16 @@ TEST_CASE("api annotate query_variant_calls with test datasource 0", "[annotate_
   gdb->query_variant_calls(variant_annotation_processor);
   delete gdb;
 
-  // Add an info field that doesn't exist to the configuration; expect custom exception
-  annotation_source0->add_attributes()->assign("no_exist_field0");
+  // Check if exception thrown when annotation buffer size is too small to hold the annotated field values
+  config->set_annotation_buffer_size(4);
   CHECK(config->SerializeToString(&config_string));
-  config->set_array_name(array);
+  gdb = new GenomicsDB(config_string, GenomicsDB::PROTOBUF_BINARY_STRING, loader_json, 0);
+  CHECK_THROWS_AS(gdb->query_variant_calls(variant_annotation_processor), GenomicsDBException);
+  delete gdb;
+
+  // Add an info field that doesn't exist to the configuration; expect custom exception
+  config->set_annotation_buffer_size(10240);
+  annotation_source0->add_attributes()->assign("no_exist_field0");
   CHECK(config->SerializeToString(&config_string));
   gdb = new GenomicsDB(config_string, GenomicsDB::PROTOBUF_BINARY_STRING, loader_json, 0);
   CHECK_THROWS_AS(gdb->query_variant_calls(variant_annotation_processor), GenomicsDBException);


### PR DESCRIPTION
Based on [feedback in PR](https://github.com/GenomicsDB/GenomicsDB/pull/186#discussion_r740577566), the changes to m_annotation_buffer is now a std::vector<unit8_t> instead of std::vector\<std::string>. The buffer is sized to either 10K(default) or to what is specified in GenomicsDBExportConfiguration.