### PR TITLE
Fix for gatk issue #7598

### DIFF
--- a/.github/scripts/install_hadoop.sh
+++ b/.github/scripts/install_hadoop.sh
@@ -27,7 +27,7 @@ install_prereqs() {
 }
 
 download_hadoop() {
-  wget -q http://www-eu.apache.org/dist/hadoop/common/$HADOOP/$HADOOP.tar.gz &&
+  wget -q https://archive.apache.org/dist/hadoop/common/$HADOOP/$HADOOP.tar.gz &&
   tar -xzf $HADOOP.tar.gz --directory $INSTALL_DIR &&
   echo "download_hadoop successful"
 }

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -76,7 +76,7 @@ jobs:
           ~/awssdk-install
           ~/gcssdk-install
           ~/protobuf-install/${{env.PROTOBUF_VERSION}}
-        key: ${{matrix.os}}-cache-prereqs-v4
+        key: ${{matrix.os}}-cache-prereqs-v5
 
     # TODO: See https://github.com/actions/cache/pull/285 using platform-independent "pip cache dir"
     - name: Cache Python artifacts for Ubuntu 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ execute_process(
     )
 
 #Build parameters/options
-set(GENOMICSDB_RELEASE_VERSION "1.4.2-SNAPSHOT" CACHE STRING "GenomicsDB release version") #used in Maven builds
+set(GENOMICSDB_RELEASE_VERSION "1.4.3-SNAPSHOT" CACHE STRING "GenomicsDB release version") #used in Maven builds
 set(GENOMICSDB_VERSION "${GENOMICSDB_RELEASE_VERSION}-${GIT_COMMIT_HASH}" CACHE STRING "GenomicsDB full version string")
 
 set(DISABLE_MPI False CACHE BOOL "Disable use of any MPI compiler/libraries")

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <spark.exclude.files>**/org/genomicsdb/spark/v2/**.java</spark.exclude.files>
     <htsjdk.version>2.23.0</htsjdk.version>
     <json.simple.version>[1.1.1,)</json.simple.version>
-    <log4j.version>[2.13.0,)</log4j.version>
+    <log4j.version>[2.15.0,)</log4j.version>
     <!-- Sync the protobuf.version with GENOMICSDB_PROTOBUF_VERSION in CMakeLists.txt -->
     <protobuf.version>3.8.0</protobuf.version>
     <protobuf_shade_version>org.genomicsdb.shaded.com.google.protobuf</protobuf_shade_version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <spark.exclude.files>**/org/genomicsdb/spark/v2/**.java</spark.exclude.files>
     <htsjdk.version>2.23.0</htsjdk.version>
     <json.simple.version>[1.1.1,)</json.simple.version>
-    <log4j.version>[2.15.0,)</log4j.version>
+    <log4j.version>[2.16.0,)</log4j.version>
     <!-- Sync the protobuf.version with GENOMICSDB_PROTOBUF_VERSION in CMakeLists.txt -->
     <protobuf.version>3.8.0</protobuf.version>
     <protobuf_shade_version>org.genomicsdb.shaded.com.google.protobuf</protobuf_shade_version>

--- a/scripts/prereqs/install_prereqs.sh
+++ b/scripts/prereqs/install_prereqs.sh
@@ -28,7 +28,7 @@ set -e
 #    $PREREQS_ENV will set up file that can be sourced to set up the ENV for building GenomicsDB
 if [[ `uname` == "Darwin" || `id -u` -ne 0 ]]; then
   INSTALL_PREFIX=${INSTALL_PREFIX:-$HOME/genomicsdb_prereqs}
-  MAVEN_INSTALL_PREFIX=INSTALL_PREFIX
+  MAVEN_INSTALL_PREFIX=$INSTALL_PREFIX
   PREREQS_ENV=${PREREQS_ENV:-$HOME/genomicsdb_prereqs.sh}
   echo "GenomicsDB dependencies(e.g. maven, protobuf, etc. that are built from source will be installed to \$INSTALL_PREFIX=$INSTALL_PREFIX"
   echo "GenomicsDB environment will be persisted to \$PREREQS_ENV=$PREREQS_ENV"

--- a/src/main/java/org/genomicsdb/importer/GenomicsDBImporter.java
+++ b/src/main/java/org/genomicsdb/importer/GenomicsDBImporter.java
@@ -612,10 +612,8 @@ public class GenomicsDBImporter extends GenomicsDBImporterJni implements JsonFil
 
     /**
      * Import multiple chromosome interval
-     *
-     * @throws InterruptedException when there is an exception in any of the threads in the stream
      */
-    public void executeImport() throws InterruptedException {
+    public void executeImport()  {
         executeImport(0);
     }
 
@@ -623,7 +621,7 @@ public class GenomicsDBImporter extends GenomicsDBImporterJni implements JsonFil
      * Import multiple chromosome interval
      * @param numThreads number of threads used to import partitions
      */
-    public void executeImport(final int numThreads) throws InterruptedException {
+    public void executeImport(final int numThreads) {
         final int batchSize = this.config.getBatchSize();
         final int sampleCount = this.config.getSampleNameToVcfPath().size();
         final int updatedBatchSize = (batchSize <= 0) ? sampleCount : Math.min(batchSize, sampleCount);

--- a/src/main/java/org/genomicsdb/importer/extensions/CallSetMapExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/CallSetMapExtensions.java
@@ -11,8 +11,6 @@ import java.net.URI;
 import java.util.*;
 
 import static com.googlecode.protobuf.format.JsonFormat.*;
-import static org.genomicsdb.GenomicsDBUtils.readEntireFile;
-import static org.genomicsdb.GenomicsDBUtils.writeToFile;
 
 public interface CallSetMapExtensions {
     /**

--- a/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -53,7 +53,6 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.junit.Rule;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;

--- a/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -22,6 +22,7 @@
 
 package org.genomicsdb.importer;
 
+import com.googlecode.protobuf.format.JsonFormat;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.variant.bcf2.BCF2Codec;
@@ -52,6 +53,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.junit.Rule;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -94,6 +96,50 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
         Assert.assertEquals(importer.isDone(), true);
         File callsetFile = new File(tempCallsetJsonFile.getAbsolutePath());
         Assert.assertTrue(callsetFile.exists());
+    }
+
+    @Test(expectedExceptions = GenomicsDBException.class)
+    public void testWriteVidMapJSONToNonexistentFolders() throws FileNotFoundException, JsonFormat.ParseException, InterruptedException {
+        GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
+                GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
+        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
+        String inputVCF = "tests/inputs/vcfs/t6.vcf.gz";
+        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport("", inputVCF, false);
+        File nonExistentFolder = new File(WORKSPACE, "non-existent-folder");
+        importer.writeVidMapJSONFile(new File(nonExistentFolder, "vidmap.json").getAbsolutePath(),
+                importer.generateVidMapFromMergedHeader(mergedHeader));
+        importer.writeVcfHeaderFile(tempVcfHeaderFile.getAbsolutePath(), mergedHeader);
+        importer.writeCallsetMapJSONFile(tempCallsetJsonFile.getAbsolutePath(), callsetMappingPB_A);
+        importer.executeImport();
+    }
+
+    @Test(expectedExceptions = GenomicsDBException.class)
+    public void testWriteCallsetJSONToNonexistentFolders() throws FileNotFoundException, JsonFormat.ParseException, InterruptedException {
+        GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
+                GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
+        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
+        String inputVCF = "tests/inputs/vcfs/t6.vcf.gz";
+        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport("", inputVCF, false);
+        File nonExistentFolder = new File(WORKSPACE, "non-existent-folder");
+        importer.writeVidMapJSONFile(tempVidJsonFile.getAbsolutePath(), importer.generateVidMapFromMergedHeader(mergedHeader));
+        importer.writeVcfHeaderFile(tempVcfHeaderFile.getAbsolutePath(), mergedHeader);
+        importer.writeCallsetMapJSONFile(new File(nonExistentFolder, "callset.json").getAbsolutePath(), callsetMappingPB_A);
+        importer.executeImport();
+    }
+
+    @Test(expectedExceptions = GenomicsDBException.class)
+    public void testVCFHeaderToNonexistentFolders() throws FileNotFoundException, JsonFormat.ParseException, InterruptedException {
+        GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
+                GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
+        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
+        String inputVCF = "tests/inputs/vcfs/t6.vcf.gz";
+        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport("", inputVCF, false);
+        File nonExistentFolder = new File(WORKSPACE, "non-existent-folder");
+        importer.writeVidMapJSONFile(tempVidJsonFile.getAbsolutePath(),
+                importer.generateVidMapFromMergedHeader(mergedHeader));
+        importer.writeVcfHeaderFile(new File(nonExistentFolder, "header.vcf").getAbsolutePath(), mergedHeader);
+        importer.writeCallsetMapJSONFile(tempCallsetJsonFile.getAbsolutePath(), callsetMappingPB_A);
+        importer.executeImport();
     }
 
     @Test(testName = "genomicsdb importer outputs merged headers as a JSON file",


### PR DESCRIPTION
This is a fix for broadinstitute/gatk#7598. We throw exceptions allowing for an abort/exit when any of the jsons or vcfheader template cannot be persisted for any reason e.g.

```
14:01:25.031 INFO  NativeLibraryLoader - Loading libgkl_compression.dylib from jar:file:/Users/nalini/gatk/build/install/gatk/lib/gkl-0.8.8.jar!/com/intel/gkl/native/libgkl_compression.dylib
14:01:25.332 INFO  GenomicsDBImport - ------------------------------------------------------------
14:01:25.332 INFO  GenomicsDBImport - The Genome Analysis Toolkit (GATK) v4.2.2.0-34-g964b5d7-SNAPSHOT
14:01:25.332 INFO  GenomicsDBImport - For support and documentation go to https://software.broadinstitute.org/gatk/
14:01:25.332 INFO  GenomicsDBImport - Executing as nalini@ng on Mac OS X v10.16 x86_64
14:01:25.333 INFO  GenomicsDBImport - Java runtime: Java HotSpot(TM) 64-Bit Server VM v1.8.0_144-b01
14:01:25.333 INFO  GenomicsDBImport - Start Date/Time: December 17, 2021 2:01:24 PM PST
14:01:25.333 INFO  GenomicsDBImport - ------------------------------------------------------------
14:01:25.333 INFO  GenomicsDBImport - ------------------------------------------------------------
14:01:25.333 INFO  GenomicsDBImport - HTSJDK Version: 2.24.1
14:01:25.333 INFO  GenomicsDBImport - Picard Version: 2.25.4
14:01:25.333 INFO  GenomicsDBImport - Built for Spark Version: 2.4.5
14:01:25.333 INFO  GenomicsDBImport - HTSJDK Defaults.COMPRESSION_LEVEL : 2
14:01:25.333 INFO  GenomicsDBImport - HTSJDK Defaults.USE_ASYNC_IO_READ_FOR_SAMTOOLS : false
14:01:25.334 INFO  GenomicsDBImport - HTSJDK Defaults.USE_ASYNC_IO_WRITE_FOR_SAMTOOLS : true
14:01:25.334 INFO  GenomicsDBImport - HTSJDK Defaults.USE_ASYNC_IO_WRITE_FOR_TRIBBLE : false
14:01:25.334 INFO  GenomicsDBImport - Deflater: IntelDeflater
14:01:25.334 INFO  GenomicsDBImport - Inflater: IntelInflater
14:01:25.334 INFO  GenomicsDBImport - GCS max retries/reopens: 20
14:01:25.334 INFO  GenomicsDBImport - Requester pays: disabled
14:01:25.334 INFO  GenomicsDBImport - Initializing engine
14:01:25.596 INFO  IntervalArgumentCollection - Processing 10000 bp from intervals
14:01:25.599 INFO  GenomicsDBImport - Done initializing engine
14:01:26.006 INFO  GenomicsDBLibLoader - GenomicsDB native library version : 1.4.3-SNAPSHOT-c8f1e512
14:01:26.007 INFO  GenomicsDBImport - Vid Map JSON file will be written to /Users/nalini/gatk/ws1/vidmap.json
14:01:26.007 INFO  GenomicsDBImport - Callset Map JSON file will be written to /Users/nalini/gatk/ws1/foo/callset.json
14:01:26.007 INFO  GenomicsDBImport - Complete VCF Header will be written to /Users/nalini/gatk/ws1/vcfheader.vcf
14:01:26.007 INFO  GenomicsDBImport - Importing to workspace - /Users/nalini/gatk/ws1
14:01:26.234 INFO  GenomicsDBImport - Importing batch 1 with 1 samples
14:01:26.310 INFO  GenomicsDBImport - Done importing batch 1/1
[TileDB::FileSystem] Error: (write_to_file) Cannot write to file; File opening error path=/Users/nalini/gatk/ws1/foo/callset.json errno=2(No such file or directory)
14:01:26.310 INFO  GenomicsDBImport - Shutting down engine
[December 17, 2021 2:01:26 PM PST] org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBImport done. Elapsed time: 0.02 minutes.
Runtime.totalMemory()=335020032
***********************************************************************

A USER ERROR has occurred: Error with GenomicsDBImport

***********************************************************************
Set the system property GATK_STACKTRACE_ON_USER_EXCEPTION (--java-options '-DGATK_STACKTRACE_ON_USER_EXCEPTION=true') to print the stack trace.

```