### PR TITLE
Force CMAKE_BUILD_TYPE to Release and TILEDB_VERBOSE to False as they are cached cmake variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,12 @@ set(IPPROOT "" CACHE PATH "Path to IPP libraries - used when intel optimized zli
 
 set(LIBDBI_DIR "" CACHE PATH "Path to libdbi install directory")
 
-if (NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+# if no build build type is specified, default to release builds
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "GenomicsDB default set to Release" FORCE)
 endif()
+message(STATUS "CMAKE_BUILD_TYPE=" ${CMAKE_BUILD_TYPE})
+
 set(USE_HDFS True CACHE BOOL "Enables HDFS support")
 set(BUILD_FOR_ARCH "" CACHE STRING "Arch for which to build - values passed to -march= option for gcc")
 
@@ -180,7 +183,7 @@ add_definitions(-D_FILE_OFFSET_BITS=64)  #large file support
 add_definitions(-DDUPLICATE_CELL_AT_END=1) #mandatory
 add_definitions(-DGENOMICSDB_VERSION=\"${GENOMICSDB_VERSION}\")
 
-if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
   add_definitions(-D_FORTIFY_SOURCE=2)
 endif()
 

--- a/cmake/Modules/FindTileDB.cmake
+++ b/cmake/Modules/FindTileDB.cmake
@@ -43,7 +43,7 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   #TileDB c-api returns a tiledb_errmsg which is what GenomicsDB should rely on
-  set(TILEDB_VERBOSE CACHE BOOL "" False FORCE)
+  set(TILEDB_VERBOSE FALSE CACHE BOOL "Suppress TileDB Verbosity for GenomicsDB" FORCE)
 endif()
 set(TILEDB_DISABLE_TESTING True)
 

--- a/cmake/Modules/FindTileDB.cmake
+++ b/cmake/Modules/FindTileDB.cmake
@@ -41,8 +41,10 @@ if((DEFINED TILEDB_SOURCE_DIR) AND (NOT "${TILEDB_SOURCE_DIR}" STREQUAL "") AND 
   set(TILEDB_SOURCE_DIR "${CMAKE_SOURCE_DIR}/dependencies/TileDB" CACHE PATH "Path to TileDB source directory" FORCE)
 endif()
 
-#TileDB c-api returns a tiledb_errmsg which is what GenomicsDB should rely on
-set(TILEDB_VERBOSE False)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  #TileDB c-api returns a tiledb_errmsg which is what GenomicsDB should rely on
+  set(TILEDB_VERBOSE CACHE BOOL "" False FORCE)
+endif()
 set(TILEDB_DISABLE_TESTING True)
 
 #Zlib


### PR DESCRIPTION
Something in the cmake newer versions has changed, we need to force `CMAKE_BUILD_TYPE` default to `Release` now. Otherwise the default is empty string, the [docs](https://cmake.org/cmake/help/v3.3/variable/CMAKE_BUILD_TYPE.html) when `CMAKE_BUILD_TYPE` is empty is not very clear, but it looks like it could be `Debug` which is what I am seeing. There is also `CMAKE_CONFIGURATION_TYPES` which `CMAKE_BUILD_TYPE` is part of, but I don't want to visit it that yet.

Also, force set TILEDB_VERBOSE to False, otherwise we see multiple error messages as GenomicsDB also logs tiledb_errmsg via spdlog.