### PR TITLE
Release automation

### DIFF
--- a/.github/scripts/tag_for_docker_release.sh
+++ b/.github/scripts/tag_for_docker_release.sh
@@ -6,12 +6,12 @@
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$CURRENT_BRANCH" != "develop" || "$CURRENT_BRANCH" != "master" ]]; then
+if [[ "$CURRENT_BRANCH" != "develop" && "$CURRENT_BRANCH" != "master" ]]; then
     echo "Release should be run from develop or master branch!"
     exit 1
 fi
 
-VERSION=$(grep "GenomicsDB release verison" $REPO_ROOT/CMakeLists.txt | cut -d '"' -f 2)
+VERSION=$(grep "GenomicsDB release version" $REPO_ROOT/CMakeLists.txt | cut -d '"' -f 2)
 GIT_COMMIT_HASH=$(git log -1 --format=%h)
 
 TAG=v${VERSION}-${GIT_COMMIT_HASH}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  PREREQS_ENV: ${{github.workspace}}/prereqs.sh
+  PREREQS_INSTALL_DIR: ${{github.workspace}}/prereqs
+  PROTOBUF_VERSION: 3.8.0
+  CMAKE_INSTALL_PREFIX: ${{github.workspace}}/install
+  GENOMICSDB_BUILD_DIR: ${{github.workspace}}/build
+  BUILD_DISTRIBUTABLE_LIBRARY: true
+
+jobs:
+  build-and-push-mac-dylib:
+    runs-on: macos-10.15
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cache built prerequisites
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{env.PREREQS_INSTALL_DIR}}
+            ~/.m2/repository
+            ~/awssdk-install
+            ~/gcssdk-install
+            ~/protobuf-install/${{env.PROTOBUF_VERSION}}
+          key: ${{matrix.os}}-cache-prereqs-v5
+
+      - name: Set version number
+        run: echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
+
+      - name: Install Prerequisites
+        shell: bash
+        working-directory: ${{github.workspace}}/scripts/prereqs
+        run: |
+          echo "Installing Prerequistes for MacOS..."
+          export INSTALL_PREFIX=$PREREQS_INSTALL_DIR
+          ./install_prereqs.sh
+
+      - name: Build GenomicsDB distributable
+        shell: bash
+        run: |
+          echo "Building GenomicsDB for MacOS..."
+          export INSTALL_PREFIX=$PREREQS_INSTALL_DIR
+          mkdir -p $GENOMICSDB_BUILD_DIR
+          source $PREREQS_ENV
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX \
+            -DCMAKE_PREFIX_PATH=$PREREQS_INSTALL_DIR -DGENOMICSDB_PROTOBUF_VERSION=$PROTOBUF_VERSION         \
+            -DGENOMICSDB_RELEASE_VERSION=${VERSION_NUMBER} -DBUILD_JAVA=1 -DUSE_HDFS=1 -DBUILD_DISTRIBUTABLE_LIBRARY=1
+          make -j4
+          make install
+          cp $CMAKE_INSTALL_PREFIX/lib/libtiledbgenomicsdb.dylib .
+
+      - name: Archive libraries as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: libtiledbgenomicsdb.dylib.${{ github.ref_name }}
+          path: libtiledbgenomicsdb.dylib
+
+  release-jar:
+    needs: [build-and-push-mac-dylib]
+    uses: ./.github/workflows/release_jar.yml
+    with:
+      dylib_artifact: libtiledbgenomicsdb.dylib.${{ github.ref_name }}
+
+  test:
+    needs: [release-jar]
+    uses: ./.github/workflows/release_test.yml
+    with:
+      release_artifact: release.${{ github.ref_name }}
+
+  publish:
+    needs: [test]
+    uses: ./.github/workflows/release_publish.yml
+    with:
+      release_artifact: release.${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/release_jar.yml
+++ b/.github/workflows/release_jar.yml
@@ -1,0 +1,61 @@
+name: Build release jar
+
+on:
+  workflow_call:
+    inputs:
+      dylib_artifact:
+        required: true
+        type: string
+
+jobs:
+  build-and-push-jar:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true # cmake does this for us...but need to patch htslib before calling cmake
+
+      - name: Set version number
+        run: echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
+
+      - name: Download dylib
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.dylib_artifact }}
+
+      - name: Build Centos 6 and create release jar
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: Dockerfile.release
+          build-args: |
+            GENOMICSDB_RELEASE_VERSION=${{ env.VERSION_NUMBER }}
+            MAC_DYLIB_PATH=/opt/libtiledbgenomicsdb.dylib
+            USE_HDFS=true
+          load: true
+          tags: ghcr.io/genomicsdb/genomicsdb:release
+
+      - name: Get artifacts from docker image
+        shell: bash
+        run: |
+          docker create -it --name genomicsdb ghcr.io/genomicsdb/genomicsdb:release bash
+          docker cp genomicsdb:/build/GenomicsDB/build/src/main/libtiledbgenomicsdb.so .
+          docker cp genomicsdb:/build/GenomicsDB/build/target/genomicsdb-${VERSION_NUMBER}.jar .
+          docker cp genomicsdb:/build/GenomicsDB/build/target/genomicsdb-${VERSION_NUMBER}-allinone.jar .
+          docker cp genomicsdb:/build/GenomicsDB/pom.xml genomicsdb-${VERSION_NUMBER}.pom
+          sed -i.bak 's/${genomicsdb.version}/'"${VERSION_NUMBER}"'/' genomicsdb-${VERSION_NUMBER}.pom
+
+      - name: Archive libraries as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: release.${{ github.ref_name }}
+          path: |
+            libtiledbgenomicsdb.*
+            genomicsdb-${{ env.VERSION_NUMBER }}.jar
+            genomicsdb-${{ env.VERSION_NUMBER }}-allinone.jar
+            genomicsdb-${{ env.VERSION_NUMBER }}.pom

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,0 +1,65 @@
+name: Publish release jar
+
+on:
+  workflow_call:
+    inputs:
+      release_artifact:
+        required: true
+        type: string
+    secrets:
+      MAVEN_GPG_PASSPHRASE:
+        required: true
+      MAVEN_GPG_PRIVATE_KEY:
+        required: true
+      OSSRH_USERNAME:
+        required: true
+      OSSRH_PASSWORD:
+        required: true
+
+jobs:
+  publish-jar:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set version number
+        run: echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: ossrh
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.release_artifact }}
+
+      - name: Deploy Maven Central
+        shell: bash
+        run: |
+          sudo apt install -y xmlstarlet
+          if [[ ${VERSION_NUMBER} = *SNAPSHOT ]]; then
+            URL=`xmlstarlet sel -t -m "//_:project" -v _:distributionManagement/_:snapshotRepository/_:url genomicsdb-${VERSION_NUMBER}.pom`
+            REPO_ID=`xmlstarlet sel -t -m "//_:project" -v _:distributionManagement/_:snapshotRepository/_:id genomicsdb-${VERSION_NUMBER}.pom`
+          else
+            URL=`xmlstarlet sel -t -m "//_:project" -v _:distributionManagement/_:repository/_:url genomicsdb-${VERSION_NUMBER}.pom`
+            REPO_ID=`xmlstarlet sel -t -m "//_:project" -v _:distributionManagement/_:repository/_:id genomicsdb-${VERSION_NUMBER}.pom`
+          fi
+          echo mvn deploy:deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}.jar \
+            -DgroupId=org.genomicsdb -DartifactId=genomicsdb -Dversion=${VERSION_NUMBER} \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID
+          mvn deploy:deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}.jar \
+            -DgroupId=org.genomicsdb -DartifactId=genomicsdb -Dversion=${VERSION_NUMBER} \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -1,0 +1,63 @@
+name: Test release jar
+
+on:
+  workflow_call:
+    inputs:
+      release_artifact:
+        required: true
+        type: string
+
+jobs:
+  test-jar:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest,macos-10.15]
+
+    runs-on: ${{matrix.os}}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout TestGenomicsDBJar
+        uses: actions/checkout@v3
+        with:
+          repository: GenomicsDB/TestGenomicsDBJar
+          ref: ml_genomicsdb_release
+
+      - name: Set version number
+        run: |
+          echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
+          echo GENOMICSDB_VERSION=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+  
+      - name: Download release artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.release_artifact }}
+
+      - name: Run smoke test
+        shell: bash
+        run: |
+          rm -f libtiledbgenomicsdb.*
+          mvn install:install-file -Dfile=genomicsdb-${VERSION_NUMBER}.jar \
+            -DgroupId=org.genomicsdb -DartifactId=genomicsdb -Dversion=${VERSION_NUMBER} \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom
+          ./test_genomicsdbjar.sh
+
+      - name: Checkout GATK
+        uses: actions/checkout@v3
+        with:
+          repository: broadinstitute/gatk
+          lfs: 'true'
+
+      - name: Try GATK integration test
+        shell: bash
+        run: |
+          ./gradlew installDist -Dgenomicsdb.version=${VERSION_NUMBER}
+          ./gradlew test --tests *GenomicsDB*

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 Omics Data Automation, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Description: Docker file to generate GenomicsDB release jar
+
+FROM ghcr.io/genomicsdb/genomicsdb:centos_6_prereqs
+ARG GENOMICSDB_RELEASE_VERSION=""
+ARG MAC_DYLIB_PATH=""
+ARG USE_HDFS=""
+
+ENV DOCKER_BUILD=true
+ENV MAC_DYLIB_PATH=${MAC_DYLIB_PATH}
+ENV USE_HDFS=${USE_HDFS}
+ENV GENOMICSDB_RELEASE_VERSION=${GENOMICSDB_RELEASE_VERSION}
+COPY . /build/GenomicsDB/
+COPY libtiledbgenomicsdb.dylib ${MAC_DYLIB_PATH}
+WORKDIR /build/GenomicsDB
+RUN useradd -r -U -m genomicsdb &&\
+    ./scripts/install_genomicsdb.sh genomicsdb /usr/local true java

--- a/Dockerfile.release_prereqs
+++ b/Dockerfile.release_prereqs
@@ -1,0 +1,28 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 Omics Data Automation, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Description: Docker file for GenomicsDB prereqs. Base image for release
+
+ARG os=centos:6
+FROM $os
+
+ENV DOCKER_BUILD=true
+COPY ./scripts/ /scripts
+RUN /scripts/prereqs/install_prereqs.sh true full

--- a/scripts/install_genomicsdb.sh
+++ b/scripts/install_genomicsdb.sh
@@ -32,6 +32,7 @@ GENOMICSDB_USER=${1:-genomicsdb}
 GENOMICSDB_INSTALL_DIR=${2:-/usr/local}
 BUILD_DISTRIBUTABLE_LIBRARY=${3:-false}
 ENABLE_BINDINGS=${4:-none}
+USE_HDFS=${USE_HDFS:-false}
 
 GENOMICSDB_USER_DIR=`eval echo ~$GENOMICSDB_USER`
 
@@ -43,10 +44,8 @@ fi
 
 if [[ $ENABLE_BINDINGS == *java* ||  $BUILD_DISTRIBUTABLE_LIBRARY == true ]]; then
 	BUILD_JAVA=true
-	USE_HDFS=false
 else
 	BUILD_JAVA=false
-	USE_HDFS=false
 fi
 
 # Autoconf version 2.73 is the highest version supported by yum install on centos 6,
@@ -65,20 +64,24 @@ repair_htslib() {
 
 build_genomicsdb() {
 	. /etc/profile
-	git_repo_check=$(git rev-parse --is-inside-work-tree)
-	git_repo_name=$(git config --get remote.origin.url)
-	if [[ $git_repo_check != "true" || $git_repo_name != *"GenomicsDB/GenomicsDB"* ]]; then
-	  echo "Could not find GenomicsDB git repo: $git_repo_check, $git_repo_name. Exiting."
-	  exit 1
-	fi
 	repair_htslib &&
 	echo "Building GenomicsDB" &&
 	rm -rf build &&
 	mkdir build &&
 	pushd build &&
-	echo "	$CMAKE .. -DCMAKE_INSTALL_PREFIX=$GENOMICSDB_INSTALL_DIR -DBUILD_DISTRIBUTABLE_LIBRARY=$BUILD_DISTRIBUTABLE_LIBRARY -DBUILD_JAVA=$BUILD_JAVA -DUSE_HDFS=$USE_HDFS" &&
-	$CMAKE .. -DCMAKE_INSTALL_PREFIX=$GENOMICSDB_INSTALL_DIR -DBUILD_DISTRIBUTABLE_LIBRARY=$BUILD_DISTRIBUTABLE_LIBRARY -DBUILD_JAVA=$BUILD_JAVA -DUSE_HDFS=$USE_HDFS && make && make install &&
-	popd &&
+	if [[ -n "$IPPROOT" && -n "$GENOMICSDB_RELEASE_VERSION" ]]; then
+	  echo "	$CMAKE .. -DCMAKE_INSTALL_PREFIX=$GENOMICSDB_INSTALL_DIR -DGENOMICSDB_RELEASE_VERSION=$GENOMICSDB_RELEASE_VERSION -DIPPROOT=$IPPROOT -DBUILD_DISTRIBUTABLE_LIBRARY=$BUILD_DISTRIBUTABLE_LIBRARY -DBUILD_JAVA=$BUILD_JAVA -DUSE_HDFS=$USE_HDFS" &&
+	  $CMAKE .. -DCMAKE_INSTALL_PREFIX=$GENOMICSDB_INSTALL_DIR -DGENOMICSDB_RELEASE_VERSION=$GENOMICSDB_RELEASE_VERSION -DIPPROOT=$IPPROOT -DBUILD_DISTRIBUTABLE_LIBRARY=$BUILD_DISTRIBUTABLE_LIBRARY -DBUILD_JAVA=$BUILD_JAVA -DUSE_HDFS=$USE_HDFS && make && make install
+	else
+	  echo "	$CMAKE .. -DCMAKE_INSTALL_PREFIX=$GENOMICSDB_INSTALL_DIR -DBUILD_DISTRIBUTABLE_LIBRARY=$BUILD_DISTRIBUTABLE_LIBRARY -DBUILD_JAVA=$BUILD_JAVA -DUSE_HDFS=$USE_HDFS" &&
+	  $CMAKE .. -DCMAKE_INSTALL_PREFIX=$GENOMICSDB_INSTALL_DIR -DBUILD_DISTRIBUTABLE_LIBRARY=$BUILD_DISTRIBUTABLE_LIBRARY -DBUILD_JAVA=$BUILD_JAVA -DUSE_HDFS=$USE_HDFS && make && make install
+	fi
+	if [[ -f "$MAC_DYLIB_PATH" ]]; then
+	  find . -name "genomicsdb*jar" -exec rm -f {} \;
+	  cp $MAC_DYLIB_PATH target/classes
+	  cp $MAC_DYLIB_PATH src/main
+	  make install
+	fi &&
 	echo "Building GenomicsDB DONE" &&
 	popd
 }

--- a/scripts/prereqs/install_prereqs.sh
+++ b/scripts/prereqs/install_prereqs.sh
@@ -59,6 +59,7 @@ fi
 ################################# Should not have to change anything below ############################
 
 CENTOS_VERSION=0
+WGET_NO_CERTIFICATE=""
 PARENT_DIR="$(dirname $0)"
 
 # $1 - path variable name
@@ -88,7 +89,7 @@ install_mvn() {
   if [ -z $MVN ]; then
     if [ ! -d $MAVEN_INSTALL_PREFIX/apache-maven-$MAVEN_VERSION ]; then
       echo "Installing Maven"
-      wget -nv https://downloads.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -P /tmp &&
+      wget $WGET_NO_CERTIFICATE -nv https://downloads.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -P /tmp &&
         tar xf /tmp/apache-maven-*.tar.gz -C $MAVEN_INSTALL_PREFIX &&
         rm /tmp/apache-maven-*.tar.gz
       echo "Installing Maven DONE"
@@ -111,7 +112,7 @@ install_protobuf() {
     echo "Installing Protobuf"
     pushd /tmp
     if [[ $BUILD_DISTRIBUTABLE_LIBRARY == true ]]; then
-      wget -nv https://github.com/protocolbuffers/protobuf/releases/download/v3.0.0-beta-1/protobuf-cpp-3.0.0-beta-1.zip &&
+      wget $WGET_NO_CERTIFICATE -nv https://github.com/protocolbuffers/protobuf/releases/download/v3.0.0-beta-1/protobuf-cpp-3.0.0-beta-1.zip &&
         unzip protobuf-cpp-3.0.0-beta-1.zip &&
         cp $PARENT_DIR/protobuf-v3.0.0-beta-1.autogen.sh.patch protobuf-3.0.0-beta-1/autogen.sh &&
         mv protobuf-3.0.0-beta-1 protobuf
@@ -136,7 +137,7 @@ install_openssl() {
   if [[ ! -d $OPENSSL_PREFIX ]]; then
     echo "Installing OpenSSL"
     pushd /tmp
-    wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
+    wget $WGET_NO_CERTIFICATE https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
       tar -xvzf openssl-$OPENSSL_VERSION.tar.gz &&
       cd openssl-$OPENSSL_VERSION &&
       if [[ `uname` == "Linux" ]]; then
@@ -161,9 +162,9 @@ install_curl() {
   if [[ ! -f $CURL_PREFIX/libcurl.a ]]; then
     echo "Installing CURL into $CURL_PREFIX"
     pushd /tmp
-    git clone https://github.com/curl/curl.git &&
-      cd curl &&
-      autoreconf -i &&
+    wget https://github.com/curl/curl/releases/download/curl-7_83_1/curl-7.83.1.tar.gz &&
+    tar xzf curl-7.83.1.tar.gz &&
+    cd curl-7.83.1 &&
       ./configure --disable-shared --with-pic -without-zstd --with-ssl=$OPENSSL_PREFIX --prefix $CURL_PREFIX &&
       make && make install && echo "Installing CURL DONE"
     rm -fr /tmp/curl
@@ -181,7 +182,7 @@ install_uuid() {
   if [[ ! -f $UUID_PREFIX/libuuid.a ]]; then
     echo "Installing libuuid into $UUID_PREFIX"
     pushd /tmp
-    wget https://sourceforge.net/projects/libuuid/files/libuuid-1.0.3.tar.gz &&
+    wget $WGET_NO_CERTIFICATE https://sourceforge.net/projects/libuuid/files/libuuid-1.0.3.tar.gz &&
       tar -xvzf libuuid-1.0.3.tar.gz &&
       cd libuuid-1.0.3 &&
       sed -i s/2.69/2.63/ configure.ac &&
@@ -194,6 +195,42 @@ install_uuid() {
     popd
   fi
   add_to_env LD_LIBRARY_PATH $UUID_PREFIX/lib
+}
+
+ZLIB_PREFIX=$INSTALL_PREFIX
+install_intel_zlib() {
+  echo "Installing Intel optimized zlib"
+
+  yum install -y yum-utils &&
+	yum-config-manager --add-repo https://yum.repos.intel.com/ipp/setup/intel-ipp.repo &&
+		rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB &&
+		yum -y install intel-ipp-2018.2-046 &&
+	  if [ ! -f /opt/intel/compilers_and_libraries_2018.2.199/linux/ipp/bin/ippvars.sh ]; then
+		  echo "Could not find ippvars.sh. Aborting installing Intel optimized zlib"
+		  exit 1
+	  fi &&
+	  wget http://zlib.net/fossils/zlib-1.2.8.tar.gz &&
+		tar -xvzf zlib-1.2.8.tar.gz &&
+	  source /opt/intel/compilers_and_libraries_2018.2.199/linux/ipp/bin/ippvars.sh intel64 &&
+  	echo "source /opt/intel/compilers_and_libraries_2018.2.199/linux/ipp/bin/ippvars.sh intel64" >> $PREREQS_ENV &&
+	  pushd $IPPROOT/examples &&
+		if [ ! -d components_and_examples_lin_ps ]; then
+			sudo mkdir components_and_examples_lin_ps
+		fi &&
+	  cd components_and_examples_lin_ps &&
+		tar -xzvf ../components_and_examples_lin_ps.tgz &&
+		popd &&
+		cd zlib-1.2.8 &&
+		patch -p1 < $IPPROOT/examples/components_and_examples_lin_ps/components/interfaces/ipp_zlib/zlib-1.2.8.patch &&
+		export CFLAGS="-m64 -DWITH_IPP -I$IPPROOT/include -fPIC" &&
+		export LDFLAGS="$IPPROOT/lib/intel64/libippdc.a $IPPROOT/lib/intel64/libipps.a $IPPROOT/lib/intel64/libippcore.a" &&
+		./configure &&
+		make shared &&
+		mkdir -p $HOME/intel_zlib/lib &&
+		cp libz.a $HOME/intel_zlib/lib &&
+		rm -fr $HOME/zlib* &&
+	echo "Installing Intel optimized zlib done"
+  add_to_env LD_LIBRARY_PATH $HOME/intel_zlib
 }
 
 centos_version() {
@@ -261,6 +298,16 @@ centos_version
 if [[ $BUILD_DISTRIBUTABLE_LIBRARY == false && $CENTOS_VERSION -eq 6 ]]; then
   echo "Centos 6 is supported only when build-arg distributable_jar=true"
   exit 1
+elif [[ $CENTOS_VERSION -eq 6 ]]; then
+  # Centos6 has EOL-ed so workaround to get yum to work
+  curl https://www.getpagespeed.com/files/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
+  yum -y install centos-release-scl
+  curl https://www.getpagespeed.com/files/centos6-scl-eol.repo --output /etc/yum.repos.d/CentOS-SCLo-scl.repo
+  curl https://www.getpagespeed.com/files/centos6-scl-rh-eol.repo --output /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+  sed -i 's/http/https/g' /etc/yum.repos.d/CentOS-Base.repo
+  sed -i 's/http/https/g' /etc/yum.repos.d/CentOS-SCLo-scl.repo
+  sed -i 's/http/https/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+  WGET_NO_CERTIFICATE=" --no-check-certificate"
 fi
 
 RC=1
@@ -269,6 +316,9 @@ install_prerequisites $2 $3 &&
     echo "Installing static libraries"
     install_openssl &&
       install_curl &&
-      install_uuid
+      install_uuid &&
+      if [[ $CENTOS_VERSION -eq 6 ]]; then
+        install_intel_zlib
+      fi
   fi && RC=0
 finalize $RC

--- a/scripts/prereqs/system/install_centos_prereqs.sh
+++ b/scripts/prereqs/system/install_centos_prereqs.sh
@@ -34,6 +34,22 @@ install_devtoolset() {
   fi
 }
 
+install_cmake3() {
+  CMAKE=`which cmake`
+  if [[ ! -z $CMAKE ]]; then
+    CMAKE_VERSION=$($CMAKE -version | awk '/version/{print $3}')
+  fi
+  if [[ -z $CMAKE_VERSION || CMAKE_VERSION < "3.6" ]]; then
+    echo "Installing cmake..."
+    wget -nv https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-Linux-x86_64.sh -P /tmp &&
+      chmod +x /tmp/cmake-3.19.1-Linux-x86_64.sh &&
+      /tmp/cmake-3.19.1-Linux-x86_64.sh --prefix=/usr/local --skip-license
+    if [ ! -f /usr/local/bin/cmake3 ]; then
+      ln -s /usr/local/bin/cmake /usr/local/bin/cmake3
+    fi
+  fi
+}
+
 install_openjdk() {
   echo "Installing openjdk" &&
   yum install -y -q java-1.8.0-openjdk-devel &&
@@ -66,7 +82,7 @@ install_system_prerequisites() {
     yum install -y -q epel-release &&
     yum install -y zlib-devel &&
     yum install -y -q openssl-devel &&
-    yum install -y -q cmake3 &&
+    install_cmake3 &&
     yum install -y -q libuuid libuuid-devel &&
     yum install -y -q patch &&
     yum install -y -q zstd &&


### PR DESCRIPTION
Adding a github action workflow to help automate the release to Maven Central. This relies on a Centos 6 docker image with prereqs (`Dockerfile.release_prereqs`) which doesn't get built as part of the workflow -- the image is just pulled. If that needs to be updated (say, we want to update openssl version or the like), that needs to be done out of band and pushed to the package repository.

The prereqs image does not include the cloud SDKs or protobuf. I left those out thinking that those might cause more churn in the prereqs image -- downside to not including is that we have to build those everytime of course so that adds time. And speaking of added time, this also does the smoke test and tries out the GATK Genomicsdb tests with the new release jar. The Mac OS tests on GATK take ~45mins....