### PR TITLE
Move to cmake 3.17 and protobuf 3.19.4

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -15,7 +15,7 @@ env:
   SPARK_ENV: ${{github.workspace}}/spark_env.sh
   HADOOP_ENV: ${{github.workspace}}/hadoop_env.sh
   PREREQS_INSTALL_DIR: ${{github.workspace}}/prereqs
-  PROTOBUF_VERSION: 3.8.0
+  PROTOBUF_VERSION: 3.19.4
   CMAKE_INSTALL_PREFIX: ${{github.workspace}}/install
   GENOMICSDB_BUILD_DIR: ${{github.workspace}}/build
   GENOMICSDB_RELEASE_VERSION: x.y.z.test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 #
 
 project(GenomicsDB)
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.17)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
 if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
@@ -62,7 +62,7 @@ set(BUILD_JAVA False CACHE BOOL "Build Java/JNI interface for combined VCF recor
 set(HTSLIB_INSTALL_DIR "" CACHE PATH "Path to htslib install directory")
 
 #Sync the GENOMICSDB_PROTOBUF_VERSION with protobuf.version in pom.xml!
-set(GENOMICSDB_PROTOBUF_VERSION "3.8.0" CACHE STRING "Version of Google Protocol Buffer library")
+set(GENOMICSDB_PROTOBUF_VERSION "3.19.4" CACHE STRING "Version of Google Protocol Buffer library")
 set(PROTOBUF_ROOT_DIR "$ENV{HOME}/protobuf-install/${GENOMICSDB_PROTOBUF_VERSION}" CACHE PATH "Path to installed protobuf")
 set(PROTOBUF_URL "https://github.com/protocolbuffers/protobuf/archive/v${GENOMICSDB_PROTOBUF_VERSION}.zip" CACHE STRING "URL to protobuf github release")
 set(PROTOBUF_REGENERATE True CACHE BOOL "Regenerate protocol buffers C++ files")

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <json.simple.version>[1.1.1,)</json.simple.version>
     <log4j.version>[2.17.0,)</log4j.version>
     <!-- Sync the protobuf.version with GENOMICSDB_PROTOBUF_VERSION in CMakeLists.txt -->
-    <protobuf.version>3.16.1</protobuf.version>
+    <protobuf.version>3.19.4</protobuf.version>
     <protobuf_shade_version>org.genomicsdb.shaded.com.google.protobuf</protobuf_shade_version>
     <testng.version>6.10</testng.version>
     <gnu.getopt.version>1.0.13</gnu.getopt.version>


### PR DESCRIPTION
- Move to `cmake version 3.17` for `SOURCE_SUBDIR` support used in finding locally built protobuf.
- Move to `protobuf version 3.19.4` to match gatk.