### PR TITLE
Add support for running gperf heap profiler from the tools.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,8 +303,8 @@ if(USE_GPERFTOOLS OR USE_GPERFTOOLS_HEAP)
 endif()
 
 #Collect memory consumption stats while producing combined VCF records
-if(DO_MEMORY_message)
-    PROFILING(STATUS "Enabling memory consumption profiling while producing combined VCF records")
+if(DO_MEMORY_PROFILING)
+    message(STATUS "Enabling memory consumption profiling while producing combined VCF records")
     add_definitions(-DDO_MEMORY_PROFILING=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2019-2021 Omics Data Automation, Inc.
+# Copyright (c) 2019-2022 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -74,8 +74,12 @@ set(LIBCSV_DIR "" CACHE PATH "Path to libcsv header and library")
 set(DO_PROFILING False CACHE BOOL "Collect some stats during execution - doesn't add much overhead")
 set(COUNT_NUM_CELLS_BETWEEN_TWO_CELLS_FROM_THE_SAME_ROW False CACHE BOOL "Counting #cells traversed in columnar iterator")
 set(PROFILE_NUM_CELLS_TO_TRAVERSE_AT_EVERY_QUERY_INTERVAL False CACHE BOOL "Counting #cells traversed in columnar iterator in sliding window")
-set(USE_GPERFTOOLS False CACHE BOOL "Collect profiling information using gperftools")
 set(DO_MEMORY_PROFILING False CACHE BOOL "Collect memory consumption in parts of the combine gVCF program - high overhead")
+
+#See https://gperftools.github.io/gperftools/cpuprofile.html
+set(USE_GPERFTOOLS False CACHE BOOL "Collect profiling information using gperftools/profiler for analysis with pprof")
+#See https://gperftools.github.io/gperftools/heapprofile.html
+set(USE_GPERFTOOLS_HEAP False CACHE BOOL "Collect heap profiling information using gperftools/tcmalloc for analysis with pprof")
 
 set(GENOMICSDB_MAVEN_BUILD_DIR ${CMAKE_BINARY_DIR}/target CACHE PATH "Path to maven build directory")
 set(MAVEN_QUIET False CACHE BOOL "Do not print mvn messages")
@@ -279,20 +283,28 @@ if(DO_PROFILING)
     endif()
 endif()
 
-if(USE_GPERFTOOLS)
+#Collect stats to use with gperf/pprof
+#See https://gperftools.github.io/gperftools/cpuprofile.html
+#See https://gperftools.github.io/gperftools/heapprofile.html
+if(USE_GPERFTOOLS OR USE_GPERFTOOLS_HEAP)
     find_package(GPerftools)
-    if(GPERFTOOLS_FOUND)
+    if(GPERFTOOLS_FOUND OR GPERFTOOLS_HEAP_FOUND)
         message(STATUS "Enabling profiling using GPerftools")
-    add_definitions(-DUSE_GPERFTOOLS)
         include_directories(${GPERFTOOLS_INCLUDE_DIR})
+        if(USE_GPERFTOOLS)
+            add_definitions(-DUSE_GPERFTOOLS)
+        endif()
+        if(USE_GPERFTOOLS_HEAP)
+            add_definitions(-DUSE_GPERFTOOLS_HEAP)
+        endif()
     else()
         message(WARNING "GPerftools headers/library not found")
     endif()
 endif()
 
 #Collect memory consumption stats while producing combined VCF records
-if(DO_MEMORY_PROFILING)
-    message(STATUS "Enabling memory consumption profiling while producing combined VCF records")
+if(DO_MEMORY_message)
+    PROFILING(STATUS "Enabling memory consumption profiling while producing combined VCF records")
     add_definitions(-DDO_MEMORY_PROFILING=1)
 endif()
 
@@ -396,6 +408,9 @@ function(build_GenomicsDB_links target)
     endif()
     if(USE_GPERFTOOLS AND GPERFTOOLS_FOUND)
         target_link_libraries(${target} ${GPERFTOOLS_PROFILER_LIBRARY})
+    endif()
+    if(USE_GPERFTOOLS_HEAP AND GPERFTOOLS_FOUND)
+        target_link_libraries(${target} ${GPERFTOOLS_HEAP_PROFILER_LIBRARY})
     endif()
     target_link_libraries(${target} ${GENOMICSDB_EXTERNAL_DEPENDENCIES_LIBRARIES})
 endfunction()

--- a/cmake/Modules/FindGPerftools.cmake
+++ b/cmake/Modules/FindGPerftools.cmake
@@ -1,8 +1,43 @@
+#
+# FindGPerftools.cmake
+#
+# The MIT License
+#
+# Copyright (c) 2022 Omics Data Automation, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
 # Determine compiler flags for gperftools
 # Once done this will define
 # GPERFTOOLS_FOUND - gperftools found
+#
 
-find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/profiler.h HINTS "${GPERFTOOLS_DIR}" "${GPERFTOOLS_DIR}/include")
-find_library(GPERFTOOLS_PROFILER_LIBRARY NAMES profiler HINTS "${GPERFTOOLS_DIR}" "${GPERFTOOLS_DIR}/lib64" "${GPERFTOOLS_DIR}/lib")
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GPerftools "Could not find gperftools headers and/or libraries ${DEFAULT_MSG}" GPERFTOOLS_INCLUDE_DIR GPERFTOOLS_PROFILER_LIBRARY)
+if (USE_GPERFTOOLS)
+  find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/profiler.h HINTS "${GPERFTOOLS_DIR}" "${GPERFTOOLS_DIR}/include")
+  find_library(GPERFTOOLS_PROFILER_LIBRARY NAMES profiler HINTS "${GPERFTOOLS_DIR}" "${GPERFTOOLS_DIR}/lib64" "${GPERFTOOLS_DIR}/lib")
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(GPerftools "Could not find gperftools headers and/or libraries ${DEFAULT_MSG}" GPERFTOOLS_PROFILER_LIBRARY GPERFTOOLS_INCLUDE_DIR)
+endif()
+
+if (USE_GPERFTOOLS_HEAP)
+  find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/tcmalloc.h HINTS "${GPERFTOOLS_DIR}" "${GPERFTOOLS_DIR}/include")
+  find_library(GPERFTOOLS_HEAP_PROFILER_LIBRARY NAMES tcmalloc HINTS "${GPERFTOOLS_DIR}" "${GPERFTOOLS_DIR}/lib64" "${GPERFTOOLS_DIR}/lib")
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(GPerftools "Could not find gperftools heap headers and/or libraries ${DEFAULT_MSG}" GPERFTOOLS_HEAP_PROFILER_LIBRARY GPERFTOOLS_INCLUDE_DIR)
+endif()

--- a/cmake/Modules/Findlibcsv.cmake
+++ b/cmake/Modules/Findlibcsv.cmake
@@ -1,3 +1,28 @@
+#
+# Findlibcsv.cmake
+#
+# The MIT License
+#
+# Copyright (c) 2022 Omics Data Automation, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
 # Determine compiler flags for libcsv
 # Once done this will define
 # LIBCSV_FOUND - libcsv found
@@ -5,4 +30,4 @@
 find_path(LIBCSV_INCLUDE_DIR NAMES csv.h HINTS "${LIBCSV_DIR}/include" "${LIBCSV_DIR}")
 find_library(LIBCSV_LIBRARY NAMES csv HINTS "${LIBCSV_DIR}/lib" "${LIBCSV_DIR}/.libs" "${LIBCSV_DIR}")
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(libcsv "Could not find libcsv headers and/or libraries ${DEFAULT_MSG}" LIBCSV_INCLUDE_DIR LIBCSV_LIBRARY)
+find_package_handle_standard_args(libcsv "Could not find libcsv headers and/or libraries ${DEFAULT_MSG}" LIBCSV_LIBRARY LIBCSV_INCLUDE_DIR)

--- a/src/main/cpp/src/loader/load_operators.cc
+++ b/src/main/cpp/src/loader/load_operators.cc
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
- * Copyright (c) 2020 Omics Data Automation, Inc.
+ * Copyright (c) 2020, 2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -27,6 +27,7 @@
 #define ONE_GB (1024ull*1024ull*1024ull)
 
 #ifdef DO_MEMORY_PROFILING
+#include "genomicsdb_logger.h"
 #include "memory_measure.h"
 #endif
 

--- a/tools/src/vcf2genomicsdb.cc
+++ b/tools/src/vcf2genomicsdb.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2021-2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -27,6 +28,10 @@
 
 #ifdef USE_GPERFTOOLS
 #include "gperftools/profiler.h"
+#endif
+
+#ifdef USE_GPERFTOOLS_HEAP
+#include "gperftools/heap-profiler.h"
 #endif
 
 extern bool g_show_import_progress;
@@ -164,7 +169,10 @@ int main(int argc, char** argv) {
     }
     auto loader_json_config_file = std::move(std::string(argv[optind]));
 #ifdef USE_GPERFTOOLS
-    ProfilerStart("gprofile.log");
+    ProfilerStart("vcf2genomicsdb.gperf.prof");
+#endif
+#ifdef USE_GPERFTOOLS_HEAP
+    HeapProfilerStart("vcf2genomicsdb.gperf.heap");
 #endif
     //Split files as per the partitions defined - don't load data
     if (split_files) {
@@ -203,6 +211,9 @@ int main(int argc, char** argv) {
       VCF2TileDBLoader loader(loader_json_config_file, my_world_mpi_rank);
       loader.read_all();
     }
+#ifdef USE_GPERFTOOLS_HEAP
+    HeapProfilerStop();
+#endif
 #ifdef USE_GPERFTOOLS
     ProfilerStop();
 #endif


### PR DESCRIPTION
1. Add support for running gperf/heap profiler with tools - `vcf2genomicsdb` and `gt_mpi_gather`. The generated profiles are named `\<toolname\>.gperf.heap` for heap profiler and `\<toolname\>.gperf.prof` for the default(cpu) profiler.
2. Pull in fix with book_keeping and cloud URLs.
3. Minor cleanup.