### PR TITLE
Support buffer/batch sizes and enabling shared posixfs optimizations in the consolidate_genomicsdb_array tool and from the Importer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ execute_process(
     )
 
 #Build parameters/options
-set(GENOMICSDB_RELEASE_VERSION "1.4.3-SNAPSHOT" CACHE STRING "GenomicsDB release version") #used in Maven builds
+set(GENOMICSDB_RELEASE_VERSION "1.4.4-SNAPSHOT" CACHE STRING "GenomicsDB release version") #used in Maven builds
 set(GENOMICSDB_VERSION "${GENOMICSDB_RELEASE_VERSION}-${GIT_COMMIT_HASH}" CACHE STRING "GenomicsDB full version string")
 
 set(DISABLE_MPI False CACHE BOOL "Disable use of any MPI compiler/libraries")

--- a/src/main/cpp/include/genomicsdb/variant_storage_manager.h
+++ b/src/main/cpp/include/genomicsdb/variant_storage_manager.h
@@ -147,7 +147,9 @@ class VariantArrayInfo {
   ~VariantArrayInfo() {
     close_array();
   }
-  void close_array(const bool consolidate_tiledb_array=false);
+  void close_array(const bool consolidate_tiledb_array=false,
+                   const size_t consolidate_buffer_size=TILEDB_CONSOLIDATION_BUFFER_SIZE,
+                   const int consolidation_batch_size=-1);
   void set_schema(const VariantArraySchema& schema) {
     m_schema = schema;
     m_cell = std::move(BufferVariantCell(m_schema));
@@ -234,7 +236,8 @@ class VariantStorageManager {
   VariantStorageManager(VariantStorageManager&& other) = delete;
 
   int open_array(const std::string& array_name, const VidMapper* vid_mapper, const char* mode, const std::string& query_filter=std::string());
-  void close_array(const int ad, const bool consolidate_tiledb_array=false);
+  void close_array(const int ad, const bool consolidate_tiledb_array=false,
+                   const int consolidation_batch_size=-1);
   int define_array(const VariantArraySchema* variant_array_schema,
                    const size_t num_cells_per_tile=1000u,
                    const bool disable_delta_encode_for_offsets=false,

--- a/src/main/cpp/include/loader/tiledb_loader.h
+++ b/src/main/cpp/include/loader/tiledb_loader.h
@@ -360,7 +360,9 @@ class VCF2TileDBLoader : public VCF2TileDBLoaderConverterBase {
   /*
    * Consolidate TileDB array
    */
-  static void consolidate_tiledb_array(const char* workspace, const char* array_name);
+  static void consolidate_tiledb_array(const char* workspace, const char* array_name,
+                                       const size_t buffer_size, const int batch_size,
+                                       const bool enable_shared_posixfs_optimzations);
  private:
   void common_constructor_initialization(
     const std::string& config_filename,

--- a/src/main/cpp/include/loader/tiledb_loader.h
+++ b/src/main/cpp/include/loader/tiledb_loader.h
@@ -361,8 +361,9 @@ class VCF2TileDBLoader : public VCF2TileDBLoaderConverterBase {
    * Consolidate TileDB array
    */
   static void consolidate_tiledb_array(const char* workspace, const char* array_name,
-                                       const size_t buffer_size, const int batch_size,
-                                       const bool enable_shared_posixfs_optimzations);
+                                       const size_t buffer_size=TILEDB_CONSOLIDATION_BUFFER_SIZE,
+                                       const int batch_size=-1,
+                                       const bool enable_shared_posixfs_optimzations=false);
  private:
   void common_constructor_initialization(
     const std::string& config_filename,

--- a/src/main/cpp/include/utils/genomicsdb_logger.h
+++ b/src/main/cpp/include/utils/genomicsdb_logger.h
@@ -33,6 +33,11 @@
 #ifndef GENOMICSDB_LOGGER
 #define GENOMICSDB_LOGGER
 
+// Override spdlog level names to upper case for consistency with log4j from Java
+#if !defined(SPDLOG_LEVEL_NAMES)
+#define SPDLOG_LEVEL_NAMES { "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "OFF" }
+#endif
+
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/fmt/fmt.h>

--- a/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
+++ b/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
@@ -111,7 +111,7 @@ VariantArrayCellIterator::VariantArrayCellIterator(TileDB_CTX* tiledb_ctx, const
                   query_filter.c_str());
   if (status != TILEDB_OK) {
     logger.fatal(VariantStorageManagerException(
-        logger.format("Error while initializing TileDB iterator\nTileDB error message : {}",
+        logger.format("Error while initializing TileDB iterator : {}",
                       tiledb_errmsg)));
   }
 #ifdef DEBUG
@@ -135,7 +135,7 @@ const BufferVariantCell& VariantArrayCellIterator::operator*() {
                   reinterpret_cast<const void**>(&field_ptr), &field_size);
     if (status != TILEDB_OK)
       logger.fatal(VariantStorageManagerException(
-          logger.format("Error while getting value from TileDB iterator for field with query index {}\nTileDB error message : {}",
+          logger.format("Error while getting value from TileDB iterator for field with query index {} : {}",
                         i, tiledb_errmsg)));
     m_cell.set_field_ptr_for_query_idx(i, field_ptr);
     m_cell.set_field_size_in_bytes(i, field_size);
@@ -145,7 +145,7 @@ const BufferVariantCell& VariantArrayCellIterator::operator*() {
                 reinterpret_cast<const void**>(&field_ptr), &field_size);
   if (status != TILEDB_OK)
       logger.fatal(VariantStorageManagerException(
-          logger.format("Error while getting coordinate value from TileDB iterator\nTileDB error message : {}",
+          logger.format("Error while getting coordinate value from TileDB iterator : {}",
                         tiledb_errmsg)));
   assert(field_size == m_variant_array_schema->dim_size_in_bytes());
   auto coords_ptr = reinterpret_cast<const int64_t*>(field_ptr);
@@ -259,8 +259,7 @@ void VariantArrayInfo::write_cell(const void* ptr) {
     auto status = tiledb_array_write(m_tiledb_array, const_cast<const void**>(&(m_buffer_pointers[0])), &(m_buffer_offsets[0]));
     if (status != TILEDB_OK)
       logger.fatal(VariantStorageManagerException(
-          logger.format("Error while writing to TileDB array\nTileDB error message : {}",
-                        tiledb_errmsg)));
+          logger.format("Error while writing to GenomicsDB array : {}", tiledb_errmsg)));
     memset(&(m_buffer_offsets[0]), 0, m_buffer_offsets.size()*sizeof(size_t));
   }
   buffer_idx = 0;
@@ -454,13 +453,12 @@ void VariantArrayInfo::update_row_bounds_in_array(
 
     if (write_file(m_tiledb_ctx, metadata_filepath, buffer.GetString(), strlen(buffer.GetString()))) {
       logger.fatal(VariantStorageManagerException(
-          logger.format("Could not write to metadata file {}\nTileDB error message : {}",
-                        metadata_filepath, tiledb_errmsg)));
+          logger.format("Could not write to metadata file {} : {}", metadata_filepath, tiledb_errmsg)));
     };
 
     if (close_file(m_tiledb_ctx, metadata_filepath)) {
       logger.fatal(VariantStorageManagerException(
-          logger.format("Could not close after write to metadata file {}\nTileDB error message : {}",
+          logger.format("Could not close after write to metadata file {} : {}",
                         metadata_filepath, tiledb_errmsg)));
     }
   }
@@ -476,23 +474,21 @@ void VariantArrayInfo::close_array(const bool consolidate_tiledb_array,
       auto status = tiledb_array_write(m_tiledb_array, const_cast<const void**>(&(m_buffer_pointers[0])), &(m_buffer_offsets[0]));
       if (status != TILEDB_OK)
         logger.fatal(VariantStorageManagerException(
-            logger.format("Error while writing to array {}\nTileDB error message : {}",
-                          m_name, tiledb_errmsg)));
+            logger.format("Error while writing to GenomicsDB array {} : {}", m_name, tiledb_errmsg)));
       memset(&(m_buffer_offsets[0]), 0, m_buffer_offsets.size()*sizeof(size_t));
     }
     auto sync_status = tiledb_array_sync(m_tiledb_array);
     if (sync_status != TILEDB_OK)
       logger.fatal(VariantStorageManagerException(
-          logger.format("Error while syncing array {} to disk\nTileDB error message : {}",
-                        m_name, tiledb_errmsg)));
+          logger.format("Error while syncing array {} to disk : {}", m_name, tiledb_errmsg)));
   }
   if (m_tiledb_array) {
     auto status = tiledb_array_finalize(m_tiledb_array);
     if (status != TILEDB_OK)
       logger.fatal(VariantStorageManagerException(
-          logger.format("Error while finalizing TileDB array {}\nTileDB error message : {}",
-                        m_name, tiledb_errmsg)));
+          logger.format("Error while finalizing GenomicsDB array {} : {}", m_name, tiledb_errmsg)));
     if (consolidate_tiledb_array) {
+      logger.info("Consolidating GenomicsDB array {} in workspace {}",  m_name, m_workspace);
       //Consolidate metadb entries as well
       std::vector<std::string> files = get_files(m_tiledb_ctx, GET_METADATA_DIRECTORY(m_workspace, m_name));
       for (auto filepath : files) {
@@ -512,8 +508,7 @@ void VariantArrayInfo::close_array(const bool consolidate_tiledb_array,
                                              consolidate_buffer_size, consolidation_batch_size);
       if (status != TILEDB_OK)
         logger.fatal(VariantStorageManagerException(
-            logger.format("Error while consolidating TileDB array {}\nTileDB error message : {}",
-                          m_name, tiledb_errmsg)));
+            logger.format("Error while consolidating GenomicsDB array {} : {}", m_name, tiledb_errmsg)));
     }
   }
   m_tiledb_array = 0;
@@ -529,8 +524,7 @@ VariantStorageManager::VariantStorageManager(const std::string& workspace, const
 
   if (TileDBUtils::initialize_workspace(&m_tiledb_ctx, workspace, false, enable_shared_posixfs_optimizations) < 0 || m_tiledb_ctx == NULL) {
     logger.fatal(VariantStorageManagerException(
-        logger.format("Error while creating TileDB workspace {}\nTileDB error message : {}",
-                      workspace, tiledb_errmsg)));
+        logger.format("Error while creating workspace {} : {}", workspace, tiledb_errmsg)));
   }
 }
 
@@ -706,7 +700,7 @@ void VariantStorageManager::delete_array(const std::string& array_name) {
     auto status = tiledb_delete(m_tiledb_ctx, (m_workspace+"/"+array_name).c_str());
     if (status != TILEDB_OK)
       logger.fatal(VariantStorageManagerException(
-          logger.format("Error while deleting TileDB array {}\nTileDB error message : {}",
+          logger.format("Error while deleting GenomicsDB array {} : {}",
                         m_workspace+"/"+array_name, tiledb_errmsg)));
   }
 }
@@ -719,8 +713,7 @@ int VariantStorageManager::define_metadata_schema(const VariantArraySchema* vari
   auto status = create_dir(m_tiledb_ctx, meta_dir);
   if (status != TILEDB_OK)
     logger.fatal(VariantStorageManagerException(
-        logger.format("Could not create GenomicsDB meta-data directory\nTileDB error message : {}",
-                      tiledb_errmsg)));
+        logger.format("Could not create GenomicsDB metadata directory : {}", tiledb_errmsg)));
   return TILEDB_OK;
 }
 
@@ -857,8 +850,7 @@ void VariantStorageManager::write_column_bounds_to_array(const int ad, const int
   
     if (write_file(m_tiledb_ctx, column_filepath, buffer.GetString(), strlen(buffer.GetString()))) {
       logger.fatal(VariantStorageManagerException(
-          logger.format("Could not write to column bounds file\nTileDB error message : {}",
-                        tiledb_errmsg)));
+          logger.format("Could not write to column bounds file : {}", tiledb_errmsg)));
     };
   
     if (close_file(m_tiledb_ctx, column_filepath)) {

--- a/src/main/cpp/src/loader/tiledb_loader.cc
+++ b/src/main/cpp/src/loader/tiledb_loader.cc
@@ -926,16 +926,16 @@ void VCF2TileDBLoader::clear() {
   m_operators_overflow.clear();
 }
 
-// TODO: Support consolidation with shared posixfs optimizations turned ON. This is only used
-// by the consolidate_genomicsdb_array tool.
-void VCF2TileDBLoader::consolidate_tiledb_array(const char* workspace, const char* array_name) {
-  VariantStorageManager sm(workspace);
+void VCF2TileDBLoader::consolidate_tiledb_array(const char* workspace, const char* array_name,
+                                                const size_t buffer_size, const int batch_size,
+                                                const bool enable_shared_posixfs_optimizations) {
+  VariantStorageManager sm(workspace, buffer_size, enable_shared_posixfs_optimizations);
   auto ad = sm.open_array(array_name, 0, "w");
   if (ad < 0)
     throw VCF2TileDBException(std::string("Error opening array ")+array_name
                               +" in workspace "+workspace+" when trying to consolidate"
                               + "\nTileDB error message : "+tiledb_errmsg);
-  sm.close_array(ad, true);
+  sm.close_array(ad, true, batch_size);
 }
 
 

--- a/src/main/cpp/src/utils/genomicsdb_logger.cc
+++ b/src/main/cpp/src/utils/genomicsdb_logger.cc
@@ -43,7 +43,7 @@ Logger logger;
 std::shared_ptr<spdlog::logger> Logger::get_logger(const std::string& name) {
   auto new_logger = spdlog::stderr_color_mt(name);
   // Follow default log4j pattern for now
-  new_logger->set_pattern("%H:%M:%S.%e %4!l  %n - pid=%P tid=%t %v");
+  new_logger->set_pattern("%H:%M:%S.%e %-5!l %n - pid=%P tid=%t %v");
 #ifdef NDEBUG
   new_logger->set_level(spdlog::level::info);
 #else

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -40,7 +40,6 @@ VCFS_DIR=$(cd $1 && pwd)
 TEMP_DIR=$(mktemp -d -t test_tools-XXXXXXXXXX)
 
 WORKSPACE=$TEMP_DIR/ws
-echo "WORKSPACE=$WORKSPACE"
 LOADER_JSON=$TEMP_DIR/ws/loader.json
 CALLSET_MAPPING_JSON=$TEMP_DIR/ws/callset_mapping.json
 TEMPLATE_HEADER=$TESTS_DIR/ws/vcf_header.vcf
@@ -341,6 +340,12 @@ run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --produce-Br
 # Test consolidate_genomicsdb_array and gt_mpi_gather after consolidation
 create_sample_list t0.vcf.gz
 ARRAY="1\$1\$249250621"
+
+# Workspace and array specified cannot be null
+EMPTY=""
+run_command "consolidate_genomicsdb_array --workspace $EMPTY --array $ARRAY" ERR
+run_command "consolidate_genomicsdb_array -w $WORKSPACE -a $EMPTY" ERR
+
 run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -o" 1 85 24 85 "#40"
 run_command "consolidate_genomicsdb_array --workspace $WORKSPACE --array $ARRAY"
 run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # The MIT License (MIT)
-# Copyright (c) 2021 Omics Data Automation Inc.
+# Copyright (c) 2021-2022 Omics Data Automation Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -46,12 +46,14 @@ TEMPLATE_HEADER=$TESTS_DIR/ws/vcf_header.vcf
 
 REFERENCE_GENOME=$VCFS_DIR/../chr1_10MB.fasta.gz
 
+EMPTY=""
+
 cleanup() {
   rm -fr $TEMP_DIR
 }
 
 die() {
-  // cleanup
+  cleanup
   if [[ $# -eq 1 ]]; then
     echo $1
   fi
@@ -155,6 +157,7 @@ EOF
 #    $2 : optional - 0(default) if command should return successfully
 #                    any other value if the command should return a failure
 run_command() {
+  echo $EMPTY > $TEMP_DIR/output
   declare -i EXPECT_NZ
   declare -i GOT_NZ  
   EXPECT_NZ=0
@@ -222,7 +225,7 @@ run_command_and_check_results() {
   run_command "vcf2genomicsdb --progress $WORKSPACE/loader.json"
 }
       
-# Basic Tests
+# Basic Tests for vcf2genomicsdb_init
 create_sample_list t0.vcf.gz
 run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST" 1 85 24 85 "#1"
 run_command "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST" ERR
@@ -338,37 +341,51 @@ create_query_json $REFERENCE_GENOME
 run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --produce-Broad-GVCF"
 
 # Test consolidate_genomicsdb_array and gt_mpi_gather after consolidation
-create_sample_list t0.vcf.gz
+diff_gt_output() {
+  sed "1 d" $1 > $1.cut
+  sed "1 d" $2 > $2.cut
+  DIFF_RESULT=$(diff $1.cut $2.cut)
+  if [[ ! -z  $DIFF_RESULT ]]; then
+     echo "gt_mpi_gather results for Test $3 differ after consolidation"
+     STATUS=1
+  fi
+}
+
+run_consolidation_and_check_results() {
+  run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
+  mv -f $TEMP_DIR/output $TEMP_DIR/output.no.consolidation
+  run_command "$1"
+  run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
+  diff_gt_output  $TEMP_DIR/output.no.consolidation $TEMP_DIR/output $2
+}
+
 ARRAY="1\$1\$249250621"
 
 # Workspace and array specified cannot be null
-EMPTY=""
 run_command "consolidate_genomicsdb_array --workspace $EMPTY --array $ARRAY" ERR
 run_command "consolidate_genomicsdb_array -w $WORKSPACE -a $EMPTY" ERR
 
+create_sample_list t0.vcf.gz
 run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -o" 1 85 24 85 "#40"
-run_command "consolidate_genomicsdb_array --workspace $WORKSPACE --array $ARRAY"
-run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
+run_consolidation_and_check_results  "consolidate_genomicsdb_array --workspace $WORKSPACE --array $ARRAY" "#41"
+
 create_sample_list t1.vcf.gz
-run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -a" 2 85 24 85 "#41"
-run_command "consolidate_genomicsdb_array -w $WORKSPACE -a $ARRAY -p"
-run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
+run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -a" 2 85 24 85 "#42"
+run_consolidation_and_check_results  "consolidate_genomicsdb_array -w $WORKSPACE -a $ARRAY -p" "#43"
 
 # Test consolidate_genomicsdb_array with buffer-size
 create_sample_list t2.vcf.gz
-run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -a" 3 85 24 85 "#42"
-run_command "consolidate_genomicsdb_array -w $WORKSPACE -a $ARRAY -z 1024 -p"
-run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
+run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -a" 3 85 24 85 "#44"
+run_consolidation_and_check_results "consolidate_genomicsdb_array -w $WORKSPACE -a $ARRAY -z 1024 -p" "#45"
 
 # Test consolidate_genomicsdb_array with batch-size
 create_sample_list t0.vcf.gz
-run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -o" 1 85 24 85 "#43"
+run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -o" 1 85 24 85 "#46"
 create_sample_list t1.vcf.gz
-run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -a" 2 85 24 85 "#44"
+run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -a" 2 85 24 85 "#47"
 create_sample_list t2.vcf.gz
-run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -a" 3 85 24 85 "#45"
-run_command "consolidate_genomicsdb_array -w $WORKSPACE -a $ARRAY -z 1024 -b 2 -p"
-run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
+run_command_and_check_results "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -a" 3 85 24 85 "#48"
+run_consolidation_and_check_results "consolidate_genomicsdb_array -w $WORKSPACE -a $ARRAY -z 1024 -b 2 -p" "#49"
 
 cleanup
 exit $STATUS

--- a/tools/src/consolidate_genomicsdb_array.cc
+++ b/tools/src/consolidate_genomicsdb_array.cc
@@ -46,7 +46,7 @@ void print_usage() {
             << "\t \e[1m--buffer-size\e[0m=<Buffer Size>, \e[1m-z\e[0m <Buffer Size>\n"
             << "\t\t Optional, default is 10M. Specify a buffer size for consolidation\n"
             << "\t \e[1m--batch-size\e[0m=<Batch Size>, \e[1m-z\e[0m <Batch Size>\n"
-            << "\t\t Optional, default is all fragments considered. Specify a batch size for consolidating with a set of fragments at a time\n"
+            << "\t\t (Experimental) Optional, default is all fragments considered. Specify a batch size for consolidating with a set of fragments at a time\n"
             << "\t \e[1m--shared-posixfs-optimizations\e[0m, \e[1m-p\e[0m\n"
             << "\t\t Optional, default is false. If specified, the array folder is not locked for read/write and file handles are kept open until a final close for write\n"
             << "\t \e[1m--version\e[0m Print version and exit\n"

--- a/tools/src/consolidate_genomicsdb_array.cc
+++ b/tools/src/consolidate_genomicsdb_array.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -20,15 +21,110 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <getopt.h>
 #include <iostream>
+
+#include "common.h"
 #include "tiledb_loader.h"
 
-// TODO: Evolve this tool to support shared_posixfs_optimizations
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+static Logger g_logger(Logger::get_logger("consolidate_genomicsdb_array"));
+
+enum GenomicsDBArgsEnum {
+  VERSION=1000,
+};
+
+void print_usage() {
+  std::cerr << "Usage: consolidate_genomicsdb_array [options]\n"
+            << "where options include:\n"
+            << "\t \e[1m--help\e[0m, \e[1m-h\e[0m Print a usage message summarizing options available and exit\n"
+            << "\t \e[1m--workspace\e[0m=<GenomicsDB workspace URI>, \e[1m-w\e[0m <GenomicsDB workspace URI>\n"
+            << "\t\t Specify path to GenomicsDB workspace\n"
+            << "\t \e[1m--array-name\e[0m=<Array Name>, \e[1m-a\e[0m <Array Name>\n"
+            << "\t\t Specify name of array that requires consolidation\n"
+            << "\t \e[1m--buffer-size\e[0m=<Buffer Size>, \e[1m-z\e[0m <Buffer Size>\n"
+            << "\t\t Optional, default is 10M. Specify a buffer size for consolidation\n"
+            << "\t \e[1m--batch-size\e[0m=<Batch Size>, \e[1m-z\e[0m <Batch Size>\n"
+            << "\t\t Optional, default is all fragments considered. Specify a batch size for consolidating with a set of fragments at a time\n"
+            << "\t \e[1m--shared-posixfs-optimizations\e[0m, \e[1m-p\e[0m\n"
+            << "\t\t Optional, default is false. If specified, the array folder is not locked for read/write and file handles are kept open until a final close for write\n"
+            << "\t \e[1m--version\e[0m Print version and exit\n"
+            << std::endl;
+}
+
 int main(int argc, char** argv) {
-  if (argc < 3) {
-    std::cerr << "Needs 2 arguments <workspace_directory> <array_name>\n";
-    exit(-1);
+  if (argc < 2) {
+    print_usage();
+    return ERR;
   }
-  VCF2TileDBLoader::consolidate_tiledb_array(argv[1], argv[2]);
+
+  static struct option long_options[] = {
+    {"workspace",                    1, 0, 'w'},
+    {"array-name",                   1, 0, 'a'},
+    {"buffer-size",                  1, 0, 'z'},
+    {"batch-size",                   1, 0, 'b'},
+    {"shared-posixfs-optimizations", 0, 0, 'p'},
+    {"version",                      0, 0, VERSION},
+    {"help",                         0, 0, 'h'},
+    {0,0,0,0}
+  };
+
+  // Set global log level to info as default
+#ifdef DEBUG
+  spdlog::set_level(spdlog::level::info);
+#else
+  spdlog::set_level(spdlog::level::debug);
+#endif
+
+  std::string workspace;
+  std::string array_name;
+  size_t buffer_size = TILEDB_CONSOLIDATION_BUFFER_SIZE;
+  int batch_size = -1;
+  bool enable_shared_posixfs_optimizations = false;
+
+  int c;
+  while ((c=getopt_long(argc, argv, "w:a:z:b:ph", long_options, NULL)) >= 0) {
+    switch (c) {
+      case 'w':
+        workspace = std::move(std::string(optarg));
+        break;
+      case 'a':
+        array_name = std::move(std::string(optarg));
+        break;
+      case 'z':
+        buffer_size = std::stoll(optarg);
+        break;
+      case 'b':
+        batch_size = std::stoi(optarg);
+      case 'p':
+        enable_shared_posixfs_optimizations = true;
+        break;
+      case 'h':
+        print_usage();
+        return 0;
+      case VERSION:
+        std::cout << GENOMICSDB_VERSION << "\n";
+        return OK;
+      default:
+        std::cerr << "Unknown command line argument\n";
+        print_usage();
+        return ERR;
+    }
+  }
+
+  // Validate options
+  if (workspace.empty()) {
+    g_logger.error("Workspace(--workspace/-w) required to be specified");
+    return ERR;
+  } else if (array_name.empty()) {
+    g_logger.error("Array Name(--array_name/-a) required to be specified");
+    return ERR;
+  }
+
+  g_logger.info("Starting consolidation of {} in {}", array_name, workspace);
+  VCF2TileDBLoader::consolidate_tiledb_array(workspace.c_str(), array_name.c_str(),
+                                             buffer_size, batch_size, enable_shared_posixfs_optimizations);
+  g_logger.info("Consolidation of {} in {} completed", array_name, workspace);
   return 0;
 }


### PR DESCRIPTION
Support buffer/batch sizes and enabling shared posixfs optimizations in the consolidate_genomicsdb_array tool and from the Java/C++ Importer via loader configuration.

Also, cleaned up logging to conform to log4j defaults and bumped up the release version to 1.4.4.snapshot in CMakeLists.txt.