### PR TITLE
Remove  reference_genome parameter from GenomicsDB constructor and refactor to move plink support to its own .h/.cc files

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -68,6 +68,7 @@ set(GenomicsDB_library_sources
     cpp/src/api/annotation_service.cc
     cpp/src/api/genomicsdb.cc
     cpp/src/api/genomicsdb_field.cc
+    cpp/src/api/genomicsdb_plink.cc
     )
 
 include_directories(${PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS})

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -5,7 +5,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019-2020 Omics Data Automation, Inc.
+ * Copyright (c) 2019-2020,2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -34,10 +34,6 @@
 #define GENOMICSDB_H
 
 #include "genomicsdb_exception.h"
-#include "variant_query_config.h"
-#include "tiledb.h"
-#include "tiledb_utils.h"
-#include "genomicsdb_logger.h"
 
 #include <map>
 #include <set>
@@ -49,7 +45,6 @@
 #include <typeindex>
 #include <typeinfo>
 #include <vector>
-#include <mpi.h>
 #include <functional>
 
 // Override project visibility set to hidden for api
@@ -247,6 +242,11 @@ class GenomicsDBResults {
 typedef GenomicsDBResults<genomicsdb_variant_t> GenomicsDBVariants;
 typedef GenomicsDBResults<genomicsdb_variant_call_t> GenomicsDBVariantCalls;
 
+// Forward Declarations for keeping Variant* classes opaque
+class Variant;
+class VariantCall;
+class VariantQueryConfig;
+
 class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
  public:
   GenomicsDBVariantCallProcessor() {};
@@ -272,11 +272,10 @@ class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
   std::shared_ptr<std::map<std::string, genomic_field_type_t>> m_genomic_field_types;
 };
 
-class Variant;
-
 class GENOMICSDB_EXPORT GenomicsDBVariantProcessor {
  public:
   GenomicsDBVariantProcessor() {};
+  ~GenomicsDBVariantProcessor() {};
   void initialize(std::map<std::string, genomic_field_type_t> genomic_field_types) {
      m_genomic_field_types = std::make_shared<std::map<std::string, genomic_field_type_t>>(std::move(genomic_field_types));
   }
@@ -291,240 +290,10 @@ class GENOMICSDB_EXPORT GenomicsDBVariantProcessor {
     }
   }
   virtual void process(const Variant& variant) = 0;
-  virtual void process(const std::vector<Variant>& variants);
+  void process(const std::vector<Variant>& variants);
  private:
   std::shared_ptr<std::map<std::string, genomic_field_type_t>> m_genomic_field_types;
 };
-
-class GENOMICSDB_EXPORT GenomicsDBPlinkProcessor : public GenomicsDBVariantProcessor {
-  public:
-    // the formats variable encodes which formats to produce by the values of specific bits: 0 - bgen, 1 - bed, 2 - tped, e.g. formats == 0b110 encodes bed and tped
-    GenomicsDBPlinkProcessor(VariantQueryConfig* qc,
-                             VidMapper* vid_mapper,
-                             const std::string& array,
-                             unsigned char formats = 7,
-                             int compression = 1,
-                             bool verbose = false,
-                             double progress_interval = -1,
-                             std::string prefix = "output",
-                             std::string fam_list = "",
-                             int rank = 0);
-
-    ~GenomicsDBPlinkProcessor() {
-      TileDBUtils::finalize_codec(codec);
-    }
-
-    virtual void process(const interval_t& interval);
-    virtual void process(const std::string& sample_name,
-                         const int64_t* coordinates,
-                         const genomic_interval_t& genomic_interval,
-                         const std::vector<genomic_field_t>& genomic_fields,
-                         const bool phased);
-    virtual void process(const Variant& variant) override;
-    void advance_state();
-    const char BGEN_MASK = 1;
-    const char  BED_MASK = 2;
-    const char TPED_MASK = 4;
-  private:
-    const std::string& array;
-    VidMapper* vid_mapper;
-    bool make_bgen, make_tped, make_bed;
-    int compression = 0; // 0 for none, 1 for zlib, 2 for zstd
-    bool verbose = false;
-    // flattened coordinate to place in sorted map, phased status of column for bgen purposes (entire column considered unphased if any are unphased)
-    std::map<uint64_t, std::pair<int, bool>> variant_map;
-    double progress_interval;
-    std::string fam_list;
-    std::string prefix;
-    VariantQueryConfig* query_config;
-    // row to place in sorted map and sample name
-    std::map<uint64_t, std::pair<int, std::string>> sample_map;
-    bool sample_map_initialized = false;
-    // fam is identical to tfam, used with bed, tped respectively
-    std::fstream tped_file, fam_file, bim_file, bed_file, bgen_file;
-    int state = 0;
-    int last_sample = -1;
-    int num_variants = 0;
-    int last_coord = -1;
-    int last_alleles = -1;
-    bool last_phased;
-    int rank;
-    int total_rows = 0;
-    int total_cols = 0;
-
-    size_t tm = 0;
-    void progress_bar(const int64_t* coords) {
-      size_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-      if (now - progress_interval > tm) {
-        // flatten column and row ranges
-        int row = 0, col = 0;
-        for(auto& a : query_config->get_query_row_ranges(rank)) {
-          if(coords[0] <= a.second) {
-            row += coords[0] - a.first + 1;
-            break;
-          }
-          else {
-            row += a.second - a.first + 1;
-          }
-        }
-        for(auto& b : query_config->get_query_column_ranges(rank)) {
-          if(coords[1] <= b.second) {
-            col += coords[1] - b.first + 1;
-            break;
-          }
-          else {
-            col += b.second - b.first + 1;
-          }
-        }
-
-        long num = (long)col * total_rows + row + ((bool)state)*((long)total_rows * total_cols);
-        long den = (long)total_rows * total_cols * 2;
-
-        logger.info("Plink progress {} / {} = {:.2f}%", num, den, 100*(double)num/den);
-
-        tm = now;
-      }
-    }
-
-    // populate variant data block in bgen file for variant with given rsid spanning genomic_interval
-    // vec is REF and ALT combined (REF is first entry)
-    void bgen_variant_data_block(const std::string& rsid, const genomic_interval_t& genomic_interval, const std::vector<std::string>& vec, bool phased);
-
-    // return vector of tokens that were separated by sep in str
-    std::vector<std::string> split(std::string str, std::string sep = ",") {
-      std::vector<std::string> retval;
-      size_t index;
-      if(str.length() >= 2) {
-        if(str[0] == '[') {
-           str = str.substr(1, str.length() - 2);
-        }
-      }
-      while((index = str.find(sep)) != std::string::npos) {
-        retval.push_back(str.substr(0, index));
-        str.erase(0, index + 1);
-      }
-      retval.push_back(str);
-      return retval;
-    };
-
-    // BED variables/functions
-    char bed_buf = 0;
-    char bed_buf_state = 0;
-    void flush_to_bed() {
-      if(bed_buf_state) {
-        bed_file.write(&bed_buf, 1);
-        bed_buf = 0;
-        bed_buf_state = 0;
-      }
-    }
-
-    void write_to_bed(char x) {
-      bed_buf += x << bed_buf_state * 2;
-      ++bed_buf_state %= 4;    
-      if(!bed_buf_state){
-        bed_file.write(&bed_buf, 1);
-        bed_buf = 0;
-      }
-    }
-    // BGEN variables
-    char min_ploidy, max_ploidy;
-    int32_t bgen_gt_size;
-    uint32_t samples_in_column = 0;
-    void *codec;
-    std::string codec_buf;
-
-    // FIXME: hard coded for B = 8
-    // callback expects GT vector
-    void bgen_enumerate_phased(int ploidy, int alleles, std::function<void(const std::vector<int>&, int)> callback, bool drop_last = true) {
-      int size = 0;
-      int ind = -1;
-      int limit = alleles - drop_last;
-      for(int i = 0; i < ploidy; i++) {
-        for(int j = 0; j < limit; j++) {
-          callback({i, j}, ++ind);
-        }
-      }
-    }
-
-    // get_probabilitiles expects allele counts
-    void bgen_enumerate_unphased(int ploidy, int alleles, std::function<void(const std::vector<int>&, size_t)> callback, bool drop_last = true) {
-      int size = 0;
-      int ind = -1;
-      std::vector<int> allele_counts(alleles);
-
-      std::function<void(int, int)> enumerate_unphased;
-      enumerate_unphased = [&] (int used, int depth) {
-        int limit = ploidy - used - ((depth == alleles - 1) && drop_last); // if the highest depth (rightmost) do not iterate to highest possible count in order to drop last ((0, 0, ..., X) is the last)
-        if(depth) {
-          for(int i = 0; i <= limit; i++) { 
-            allele_counts[depth] = i;
-            enumerate_unphased(used + i, depth - 1);
-          }
-        }
-        else {
-          allele_counts[depth] = ploidy - used;
-          ++ind;
-          callback(allele_counts, (size_t)ind);
-        }
-      };
-
-      enumerate_unphased(0, alleles - 1);    
-    }
-
-    void bgen_empty_cell(int ploidy, int alleles, bool phased) {
-      auto write_zero = [&] (const std::vector<int>& v, int) {
-        char z = 0;
-        codec_buf.push_back(0);
-      };
-      if(phased) {
-        bgen_enumerate_phased(ploidy, alleles, write_zero);
-      }
-      else {
-        bgen_enumerate_unphased(ploidy, alleles, write_zero);
-      }
-    }
-
-    // fill in size, min/max ploidy of last column
-    void bgen_finish_gt() {
-      // write min ploidy
-      codec_buf[7] = min_ploidy;      
-
-      // write max ploidy
-      codec_buf[8] = max_ploidy;
-
-      size_t uncompressed_size = codec_buf.size(), data_size = codec_buf.size();
-
-      if(compression) {
-        char* data;
-        TileDBUtils::compress(codec, (unsigned char*)codec_buf.c_str(), codec_buf.length(), (void**)&data, data_size);
-        size_t total_size = data_size + 4;
-        bgen_file.write((char*)&total_size, 4); // BGEN: size of previous gt probability data plus D field
-        bgen_file.write((char*)&uncompressed_size, 4);
-        bgen_file.write(data, data_size);
-      }
-      else {
-        bgen_file.write((char*)&uncompressed_size, 4); // BGEN: size of previous gt probability data plus D field
-        bgen_file.write(codec_buf.c_str(), codec_buf.length());
-      }
-
-      codec_buf.clear();
-      bgen_gt_size = 0;
-      min_ploidy = 64;
-      max_ploidy = -1;
-    }
-
-    // locations in file
-    int bgen_gt_size_offset;
-    int bgen_min_ploidy_offset;
-    int bgen_max_ploidy_offset;
-    int bgen_ploidy_info_offset;
-    int bgen_probability_offset;
-};
-
-// Forward Declarations for keeping Variant* classes opaque
-class Variant;
-class VariantCall;
-class VariantQueryConfig;
 
 /**
  * Experimental Query Interface to GenomicsDB for Arrays partitioned by columns
@@ -541,7 +310,6 @@ class GenomicsDB {
    *   workspace
    *   callset_mapping_file
    *   vid_mapping_file
-   *   reference_genome
    *   attributes, optional 
    *   segment_size, optional
    * Throws GenomicsDBException
@@ -549,7 +317,6 @@ class GenomicsDB {
   GENOMICSDB_EXPORT GenomicsDB(const std::string& workspace,
              const std::string& callset_mapping_file,
              const std::string& vid_mapping_file,
-             const std::string& reference_genome,
              const std::vector<std::string>attributes = ALL_ATTRIBUTES,
              const uint64_t segment_size = DEFAULT_SEGMENT_SIZE);
 
@@ -626,24 +393,51 @@ class GenomicsDB {
    */
   GENOMICSDB_EXPORT GenomicsDBVariantCalls query_variant_calls(GenomicsDBVariantCallProcessor& processor);
 
+  /**
+   * Generate multi-sample vcf files from GenomicsDB in the Broad GVCF format for given array constrained by
+   *  column/row ranges
+   *       - see https://gatk.broadinstitute.org/hc/en-us/articles/360035531812-GVCF-Genomic-Variant-Call-Format
+   */
   GENOMICSDB_EXPORT void generate_vcf(const std::string& array,
                                  genomicsdb_ranges_t column_ranges,
                                  genomicsdb_ranges_t row_ranges,
+                                 const std::string& reference_genome,
+                                 const std::string& vcf_header = "vcf_header.vcf",
                                  const std::string& output = "",
                                  const std::string& output_format = "",
                                  bool overwrite = false);
 
+  /**
+   * Generate multi-sample vcf files from GenomicsDB in the Broad GVCF format using set configuration. This
+   *  method is useful with parallelism paradigms (MPI, Intel TBB)
+   *       - see https://gatk.broadinstitute.org/hc/en-us/articles/360035531812-GVCF-Genomic-Variant-Call-Format
+   */
   GENOMICSDB_EXPORT void generate_vcf(const std::string& output = "",
                                       const std::string& output_format = "",
                                       bool overwrite = false);
 
   /**
-   * Query by column and row ranges, use results to generate plink .ped and .map files
-   * The two files will be named <output_prefix>.ped and <output_prefix>.map
+   * Generate plink files from GenomicsDB for given array constrained by column/row ranges and given format to
+   * generate plink .ped and .map files. The output files are named <output_prefix>.ped and <output_prefix>.map
+   * respectively.
    */
   GENOMICSDB_EXPORT void generate_plink(const std::string& array,
-                                        VariantQueryConfig* query_config,
+                                        genomicsdb_ranges_t column_ranges,
+                                        genomicsdb_ranges_t row_ranges,
                                         unsigned char format = 7,
+                                        int compression = 1,
+                                        bool one_pass = false,
+                                        bool verbose = false,
+                                        double progress_interval = -1,
+                                        const std::string& output_prefix = "output",
+                                        const std::string& fam_list = "");
+
+ /**
+   * Generate plink files from GenomicsDB for given format to generate plink .ped and .map files. The output
+   * files are named <output_prefix>.ped and <output_prefix>.map
+   * respectively. This method is useful with parallelism paradigms (MPI, Intel TBB).
+   */
+  GENOMICSDB_EXPORT void generate_plink(unsigned char format = 7,
                                         int compression = 1,
                                         bool one_pass = false,
                                         bool verbose = false,
@@ -682,11 +476,7 @@ class GenomicsDB {
                     const std::string& output_format,
                     bool overwrite);
 
-  /**
-   * Utility function to set the type of the ALT field to string
-   */ 
-  void change_alt_to_string(std::map<std::string, genomic_field_type_t>& types);
-
+ private:
   VariantQueryConfig* get_query_config_for(const std::string& array);
 
   void* m_storage_manager = nullptr; // Pointer to VariantStorageManager instance

--- a/src/main/cpp/include/api/genomicsdb_plink.h
+++ b/src/main/cpp/include/api/genomicsdb_plink.h
@@ -1,0 +1,268 @@
+/**
+ * @file genomicsdb_plink.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Interface to GenomicsDB plink support
+ *
+ **/
+
+#pragma once
+
+#include "genomicsdb.h"
+
+// TODO: FIXME: Remove the following includes
+#include "genomicsdb_logger.h"
+#include "tiledb.h"
+#include "tiledb_utils.h"
+#include "variant_query_config.h"
+#include "vid_mapper.h"
+
+// TODO: FIXME: Remove references to internal classes, so the api remains opaque
+
+class GENOMICSDB_EXPORT GenomicsDBPlinkProcessor : public GenomicsDBVariantProcessor {
+  public:
+    // the formats variable encodes which formats to produce by the values of specific bits: 0 - bgen, 1 - bed, 2 - tped, e.g. formats == 0b110 encodes bed and tped
+    GenomicsDBPlinkProcessor(VariantQueryConfig* qc,
+                             const std::string& array,
+                             unsigned char formats = 7,
+                             int compression = 1,
+                             bool verbose = false,
+                             double progress_interval = -1,
+                             std::string prefix = "output",
+                             std::string fam_list = "",
+                             int rank = 0);
+
+    ~GenomicsDBPlinkProcessor() {
+      TileDBUtils::finalize_codec(codec);
+    }
+
+    virtual void process(const Variant& variant);
+    virtual void process(const std::string& sample_name,
+                         const int64_t* coordinates,
+                         const genomic_interval_t& genomic_interval,
+                         const std::vector<genomic_field_t>& genomic_fields,
+                         const bool phased);
+
+    void advance_state();
+    const char BGEN_MASK = 1;
+    const char  BED_MASK = 2;
+    const char TPED_MASK = 4;
+  private:
+    const std::string& array;
+    const VidMapper& vid_mapper;
+    bool make_bgen, make_tped, make_bed;
+    int compression = 0; // 0 for none, 1 for zlib, 2 for zstd
+    bool verbose = false;
+    // flattened coordinate to place in sorted map, phased status of column for bgen purposes (entire column considered unphased if any are unphased)
+    std::map<uint64_t, std::pair<int, bool>> variant_map;
+    double progress_interval;
+    std::string fam_list;
+    std::string prefix;
+    VariantQueryConfig* query_config;
+    // row to place in sorted map and sample name
+    std::map<uint64_t, std::pair<int, std::string>> sample_map;
+    bool sample_map_initialized = false;
+    // fam is identical to tfam, used with bed, tped respectively
+    std::fstream tped_file, fam_file, bim_file, bed_file, bgen_file;
+    int state = 0;
+    int last_sample = -1;
+    int num_variants = 0;
+    int last_coord = -1;
+    int last_alleles = -1;
+    bool last_phased;
+    int rank;
+    int total_rows = 0;
+    int total_cols = 0;
+
+    size_t tm = 0;
+    void progress_bar(const int64_t* coords) {
+      size_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+      if (now - progress_interval > tm) {
+        // flatten column and row ranges
+        int row = 0, col = 0;
+        for(auto& a : query_config->get_query_row_ranges(rank)) {
+          if(coords[0] <= a.second) {
+            row += coords[0] - a.first + 1;
+            break;
+          }
+          else {
+            row += a.second - a.first + 1;
+          }
+        }
+        for(auto& b : query_config->get_query_column_ranges(rank)) {
+          if(coords[1] <= b.second) {
+            col += coords[1] - b.first + 1;
+            break;
+          }
+          else {
+            col += b.second - b.first + 1;
+          }
+        }
+
+        long num = (long)col * total_rows + row + ((bool)state)*((long)total_rows * total_cols);
+        long den = (long)total_rows * total_cols * 2;
+
+        logger.info("Plink progress {} / {} = {:.2f}%", num, den, 100*(double)num/den);
+
+        tm = now;
+      }
+    }
+
+    // populate variant data block in bgen file for variant with given rsid spanning genomic_interval
+    // vec is REF and ALT combined (REF is first entry)
+    void bgen_variant_data_block(const std::string& rsid, const genomic_interval_t& genomic_interval, const std::vector<std::string>& vec, bool phased);
+
+    // return vector of tokens that were separated by sep in str
+    std::vector<std::string> split(std::string str, std::string sep = ",") {
+      std::vector<std::string> retval;
+      size_t index;
+      if(str.length() >= 2) {
+        if(str[0] == '[') {
+           str = str.substr(1, str.length() - 2);
+        }
+      }
+      while((index = str.find(sep)) != std::string::npos) {
+        retval.push_back(str.substr(0, index));
+        str.erase(0, index + 1);
+      }
+      retval.push_back(str);
+      return retval;
+    };
+
+    // BED variables/functions
+    char bed_buf = 0;
+    char bed_buf_state = 0;
+    void flush_to_bed() {
+      if(bed_buf_state) {
+        bed_file.write(&bed_buf, 1);
+        bed_buf = 0;
+        bed_buf_state = 0;
+      }
+    }
+
+    void write_to_bed(char x) {
+      bed_buf += x << bed_buf_state * 2;
+      ++bed_buf_state %= 4;    
+      if(!bed_buf_state){
+        bed_file.write(&bed_buf, 1);
+        bed_buf = 0;
+      }
+    }
+    // BGEN variables
+    char min_ploidy, max_ploidy;
+    int32_t bgen_gt_size;
+    uint32_t samples_in_column = 0;
+    void *codec;
+    std::string codec_buf;
+
+    // FIXME: hard coded for B = 8
+    // callback expects GT vector
+    void bgen_enumerate_phased(int ploidy, int alleles, std::function<void(const std::vector<int>&, int)> callback, bool drop_last = true) {
+      int size = 0;
+      int ind = -1;
+      int limit = alleles - drop_last;
+      for(int i = 0; i < ploidy; i++) {
+        for(int j = 0; j < limit; j++) {
+          callback({i, j}, ++ind);
+        }
+      }
+    }
+
+    // get_probabilitiles expects allele counts
+    void bgen_enumerate_unphased(int ploidy, int alleles, std::function<void(const std::vector<int>&, size_t)> callback, bool drop_last = true) {
+      int size = 0;
+      int ind = -1;
+      std::vector<int> allele_counts(alleles);
+
+      std::function<void(int, int)> enumerate_unphased;
+      enumerate_unphased = [&] (int used, int depth) {
+        int limit = ploidy - used - ((depth == alleles - 1) && drop_last); // if the highest depth (rightmost) do not iterate to highest possible count in order to drop last ((0, 0, ..., X) is the last)
+        if(depth) {
+          for(int i = 0; i <= limit; i++) { 
+            allele_counts[depth] = i;
+            enumerate_unphased(used + i, depth - 1);
+          }
+        }
+        else {
+          allele_counts[depth] = ploidy - used;
+          ++ind;
+          callback(allele_counts, (size_t)ind);
+        }
+      };
+
+      enumerate_unphased(0, alleles - 1);    
+    }
+
+    void bgen_empty_cell(int ploidy, int alleles, bool phased) {
+      auto write_zero = [&] (const std::vector<int>& v, int) {
+        char z = 0;
+        codec_buf.push_back(0);
+      };
+      if(phased) {
+        bgen_enumerate_phased(ploidy, alleles, write_zero);
+      }
+      else {
+        bgen_enumerate_unphased(ploidy, alleles, write_zero);
+      }
+    }
+
+    // fill in size, min/max ploidy of last column
+    void bgen_finish_gt() {
+      // write min ploidy
+      codec_buf[7] = min_ploidy;      
+
+      // write max ploidy
+      codec_buf[8] = max_ploidy;
+
+      size_t uncompressed_size = codec_buf.size(), data_size = codec_buf.size();
+
+      if(compression) {
+        char* data;
+        TileDBUtils::compress(codec, (unsigned char*)codec_buf.c_str(), codec_buf.length(), (void**)&data, data_size);
+        size_t total_size = data_size + 4;
+        bgen_file.write((char*)&total_size, 4); // BGEN: size of previous gt probability data plus D field
+        bgen_file.write((char*)&uncompressed_size, 4);
+        bgen_file.write(data, data_size);
+      }
+      else {
+        bgen_file.write((char*)&uncompressed_size, 4); // BGEN: size of previous gt probability data plus D field
+        bgen_file.write(codec_buf.c_str(), codec_buf.length());
+      }
+
+      codec_buf.clear();
+      bgen_gt_size = 0;
+      min_ploidy = 64;
+      max_ploidy = -1;
+    }
+
+    // locations in file
+    int bgen_gt_size_offset;
+    int bgen_min_ploidy_offset;
+    int bgen_max_ploidy_offset;
+    int bgen_ploidy_info_offset;
+    int bgen_probability_offset;
+};

--- a/src/main/cpp/include/config/genomicsdb_config_base.h
+++ b/src/main/cpp/include/config/genomicsdb_config_base.h
@@ -93,7 +93,9 @@ class GenomicsDBConfigBase {
   inline size_t get_combined_vcf_records_buffer_size_limit() const {
     return m_combined_vcf_records_buffer_size_limit;
   }
-  void set_vcf_header_filename(const std::string& vcf_header_filename);
+  void set_vcf_header_filename(const std::string& vcf_header_filename) {
+    m_vcf_header_filename = vcf_header_filename;
+  }
   const std::string& get_vcf_header_filename() const {
     return m_vcf_header_filename;
   }

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -529,7 +529,7 @@ void GenomicsDB::generate_vcf(const std::string& array,
     query_config.set_query_row_ranges(row_ranges);
   }
   query_config.set_reference_genome(reference_genome);
-  //query_config.set_vcf_header_filename(vcf_header);
+  query_config.set_vcf_header_filename(vcf_header);
 
   query_config.validate();
 

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019-2020 Omics Data Automation, Inc.
+ * Copyright (c) 2019-2020,2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -71,19 +71,16 @@ std::string genomicsdb_version() {
 #define VERIFY(X) if(!(X)) throw GenomicsDBException(#X);
 
 void check(const std::string& workspace,
-                  const uint64_t segment_size,
-                  const std::string& reference_genome) {
+           const uint64_t segment_size) {
   VERIFY(!workspace.empty() && "Workspace specified cannot be empty");
   VERIFY(segment_size && "Segment size specified has to be greater than 0");
-  VERIFY(!reference_genome.empty() && "Reference Genome cannot be empty for querying");
 }
 
 void check(const std::string& workspace,
                   const uint64_t segment_size,
                   const std::string& callset_mapping_file,
-                  const std::string& vid_mapping_file,
-                  const std::string& reference_genome) {
-  check(workspace, segment_size, reference_genome);
+           const std::string& vid_mapping_file) {
+  check(workspace, segment_size);
   VERIFY(!callset_mapping_file.empty() && "Callset Mapping File cannot be empty");
   VERIFY(!vid_mapping_file.empty() && "Vid Mapping File cannot be empty");
 }
@@ -92,10 +89,9 @@ void check(const std::string& workspace,
 GenomicsDB::GenomicsDB(const std::string& workspace,
                        const std::string& callset_mapping_file,
                        const std::string& vid_mapping_file,
-                       const std::string& reference_genome,
                        const std::vector<std::string>attributes,
                        const uint64_t segment_size) {
-  check(workspace, segment_size, callset_mapping_file, vid_mapping_file, reference_genome);
+  check(workspace, segment_size, callset_mapping_file, vid_mapping_file);
 
   // Create base query configuration
   m_query_config = new VariantQueryConfig();
@@ -105,7 +101,6 @@ GenomicsDB::GenomicsDB(const std::string& workspace,
   query_config->set_workspace(workspace);
   query_config->set_callset_mapping_file(callset_mapping_file);
   query_config->set_vid_mapping_file(vid_mapping_file);
-  query_config->set_reference_genome(reference_genome);
   query_config->set_attributes_to_query(attributes);
 
   // Create storage manager
@@ -162,8 +157,7 @@ GenomicsDB::GenomicsDB(const std::string& query_configuration,
   }
 
   check(query_config->get_workspace(concurrency_rank),
-        query_config->get_segment_size(),
-        query_config->get_reference_genome());
+        query_config->get_segment_size());
 
   // Discard intervals not part of this partition
   query_config->subset_query_column_ranges_based_on_partition(loader_config, concurrency_rank);
@@ -190,7 +184,7 @@ GenomicsDB::~GenomicsDB() {
 }
 
 std::map<std::string, genomic_field_type_t> create_genomic_field_types(const VariantQueryConfig &query_config,
-                                       void *annotation_service) {
+                                                                       void *annotation_service, bool change_alt_to_string=false) {
   std::map<std::string, genomic_field_type_t> genomic_field_types;
   for (auto i=0u; i<query_config.get_num_queried_attributes(); i++) {
     const std::string attribute_name = query_config.get_query_attribute_name(i);
@@ -200,13 +194,24 @@ std::map<std::string, genomic_field_type_t> create_genomic_field_types(const Var
       assert(descr.get_num_elements_in_tuple() > 0);
       const std::type_index type_index = descr.get_tuple_element_type_index(0);
       const FieldLengthDescriptor length_descr = field_info->m_length_descriptor;
-      genomic_field_types.insert(std::make_pair(
-      attribute_name,
-      genomic_field_type_t(type_index,
-                           length_descr.is_fixed_length_field(),
-                           length_descr.is_fixed_length_field()?length_descr.get_num_elements():0,
-                           length_descr.get_num_dimensions(),
-                           length_descr.is_length_ploidy_dependent()&&length_descr.contains_phase_information())));
+      if (change_alt_to_string && attribute_name == "ALT") {
+        // ALT pointer will be to the first std::string in a std::vector owned by an instance of VariantFieldALTData
+        genomic_field_types.insert(std::make_pair(
+            attribute_name,
+            genomic_field_type_t(genomic_field_type_t::genomicsdb_basic_type::STRING,
+                                 length_descr.is_fixed_length_field(),
+                                 length_descr.is_fixed_length_field()?length_descr.get_num_elements():0,
+                                 length_descr.get_num_dimensions(),
+                                 length_descr.is_length_ploidy_dependent()&&length_descr.contains_phase_information())));
+      } else {
+        genomic_field_types.insert(std::make_pair(
+            attribute_name,
+            genomic_field_type_t(type_index,
+                                 length_descr.is_fixed_length_field(),
+                                 length_descr.is_fixed_length_field()?length_descr.get_num_elements():0,
+                                 length_descr.get_num_dimensions(),
+                                 length_descr.is_length_ploidy_dependent()&&length_descr.contains_phase_information())));
+      }
     }
   }
   if (annotation_service) {
@@ -236,22 +241,16 @@ GenomicsDBVariants GenomicsDB::query_variants(const std::string& array,
 
   query_config.validate();
 
-  // ALT pointer will be to the first std::string in a std::vector owned by an instance of VariantFieldALTData
-  auto field_types = create_genomic_field_types(query_config, m_annotation_service);
-  change_alt_to_string(field_types);
-
-  return GenomicsDBVariants(TO_GENOMICSDB_VARIANT_VECTOR(query_variants(array, &query_config)), field_types);
+  return GenomicsDBVariants(TO_GENOMICSDB_VARIANT_VECTOR(query_variants(array, &query_config)),
+                            create_genomic_field_types(query_config, m_annotation_service, true));
 }
 
 GenomicsDBVariants GenomicsDB::query_variants() {
   VariantQueryConfig* query_config = TO_VARIANT_QUERY_CONFIG(m_query_config);
   const std::string& array = query_config->get_array_name(m_concurrency_rank);
 
-  // ALT pointer will be to the first std::string in a std::vector owned by an instance of VariantFieldALTData
-  auto field_types = create_genomic_field_types(*query_config, m_annotation_service);
-  change_alt_to_string(field_types);
-
-  return GenomicsDBVariants(TO_GENOMICSDB_VARIANT_VECTOR(query_variants(array, query_config)), field_types);
+  return GenomicsDBVariants(TO_GENOMICSDB_VARIANT_VECTOR(query_variants(array, query_config)),
+                            create_genomic_field_types(*query_config, m_annotation_service, true));
 }
 
 
@@ -491,18 +490,12 @@ std::vector<VariantCall>* GenomicsDB::query_variant_calls(const std::string& arr
   query_processor->do_query_bookkeeping(query_processor->get_array_schema(),
                                         *query_config, query_config->get_vid_mapper(), true);
 
-#if(DEBUG)
-  //print_variant_calls(*query_config, *query_processor, query_config->get_vid_mapper());
+#if(0)
+  print_variant_calls(*query_config, *query_processor, query_config->get_vid_mapper());
 #endif
 
   // Perform Query over all the intervals
   std::vector<VariantCall> *pvariant_calls = new std::vector<VariantCall>;
-  VidMapper* vid_mapper;
-  if (m_vid_mapper)  {
-    vid_mapper = TO_VID_MAPPER(m_vid_mapper);
-  } else {
-    vid_mapper = const_cast<VidMapper *>(&query_config->get_vid_mapper());
-  }
 
   GatherVariantCalls gather_variant_calls(processor, *query_config, m_annotation_service);
   query_processor->iterate_over_cells(query_processor->get_array_descriptor(), *query_config, gather_variant_calls, true);
@@ -520,6 +513,8 @@ std::vector<VariantCall>* GenomicsDB::query_variant_calls(const std::string& arr
 void GenomicsDB::generate_vcf(const std::string& array,
                               genomicsdb_ranges_t column_ranges,
                               genomicsdb_ranges_t row_ranges,
+                              const std::string& reference_genome,
+                              const std::string& vcf_header,
                               const std::string& output,
                               const std::string& output_format,
                               bool overwrite) {
@@ -533,6 +528,8 @@ void GenomicsDB::generate_vcf(const std::string& array,
   if (row_ranges.size() > 0) {
     query_config.set_query_row_ranges(row_ranges);
   }
+  query_config.set_reference_genome(reference_genome);
+  //query_config.set_vcf_header_filename(vcf_header);
 
   query_config.validate();
 
@@ -579,45 +576,8 @@ void GenomicsDB::generate_vcf(const std::string& array, VariantQueryConfig* quer
   delete query_processor;
 }
 
-void GenomicsDB::change_alt_to_string(std::map<std::string, genomic_field_type_t>& types) {
-  auto it = types.find("ALT");
-  if(it != types.end()) {
-    it->second.type_idx = genomic_field_type_t::genomicsdb_basic_type::STRING;
-  }
-}
-
 template<class VariantOrVariantCall>
 std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config);
-
-void GenomicsDB::generate_plink(const std::string& array,
-                                VariantQueryConfig* query_config,
-                                unsigned char format,
-                                int compression,
-                                bool one_pass,
-                                bool verbose,
-                                double progress_interval,
-                                const std::string& output_prefix,
-                                const std::string& fam_list) {
-  if(!m_vid_mapper) {
-    logger.error("No valid VidMapper, PLINK generation cancelled");
-    return;
-  }
-
-  GenomicsDBPlinkProcessor proc(query_config, static_cast<VidMapper*>(m_vid_mapper), array, format, compression, verbose, progress_interval, output_prefix, fam_list, m_concurrency_rank);
-  auto types = create_genomic_field_types(*query_config, m_annotation_service);
-  change_alt_to_string(types);
-
-  proc.initialize(types);
-
-  if(!one_pass) { // if one_pass is true, skip first pass and get participating samples from callset (will include samples without data)
-    query_variants(array, query_config, proc);
-  }
-  proc.advance_state();
-  query_variants(array, query_config, proc);
-  proc.advance_state();
-
-  VidMapper* vid_mapper = static_cast<VidMapper*>(m_vid_mapper);
-}
 
 // Template to get the mapped interval from the GenomicsDB array for the Variant(Call)
 template<class VariantOrVariantCall>
@@ -722,10 +682,8 @@ std::vector<genomic_field_t> GenomicsDB::get_genomic_fields(const std::string& a
 GenomicsDBVariantCalls GenomicsDB::get_variant_calls(const std::string& array, const genomicsdb_variant_t* variant) {
   std::vector<VariantCall>* variant_calls = const_cast<std::vector<VariantCall>*>(&(TO_VARIANT(variant)->get_calls()));
 
-  auto types = create_genomic_field_types(*get_query_config_for(array), m_annotation_service);
-  change_alt_to_string(types);
-
-  return GenomicsDBResults<genomicsdb_variant_call_t>(TO_GENOMICSDB_VARIANT_CALL_VECTOR(variant_calls), types);
+  return GenomicsDBResults<genomicsdb_variant_call_t>(TO_GENOMICSDB_VARIANT_CALL_VECTOR(variant_calls),
+                                                      create_genomic_field_types(*get_query_config_for(array), m_annotation_service, true));
 }
 
 int64_t GenomicsDB::get_row(const genomicsdb_variant_call_t* variant_call) {
@@ -800,668 +758,4 @@ void GenomicsDBVariantProcessor::process(const std::vector<Variant>& variants) {
   for(const auto& variant : variants) {
     process(variant);
   }
-}
-
-GenomicsDBPlinkProcessor::GenomicsDBPlinkProcessor(VariantQueryConfig* qc,
-                                                   VidMapper* vid_mapper,
-                                                   const std::string& array,
-                                                   unsigned char formats,
-                                                   int compression,
-                                                   bool verbose,
-                                                   double progress_interval,
-                                                   std::string prefix,
-                                                   std::string fam_list,
-                                                   int rank
-                                                  ) : query_config(qc), vid_mapper(vid_mapper), array(array), compression(compression), verbose(verbose), progress_interval(progress_interval), prefix(prefix), fam_list(fam_list), rank(rank) {
-  make_bgen = (bool)(formats & BGEN_MASK);
-  make_bed = (bool)(formats & BED_MASK);
-  make_tped = (bool)(formats & TPED_MASK);
-
-  // For use with BGEN compression
-  if(compression == 1) {
-    TileDBUtils::create_codec(&codec, TILEDB_GZIP, Z_DEFAULT_COMPRESSION);
-  }
-  else {
-    TileDBUtils::create_codec(&codec, TILEDB_ZSTD, 9);
-  }
-
-  // open various files
-  if(make_tped) {
-    tped_file.open(prefix + ".tped", std::ios::out);
-  }
-  if(make_bed) {
-    bed_file.open(prefix + ".bed", std::ios::out | std::ios::binary);
-    bim_file.open(prefix + ".bim", std::ios::out);
-  }
-  if(make_tped || make_bed) {
-    fam_file.open(prefix + ".fam", std::ios::out);
-  }
-  if(make_bgen) {
-    bgen_file.open(prefix + ".bgen", std::ios::out | std::ios::binary);
-  }
-
-  if(make_bed) {
-    char magic_numbers[] = {0x6c, 0x1b, 0x01};
-    bed_file.write(magic_numbers, 3); // BED: magic numbers
-  }
-
-  if(make_bgen) {
-    int32_t zero = 0;
-    int32_t offset = 20; // BGEN: offset of first variant data block relative to 5th byte. Always 20 here because free data area left empty
-    bgen_file.write((char*)&offset, 4); // BGEN: first 4 bytes has offset
-    bgen_file.write((char*)&offset, 4); // BGEN: beginning of header, next 4 bytes same in this case
-    bgen_file.write((char*)&zero, 4); // BGEN: 4 bytes number of variants (M), filled in later
-    bgen_file.write((char*)&zero, 4); // BGEN: 4 bytes number of samples (N), filled in later
-
-    char bgen_magic_numbers[] = {'b', 'g', 'e', 'n'};
-    bgen_file.write(bgen_magic_numbers, 4); // BGEN: 4 bytes bgen magic number
-
-    int32_t flags = 0b10000000000000000000000000001000; // BGEN: layout 2, sample identifier block present
-    flags = flags | compression;
-    bgen_file.write((char*)&flags, 4); // BGEN: 4 bytes flags, end of header
-  }
-
-  // for use with progress bar
-  for(auto& a : query_config->get_query_row_ranges(rank)) {
-    total_rows += a.second - a.first + 1;
-  }
-  for(auto& b : query_config->get_query_column_ranges(rank)) {
-    total_cols += b.second - b.first + 1;
-  }
-}
-
-void GenomicsDBPlinkProcessor::bgen_variant_data_block(const std::string& rsid, const genomic_interval_t& genomic_interval, const std::vector<std::string>& vec, bool phased) {
-  // BGEN: fill in genotype block size and min/max ploidy from previous iteration
-  if(last_sample != -1) { // no need on first column
-    if(samples_in_column < sample_map.size()) {
-      min_ploidy = (min_ploidy > 2) ? 2 : min_ploidy;
-      max_ploidy = (max_ploidy < 2) ? 2 : max_ploidy;
-    }
-    samples_in_column = 0;
-    bgen_finish_gt();
-  }
-  min_ploidy = 64;
-  max_ploidy = -1;
-
-  // BGEN: variant data blocks
-  int16_t zero = 0;
-  int16_t one = 1;
-  bgen_file.write((char*)&one, 2); // BGEN: 2 byte length of variant identifier, not stored in GenomicsDB so using dummy
-  bgen_file.write((char*)&one, 1); // BGEN: dummy variant id
-  int16_t rsid_len = rsid.length();
-  bgen_file.write((char*)&rsid_len, 2); // BGEN: 2 byte length of rsid
-  bgen_file.write(rsid.c_str(), rsid_len); // BGEN: rsid
-  std::string chrom = genomic_interval.contig_name;
-  int16_t chrom_len = chrom.length();
-  bgen_file.write((char*)&chrom_len, 2); // BGEN: 2 byte chrom length
-  bgen_file.write(chrom.c_str(), chrom_len); // BGEN: chrom
-  uint32_t variant_pos = genomic_interval.interval.first;
-  bgen_file.write((char*)&variant_pos, 4); // BGEN: 4 byte variant position
-  int16_t K = vec.size();
-  bgen_file.write((char*)&K, 2);// BGEN: 2 byte K for number of alleles
-  // write alleles and lengths
-  int32_t len;
-  for(auto& a : vec) { // iterate over alleles
-    len = a.length();
-    bgen_file.write((char*)&len, 4); // BGEN: 4 byte length of allele
-    bgen_file.write(a.c_str(), len); // BGEN: allele
-  }
-
-  // BGEN: genotype data block (layout 2, uncompressed)
-  bgen_gt_size_offset = bgen_file.tellp();
-  bgen_gt_size = 0;
-  int32_t fourB_zero = 0;
-
-  // BGEN: preallocate probability data storage
-  int32_t N = sample_map.size();
-  codec_buf.append((char*)&N, 4); // BGEN: 4 byte N
-  codec_buf.append((char*)&K, 2); // BGEN: 2 byte K
-  bgen_min_ploidy_offset = bgen_file.tellp();
-  codec_buf.append((char*)&fourB_zero, 1); // BGEN: 1 byte min ploidy (placeholder)
-  bgen_max_ploidy_offset = bgen_file.tellp();
-  codec_buf.append((char*)&fourB_zero, 1); // BGEN: 1 byte max ploidy (placeholder)
-  bgen_ploidy_info_offset = bgen_file.tellp();
-  char default_sample_info = 0b10000010; // default missingness and ploidy information: set to missing/diploid unspecified
-  for(int j = 0; j < N; j++) {
-    codec_buf.append(&default_sample_info, 1); // BGEN: default sample information within this variant: because missing is set to 1, no need to backfill skipped cells
-  }
-  codec_buf.append((char*)&phased, 1); // BGEN: 1 byte phased
-  char B = 8; // precision at one byte to avoid alignment difficulties
-  codec_buf.append(&B, 1); // BGEN: 1 byte unsigned bits of precision
-  bgen_probability_offset = bgen_file.tellp();
-}
-
-void GenomicsDBPlinkProcessor::process(const Variant& variant) {
-  auto& calls = variant.get_calls();
-
-  bool phased = true;
-  std::string gt_string;
-
-  for(auto& c : calls) {
-    auto fields = get_genomic_fields_for(array, &c, query_config);
-    
-    for(auto& f : fields) {
-      if(f.name == "GT") {
-        gt_string = f.to_string(get_genomic_field_type(f.name));
-
-        if(gt_string.find('/') != std::string::npos && gt_string.find('.') == std::string::npos) { // unphased if contains a slash or is ./. (might be able to use GL/PL, which are unphased probabilities)
-          phased = false;
-        }
-        break;
-      }
-    }
-    if(!phased) { break; }
-  }
-
-  for(auto& c : calls) {
-    auto fields = get_genomic_fields_for(array, &c, query_config);
-
-    int64_t coords[] = {(int64_t)c.get_row_idx(), (int64_t)c.get_column_begin()};
-    int64_t end_position = c.get_column_end();
-
-    std::string contig_name;
-    int64_t contig_position;
-    if (!vid_mapper->get_contig_location(coords[1], contig_name, contig_position)) {
-      std::cerr << "Could not find genomic interval associated with Variant(Call) at "
-        << coords[1] << std::endl;
-      continue;
-    }
-
-    contig_position++;
-    genomic_interval_t genomic_interval(std::move(contig_name),
-                                        std::make_pair(contig_position, contig_position+end_position-coords[1]));
-
-    std::string sample_name;
-    if (!vid_mapper->get_callset_name(coords[0], sample_name)) {
-      sample_name = "NONE";
-    }
-
-    process(sample_name, coords, genomic_interval, fields, phased);
-  }
-}
-
-void GenomicsDBPlinkProcessor::process(const std::string& sample_name,
-                                       const int64_t* coords,
-                                       const genomic_interval_t& genomic_interval,
-                                       const std::vector<genomic_field_t>& genomic_fields,
-                                       const bool phased) {
-  last_phased = phased;
-
-  if(progress_interval > 0) {
-    progress_bar(coords);
-  }
-
-  std::string ref_string, alt_string, gt_string, id_string, pl_string, gl_string, pq_string;
-  for(auto& f : genomic_fields) {
-    if(f.name == "ALT") {
-      std::string combined_alt = f.recombine_ALT_value(get_genomic_field_type(f.name));
-      if(combined_alt.size()) {
-        alt_string = combined_alt.substr(1, combined_alt.length() - 2);
-      }
-    }
-    else if(f.name == "REF") {
-      ref_string = f.to_string(get_genomic_field_type(f.name));
-    }
-    else if(f.name == "GT") {
-      gt_string = f.to_string(get_genomic_field_type(f.name));
-    }
-    else if(f.name == "ID") {
-      id_string = f.to_string(get_genomic_field_type(f.name));
-    }
-    else if(f.name == "PL") {
-      pl_string = f.to_string(get_genomic_field_type(f.name));
-    }
-    else if(f.name == "GL") {
-      gl_string = f.to_string(get_genomic_field_type(f.name));
-    }
-    else if(f.name == "PQ") {
-      pq_string = f.to_string(get_genomic_field_type(f.name));
-    }
-  }
-
-  if(!alt_string.size()) {
-    logger.error("No ALT field for sample: {} row: {} column: {}", sample_name, coords[0], coords[1]);
-    exit(1);
-  }
-  if(!ref_string.size()) {
-    logger.error("No REF field for sample: {} row: {} column: {}", sample_name, coords[0], coords[1]);
-    exit(1);
-  }
-  if(!gt_string.size()) {
-    logger.error("No GT field for sample: {} row: {} column: {}", sample_name, coords[0], coords[1]);
-    exit(1);
-  }
-
-  // collect alleles
-  std::vector<std::string> vec = {ref_string};
-  size_t index;
-  while((index = alt_string.find(", ")) != std::string::npos) {
-    vec.push_back(alt_string.substr(0, index));
-    alt_string.erase(0, index + 2);
-  }
-  vec.push_back(alt_string);
-
-  std::vector<int> gt_vec;
-  auto iter = gt_string.begin();
-
-  // parse GT
-  try {
-    while((iter = find_if(gt_string.begin(), gt_string.end(), [] (char c) { return c == '|' || c == '/'; })) != gt_string.end()) {
-      index = iter - gt_string.begin();
-      gt_vec.push_back(std::stoi(gt_string.substr(0, index)));
-      gt_string.erase(0, index + 1);
-    }
-    gt_vec.push_back(std::stoi(gt_string));
-  }
-  catch (...) { // probably ./., treat as missing cell
-    return;
-  }
-
-  for(auto g : gt_vec) {
-    if(g < 0 || g >= vec.size()) {
-      if(verbose) {
-        logger.error("GT field for sample: {} row: {} column: {},  contains index {}, which is out of bounds (1 ref allele, {} alt allele(s))", sample_name, coords[0], coords[1], g, vec.size() - 1);
-       }
-      return;
-    }
-  }
-
-  int16_t ploidy = gt_vec.size();
-
-  if(!state) {
-    sample_map_initialized = true; // possible to skip first pass, sample map will be populated from callset
-
-    sample_map.insert(std::make_pair(coords[0], std::make_pair(-1, sample_name)));
-    last_coord = coords[1];
-    return;
-  }
-
-  if(ploidy != 2 && (make_bed || make_tped)) { 
-    logger.error("The tped/bed formats do not support ploidies other than 2.");
-    make_bed = 0;
-    make_tped = 0;
-    if(make_bgen) {
-      logger.info("Continuing bgen generation");
-    } 
-  }
-
-  if(state == 1) {
-    std::string rsid;
-    std::string rsid_row;
-    if(id_string.size()) {
-      rsid = id_string;
-    }
-    else {
-      rsid = genomic_interval.contig_name + ":" + std::to_string(genomic_interval.interval.first);
-    }
-    rsid_row = genomic_interval.contig_name + " " + rsid + " 0 " + std::to_string(genomic_interval.interval.first);
-
-    int sind = sample_map[coords[0]].first;
-
-    // backfill if needed
-    bool backfill = coords[1] - last_coord && last_coord != -1;
-    int add_to_prev = backfill ? sample_map.size() - (last_sample + 1) : 0;
-    int add_to_current = backfill ? sind : sind - (last_sample + 1);
-
-    if(last_coord != coords[1]) { // first in variant
-      num_variants++;
-
-      for(int i = 0; i < add_to_prev; i++) { // backfill samples missing from previous variant
-        if(make_tped) {
-          tped_file << " 0 0";
-        }
-        if(make_bed) {
-          write_to_bed(1);
-        }
-        if(make_bgen) {
-          // BGEN: backfill probability data
-          bgen_empty_cell(2, last_alleles, phased);
-        }
-      }
-      if(make_bed) {
-        flush_to_bed();
-      }
-
-      if(make_tped) {
-        if(last_sample != -1) { // first line should not have newline
-          tped_file << std::endl;
-        }
-        tped_file << rsid_row;
-      }
-
-      if(make_bgen) {
-        bgen_variant_data_block(rsid, genomic_interval, vec, phased);
-      }
-    }
-    else {
-      samples_in_column++;
-    }
-
-    for(int i = 0; i < add_to_current; i++) { // backfill samples missing from current variant
-      if(make_bed) {
-        write_to_bed(1);
-      }
-
-      if(make_tped) {
-        tped_file << " 0 0";
-      }
-
-      if(make_bgen) {
-        // BGEN: backfill probability data
-        bgen_empty_cell(2, vec.size(), phased);
-      }
-    }
-
-    // safe to update now that backfilling is over
-    last_alleles = vec.size();
-
-    if(make_bed) {
-      char gt_code;
-      if(!(gt_vec[0] || gt_vec[1])) { // homozygous for first allele
-        gt_code = 0;
-      }
-      else if(gt_vec[0] + gt_vec[1] == 1) { // heterozygous
-        gt_code = 2;
-      }
-      else if(gt_vec[0] == 1 && gt_vec[1] == 1) { // homozygous for second allele
-        gt_code = 3;
-      }
-      else { // missing genotype
-        gt_code = 1;
-      }
-
-      if(last_coord != coords[1]) {
-        bim_file << rsid_row;
-        bim_file << " " << vec[0] << " " << vec[1] << std::endl;
-      }
-      write_to_bed(gt_code);
-    }
-
-    if(make_tped) {
-      tped_file << " " << vec[gt_vec[0]] << " " << vec[gt_vec[1]];
-    }
-
-    last_sample = sample_map[coords[0]].first;
-    //last_variant = vind;
-    last_coord = coords[1];
-
-    // convert PL to BGEN format
-    std::vector<double> pl_vec;
-    bool pl_dot = false;
-
-    try {
-      for(auto& tok : split(pl_string)) {
-        if(tok == ".") pl_dot = true;
-        int val = std::stoi(tok);
-        if(val >= 0) {
-          pl_vec.push_back(val);
-        }
-        else {
-          throw std::runtime_error("PL value is negative");
-        }
-      }
-    }
-    catch(...) {
-      pl_vec.clear();
-      if(!pl_dot && verbose) {
-        logger.error("PL field for sample: {} row: {} column: {} contains a negative value or otherwise did not parse, full string: {}", sample_name, coords[0], coords[1], pl_string);
-      }
-    }
-
-    std::vector<char> pl_probs;
-
-    double pl_total = 0;
-    double epsilon = .05;
-    for(auto& a : pl_vec) {
-      double prob = std::pow(10, double(a)/-10);
-      pl_total += prob;
-      pl_probs.push_back(char(std::numeric_limits<unsigned char>::max() * prob));
-    }
-
-    // parse GL
-    std::vector<double> gl_vec;
-    bool gl_dot = false;
-
-    try {
-      for(auto& tok : split(gl_string)) {
-        if(tok == ".") gl_dot = true;
-        double val = std::stod(tok);
-        if(val <= 0) {
-          gl_vec.push_back(val);
-        }
-        else {
-          throw std::runtime_error("GL value is positive");
-        }
-      }
-    }
-    catch(...) {
-      gl_vec.clear();
-      if(!gl_dot && verbose) {
-        logger.error("GL field for sample: {} row: {} column: {} contains a strictly positive value or otherwise did not parse, full string {}", sample_name, coords[0], coords[1], gl_string);
-      }
-    }
-
-    std::vector<char> gl_probs;
-
-    double gl_total = 0;
-    for(auto& a : gl_vec) {
-      double prob = std::pow(10, a);
-      gl_total += prob;
-      gl_probs.push_back(char(std::numeric_limits<unsigned char>::max() * prob));
-    }
-
-    std::vector<char> probs;
-
-    // subtract 1 representing reference
-    auto num_genotypes = KnownFieldInfo::get_number_of_genotypes(vec.size() - 1, ploidy);
-
-    if(gl_probs.size()) { // prefer gl as it is more precise (pl is rounded)
-      if(gl_probs.size() == num_genotypes) {
-        if(std::abs(1 - gl_total) > epsilon && verbose) {
-          logger.warn("GL probabilities at sample: {} row: {} column: {} sum to {}, expected near 1. Generated BGEN may be invalid", sample_name, coords[0], coords[1], gl_total);
-        }
-        probs = gl_probs;
-      }
-      else {
-        if(verbose) {
-          logger.error("GL length at sample: {} row: {} column: {} is {}, expected {}. Defaulting to using GT to construct probabilities", sample_name, coords[0], coords[1], gl_vec.size(), num_genotypes);
-        }
-      }
-    }
-    else if(pl_probs.size()) {
-      if(pl_probs.size() == num_genotypes) {
-        if(std::abs(1 - pl_total) > epsilon && verbose) {
-          logger.warn("PL probabilities at sample: {} row: {} column: {} sum to {}, expected near 1. Generated BGEN may be invalid", sample_name, coords[0], coords[1], pl_total);
-        }
-        probs = pl_probs;
-      }
-      else {
-        if(verbose) {
-          logger.error("PL length at sample: {} row: {} column: {} is {}, expected {}. Defaulting to using GT to construct probabilities", sample_name, coords[0], coords[1], pl_vec.size(), num_genotypes);
-        }
-      }
-    }
-
-    double pq;
-    if(pq_string.length()) {
-      try {
-        pq = std::pow(10, (double)std::stoi(pq_string)/-10);
-      }
-      catch(...) {
-        pq_string.clear();
-      }
-    }
-
-    auto write_phased_probability = [&] (const std::vector<int>& v, size_t ind) {
-      char p = gt_vec[v[0]] == v[1] ? -1 : 0;
-      codec_buf.push_back(p);
-    };
-
-    auto write_unphased_probability = [&] (const std::vector<int>& v, size_t ind) {
-      char p;
-
-      if(!probs.size()) {
-        std::vector<int> counts(vec.size(), 0);
-        for(auto& g : gt_vec) {
-          counts[g]++;
-        }
-        p = counts == v ? -1 : 0;
-      }
-      else {
-        if(ind < probs.size()) {
-          p = probs[ind];
-        }
-        else {
-          // NOTE: this should never be triggered, GL/PL length is checked above
-          logger.error("BGEN generation error: GL/PL probabilies only have {} term(s), halting BGEN generation", probs.size());
-          make_bgen = 0;
-        }
-      }
-      codec_buf.push_back(p);
-    };
-
-    if(make_bgen) {
-      // store sample as not missing/ploidy info
-      if(ploidy < 64) {
-         min_ploidy = ploidy < min_ploidy ? ploidy : min_ploidy;
-        max_ploidy = ploidy > max_ploidy ? ploidy : max_ploidy;
-        char p = ploidy;
-        codec_buf[8 + sample_map[coords[0]].first] = p;
-
-        if(phased) { // phased
-          bgen_enumerate_phased(ploidy, vec.size(), write_phased_probability);
-        }
-         else { // unphased
-          bgen_enumerate_unphased(ploidy, vec.size(), write_unphased_probability);
-        }
-      }
-    }
-  }
-}
-
-void GenomicsDBPlinkProcessor::process(const interval_t& interval) {
-  return;
-}
-
-void GenomicsDBPlinkProcessor::advance_state() {
-  if(!state) {
-    if(!sample_map_initialized) { // populate from callset
-      std::string str;
-      auto num_rows = query_config->get_num_rows_to_query();
-      int row;
-      for(int i = 0; i < num_rows; i++) {
-        row = query_config->get_array_row_idx_for_query_row_idx(i);
-        vid_mapper->get_callset_name(row, str);
-        sample_map.insert(std::make_pair(row, std::make_pair(-1, str)));
-      }
-    }
-
-    // associate samples with sorted position
-    int i = -1;
-    for(auto& a : sample_map) {
-      ++i;
-      a.second.first = (uint64_t)i;
-    }
-    // associate variants with sorted position
-    i = -1;
-    last_sample = -1;
-    last_coord = -1;
-  
-    if(make_bed || make_tped) {
-      // Find samples coincident with entries in fam files (if specified) and associate information with sample name
-      std::map<std::string, std::string> fam_entries;
-    
-      if(fam_list.length()) {
-        std::ifstream fam_list_file(fam_list);
-        std::string fname;
-        while(std::getline(fam_list_file, fname)) {
-          std::ifstream file(fname);
-          std::string entry;
-          while(std::getline(file, entry)) {
-            std::string fid, wfid, fthid, mthid;
-            char sex, pt;
-            std::stringstream(entry) >> fid >> wfid >> fthid >> mthid >> sex >> pt;
-            fam_entries.insert(std::make_pair(wfid, entry));
-          }
-        }
-      }
-      for(auto& s : sample_map) {
-        if(fam_entries.count(s.second.second)) {
-          fam_file << fam_entries[s.second.second] << std::endl;
-        }
-        else {
-          fam_file << s.second.second << " " << s.second.second << " 0 0 0 0" << std::endl;
-        }
-      }
-    }
-
-    if(make_bgen) {
-      // BGEN: fill in N in header
-      bgen_file.seekp(12);
-      int32_t N = sample_map.size();
-      bgen_file.write((char*)&N, 4); // BGEN: 4 byte N
-      // Fill in M at end, as first pass, which counts variants, may be skipped
-
-      // BGEN: write sample identifier block
-      bgen_file.seekp(24);
-      int32_t lsi = 0;
-      bgen_file.write((char*)&lsi, 4); // BGEN: 4 byte total length of sample identifier block, filled in last
-      bgen_file.write((char*)&N, 4); // BGEN: 4 byte N, deliberately duplicated here as per spec
-      lsi = 8; // total length includes 8 bytes metainfo
-
-      int16_t len;
-      for(auto& s : sample_map) { // BGEN: write each sample id, can potentially be combined with above foreach loop
-        len = s.second.second.length();
-        lsi += len + 2; // total length increased by length of identifier and 2 byte length field
-       
-        bgen_file.write((char*)&len, 2);
-        bgen_file.write(s.second.second.c_str(), len);
-      }
-
-      bgen_file.seekp(24);
-      bgen_file.write((char*)&lsi, 4); // BGEN: 4 byte total length of sample identifier block, now with correct value
-       bgen_file.seekp(0);
-      int32_t offset = lsi + 20;
-      bgen_file.write((char*)&offset, 4);
-      // BGEN: update initial offset to include size of sample block
-      bgen_file.seekp(24 + lsi); // seek to end of sample identifier block
-    }
-  }
-
-  if(state == 1) {
-    // if skipped some samples at end, fill with reample_map.insert(std::make_pair(sample_name, -1));
-    int add_to_current = sample_map.size() - (last_sample + 1);
-
-    for(int i = 0; i < add_to_current; i++) {
-      if(make_tped) {
-        tped_file << " 0 0";
-      }
-      if(make_bed) {
-        write_to_bed(1);
-      }
-      if(make_bgen) {
-        // BGEN: backfill last variant
-        bgen_empty_cell(2, last_alleles, last_phased);
-      }
-    }
-    if(make_bed) {
-      flush_to_bed();
-    }
-
-    if(make_tped) {
-      tped_file << std::endl;
-    }
-
-    if(sample_map.size() && make_bgen) {
-      bgen_finish_gt();
-    }
-
-    if(make_bgen) {
-      // BGEN: fill in M in header
-      bgen_file.seekp(8);
-      int32_t M = num_variants;
-      bgen_file.write((char*)&M, 4); // BGEN: 4 byte M
-    }
-  }
-  state++;
 }

--- a/src/main/cpp/src/api/genomicsdb_field.cc
+++ b/src/main/cpp/src/api/genomicsdb_field.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2020 Omics Data Automation, Inc.
+ * Copyright (c) 2020,2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -51,9 +51,8 @@ std::string genomic_field_t::recombine_ALT_value(const genomic_field_type_t& fie
         output.empty()?output=item:output=output+separator+item;
       }
     }
-  }
-  // otherwise treat as char*
-  else {
+  } else {
+    // otherwise treat as char*
     std::stringstream ss(str_value());
     while (std::getline(ss, item, PHASED_ALLELE_SEPARATOR)){
       if (IS_NON_REF_ALLELE(item)) {

--- a/src/main/cpp/src/api/genomicsdb_plink.cc
+++ b/src/main/cpp/src/api/genomicsdb_plink.cc
@@ -1,0 +1,771 @@
+/**
+ * @file genomicsdb_plink.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Implementation of the query interface to GenomicsDB and plink
+ *
+ **/
+
+#include "genomicsdb_plink.h"
+
+#include <iostream>
+#include <string>
+
+#include "annotation_service.h"
+#include "query_variants.h"
+#include "tiledb_utils.h"
+#include "variant_field_data.h"
+#include "variant_operations.h"
+#include "variant_query_config.h"
+#include "vcf_adapter.h"
+#include "vid_mapper_pb.h"
+
+#define TO_VARIANT_QUERY_CONFIG(X) (reinterpret_cast<VariantQueryConfig *>(static_cast<void *>(X)))
+
+// Prototypes to internal methods in genomicsdb.cc declared here instead of header to keep the api opaque
+std::map<std::string, genomic_field_type_t> create_genomic_field_types(const VariantQueryConfig &query_config,
+                                                   void *annotation_service, bool change_alt_to_string=false);
+template<class VariantOrVariantCall>
+std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config);
+
+void GenomicsDB::generate_plink(const std::string& array,
+                                genomicsdb_ranges_t column_ranges,
+                                genomicsdb_ranges_t row_ranges,
+                                unsigned char format,
+                                int compression,
+                                bool one_pass,
+                                bool verbose,
+                                double progress_interval,
+                                const std::string& output_prefix,
+                                const std::string& fam_list) {
+   // Create Variant Config for given concurrency_rank
+  VariantQueryConfig *base_query_config = TO_VARIANT_QUERY_CONFIG(m_query_config);
+  VariantQueryConfig query_config(*base_query_config);
+  query_config.set_array_name(array);
+  if (column_ranges.size() > 0) {
+    query_config.set_query_column_ranges(column_ranges);
+  }
+  if (row_ranges.size() > 0) {
+    query_config.set_query_row_ranges(row_ranges);
+  }
+
+  query_config.validate();
+
+  GenomicsDBPlinkProcessor proc(&query_config, array, format, compression, verbose, progress_interval,
+                                output_prefix, fam_list, m_concurrency_rank);
+
+  proc.initialize(create_genomic_field_types(query_config, m_annotation_service, true));
+
+  if(!one_pass) { // if one_pass is true, skip first pass and get participating samples from callset (will include samples without data)
+    query_variants(array, &query_config, proc);
+  }
+  proc.advance_state();
+  query_variants(array, &query_config, proc);
+  proc.advance_state();
+}
+
+void GenomicsDB::generate_plink(unsigned char format,
+                                int compression,
+                                bool one_pass,
+                                bool verbose,
+                                double progress_interval,
+                                const std::string& output_prefix,
+                                const std::string& fam_list) {
+  VariantQueryConfig* query_config = TO_VARIANT_QUERY_CONFIG(m_query_config);
+
+  auto array = query_config->get_array_name(m_concurrency_rank);
+  GenomicsDBPlinkProcessor proc(query_config, array, format, compression, verbose, progress_interval,
+                                output_prefix, fam_list, m_concurrency_rank);
+
+  proc.initialize(create_genomic_field_types(*query_config, m_annotation_service, true));
+
+  if(!one_pass) { // if one_pass is true, skip first pass and get participating samples from callset (will include samples without data)
+    query_variants(array, query_config, proc);
+  }
+  proc.advance_state();
+  query_variants(array, query_config, proc);
+  proc.advance_state();
+}
+
+GenomicsDBPlinkProcessor::GenomicsDBPlinkProcessor(VariantQueryConfig* qc,
+                                                   const std::string& array,
+                                                   unsigned char formats,
+                                                   int compression,
+                                                   bool verbose,
+                                                   double progress_interval,
+                                                   std::string prefix,
+                                                   std::string fam_list,
+                                                   int rank
+                                                   ) : query_config(qc), vid_mapper(qc->get_vid_mapper()), array(array), compression(compression), verbose(verbose), progress_interval(progress_interval), prefix(prefix), fam_list(fam_list), rank(rank) {
+  make_bgen = (bool)(formats & BGEN_MASK);
+  make_bed = (bool)(formats & BED_MASK);
+  make_tped = (bool)(formats & TPED_MASK);
+
+  // For use with BGEN compression
+  if(compression == 1) {
+    TileDBUtils::create_codec(&codec, TILEDB_GZIP, Z_DEFAULT_COMPRESSION);
+  }
+  else {
+    TileDBUtils::create_codec(&codec, TILEDB_ZSTD, 9);
+  }
+
+  // open various files
+  if(make_tped) {
+    tped_file.open(prefix + ".tped", std::ios::out);
+  }
+  if(make_bed) {
+    bed_file.open(prefix + ".bed", std::ios::out | std::ios::binary);
+    bim_file.open(prefix + ".bim", std::ios::out);
+  }
+  if(make_tped || make_bed) {
+    fam_file.open(prefix + ".fam", std::ios::out);
+  }
+  if(make_bgen) {
+    bgen_file.open(prefix + ".bgen", std::ios::out | std::ios::binary);
+  }
+
+  if(make_bed) {
+    char magic_numbers[] = {0x6c, 0x1b, 0x01};
+    bed_file.write(magic_numbers, 3); // BED: magic numbers
+  }
+
+  if(make_bgen) {
+    int32_t zero = 0;
+    int32_t offset = 20; // BGEN: offset of first variant data block relative to 5th byte. Always 20 here because free data area left empty
+    bgen_file.write((char*)&offset, 4); // BGEN: first 4 bytes has offset
+    bgen_file.write((char*)&offset, 4); // BGEN: beginning of header, next 4 bytes same in this case
+    bgen_file.write((char*)&zero, 4); // BGEN: 4 bytes number of variants (M), filled in later
+    bgen_file.write((char*)&zero, 4); // BGEN: 4 bytes number of samples (N), filled in later
+
+    char bgen_magic_numbers[] = {'b', 'g', 'e', 'n'};
+    bgen_file.write(bgen_magic_numbers, 4); // BGEN: 4 bytes bgen magic number
+
+    int32_t flags = 0b10000000000000000000000000001000; // BGEN: layout 2, sample identifier block present
+    flags = flags | compression;
+    bgen_file.write((char*)&flags, 4); // BGEN: 4 bytes flags, end of header
+  }
+
+  // for use with progress bar
+  for(auto& a : query_config->get_query_row_ranges(rank)) {
+    total_rows += a.second - a.first + 1;
+  }
+  for(auto& b : query_config->get_query_column_ranges(rank)) {
+    total_cols += b.second - b.first + 1;
+  }
+}
+
+void GenomicsDBPlinkProcessor::bgen_variant_data_block(const std::string& rsid, const genomic_interval_t& genomic_interval, const std::vector<std::string>& vec, bool phased) {
+  // BGEN: fill in genotype block size and min/max ploidy from previous iteration
+  if(last_sample != -1) { // no need on first column
+    if(samples_in_column < sample_map.size()) {
+      min_ploidy = (min_ploidy > 2) ? 2 : min_ploidy;
+      max_ploidy = (max_ploidy < 2) ? 2 : max_ploidy;
+    }
+    samples_in_column = 0;
+    bgen_finish_gt();
+  }
+  min_ploidy = 64;
+  max_ploidy = -1;
+
+  // BGEN: variant data blocks
+  int16_t zero = 0;
+  int16_t one = 1;
+  bgen_file.write((char*)&one, 2); // BGEN: 2 byte length of variant identifier, not stored in GenomicsDB so using dummy
+  bgen_file.write((char*)&one, 1); // BGEN: dummy variant id
+  int16_t rsid_len = rsid.length();
+  bgen_file.write((char*)&rsid_len, 2); // BGEN: 2 byte length of rsid
+  bgen_file.write(rsid.c_str(), rsid_len); // BGEN: rsid
+  std::string chrom = genomic_interval.contig_name;
+  int16_t chrom_len = chrom.length();
+  bgen_file.write((char*)&chrom_len, 2); // BGEN: 2 byte chrom length
+  bgen_file.write(chrom.c_str(), chrom_len); // BGEN: chrom
+  uint32_t variant_pos = genomic_interval.interval.first;
+  bgen_file.write((char*)&variant_pos, 4); // BGEN: 4 byte variant position
+  int16_t K = vec.size();
+  bgen_file.write((char*)&K, 2);// BGEN: 2 byte K for number of alleles
+  // write alleles and lengths
+  int32_t len;
+  for(auto& a : vec) { // iterate over alleles
+    len = a.length();
+    bgen_file.write((char*)&len, 4); // BGEN: 4 byte length of allele
+    bgen_file.write(a.c_str(), len); // BGEN: allele
+  }
+
+  // BGEN: genotype data block (layout 2, uncompressed)
+  bgen_gt_size_offset = bgen_file.tellp();
+  bgen_gt_size = 0;
+  int32_t fourB_zero = 0;
+
+  // BGEN: preallocate probability data storage
+  int32_t N = sample_map.size();
+  codec_buf.append((char*)&N, 4); // BGEN: 4 byte N
+  codec_buf.append((char*)&K, 2); // BGEN: 2 byte K
+  bgen_min_ploidy_offset = bgen_file.tellp();
+  codec_buf.append((char*)&fourB_zero, 1); // BGEN: 1 byte min ploidy (placeholder)
+  bgen_max_ploidy_offset = bgen_file.tellp();
+  codec_buf.append((char*)&fourB_zero, 1); // BGEN: 1 byte max ploidy (placeholder)
+  bgen_ploidy_info_offset = bgen_file.tellp();
+  char default_sample_info = 0b10000010; // default missingness and ploidy information: set to missing/diploid unspecified
+  for(int j = 0; j < N; j++) {
+    codec_buf.append(&default_sample_info, 1); // BGEN: default sample information within this variant: because missing is set to 1, no need to backfill skipped cells
+  }
+  codec_buf.append((char*)&phased, 1); // BGEN: 1 byte phased
+  char B = 8; // precision at one byte to avoid alignment difficulties
+  codec_buf.append(&B, 1); // BGEN: 1 byte unsigned bits of precision
+  bgen_probability_offset = bgen_file.tellp();
+}
+
+void GenomicsDBPlinkProcessor::process(const Variant& variant) {
+  auto& calls = variant.get_calls();
+
+  bool phased = true;
+  std::string gt_string;
+
+  for(auto& c : calls) {
+    auto fields = get_genomic_fields_for(array, &c, query_config);
+    
+    for(auto& f : fields) {
+      if(f.name == "GT") {
+        gt_string = f.to_string(get_genomic_field_type(f.name));
+
+        if(gt_string.find('/') != std::string::npos && gt_string.find('.') == std::string::npos) { // unphased if contains a slash or is ./. (might be able to use GL/PL, which are unphased probabilities)
+          phased = false;
+        }
+        break;
+      }
+    }
+    if(!phased) { break; }
+  }
+
+  for(auto& c : calls) {
+    auto fields = get_genomic_fields_for(array, &c, query_config);
+
+    int64_t coords[] = {(int64_t)c.get_row_idx(), (int64_t)c.get_column_begin()};
+    int64_t end_position = c.get_column_end();
+
+    std::string contig_name;
+    int64_t contig_position;
+    if (!vid_mapper.get_contig_location(coords[1], contig_name, contig_position)) {
+      std::cerr << "Could not find genomic interval associated with Variant(Call) at "
+        << coords[1] << std::endl;
+      continue;
+    }
+
+    contig_position++;
+    genomic_interval_t genomic_interval(std::move(contig_name),
+                                        std::make_pair(contig_position, contig_position+end_position-coords[1]));
+
+    std::string sample_name;
+    if (!vid_mapper.get_callset_name(coords[0], sample_name)) {
+      sample_name = "NONE";
+    }
+
+    process(sample_name, coords, genomic_interval, fields, phased);
+  }
+}
+
+void GenomicsDBPlinkProcessor::process(const std::string& sample_name,
+                                       const int64_t* coords,
+                                       const genomic_interval_t& genomic_interval,
+                                       const std::vector<genomic_field_t>& genomic_fields,
+                                       const bool phased) {
+  last_phased = phased;
+
+  if(progress_interval > 0) {
+    progress_bar(coords);
+  }
+
+  std::string ref_string, alt_string, gt_string, id_string, pl_string, gl_string, pq_string;
+  for(auto& f : genomic_fields) {
+    if(f.name == "ALT") {
+      std::string combined_alt = f.recombine_ALT_value(get_genomic_field_type(f.name));
+      if(combined_alt.size()) {
+        alt_string = combined_alt.substr(1, combined_alt.length() - 2);
+      }
+    }
+    else if(f.name == "REF") {
+      ref_string = f.to_string(get_genomic_field_type(f.name));
+    }
+    else if(f.name == "GT") {
+      gt_string = f.to_string(get_genomic_field_type(f.name));
+    }
+    else if(f.name == "ID") {
+      id_string = f.to_string(get_genomic_field_type(f.name));
+    }
+    else if(f.name == "PL") {
+      pl_string = f.to_string(get_genomic_field_type(f.name));
+    }
+    else if(f.name == "GL") {
+      gl_string = f.to_string(get_genomic_field_type(f.name));
+    }
+    else if(f.name == "PQ") {
+      pq_string = f.to_string(get_genomic_field_type(f.name));
+    }
+  }
+
+  if(!alt_string.size()) {
+    logger.error("No ALT field for sample: {} row: {} column: {}", sample_name, coords[0], coords[1]);
+    exit(1);
+  }
+  if(!ref_string.size()) {
+    logger.error("No REF field for sample: {} row: {} column: {}", sample_name, coords[0], coords[1]);
+    exit(1);
+  }
+  if(!gt_string.size()) {
+    logger.error("No GT field for sample: {} row: {} column: {}", sample_name, coords[0], coords[1]);
+    exit(1);
+  }
+
+  // collect alleles
+  std::vector<std::string> vec = {ref_string};
+  size_t index;
+  while((index = alt_string.find(", ")) != std::string::npos) {
+    vec.push_back(alt_string.substr(0, index));
+    alt_string.erase(0, index + 2);
+  }
+  vec.push_back(alt_string);
+
+  std::vector<int> gt_vec;
+  auto iter = gt_string.begin();
+
+  // parse GT
+  try {
+    while((iter = find_if(gt_string.begin(), gt_string.end(), [] (char c) { return c == '|' || c == '/'; })) != gt_string.end()) {
+      index = iter - gt_string.begin();
+      gt_vec.push_back(std::stoi(gt_string.substr(0, index)));
+      gt_string.erase(0, index + 1);
+    }
+    gt_vec.push_back(std::stoi(gt_string));
+  }
+  catch (...) { // probably ./., treat as missing cell
+    return;
+  }
+
+  for(auto g : gt_vec) {
+    if(g < 0 || g >= vec.size()) {
+      if(verbose) {
+        logger.error("GT field for sample: {} row: {} column: {},  contains index {}, which is out of bounds (1 ref allele, {} alt allele(s))", sample_name, coords[0], coords[1], g, vec.size() - 1);
+       }
+      return;
+    }
+  }
+
+  int16_t ploidy = gt_vec.size();
+
+  if(!state) {
+    sample_map_initialized = true; // possible to skip first pass, sample map will be populated from callset
+
+    sample_map.insert(std::make_pair(coords[0], std::make_pair(-1, sample_name)));
+    last_coord = coords[1];
+    return;
+  }
+
+  if(ploidy != 2 && (make_bed || make_tped)) { 
+    logger.error("The tped/bed formats do not support ploidies other than 2.");
+    make_bed = 0;
+    make_tped = 0;
+    if(make_bgen) {
+      logger.info("Continuing bgen generation");
+    } 
+  }
+
+  if(state == 1) {
+    std::string rsid;
+    std::string rsid_row;
+    if(id_string.size()) {
+      rsid = id_string;
+    }
+    else {
+      rsid = genomic_interval.contig_name + ":" + std::to_string(genomic_interval.interval.first);
+    }
+    rsid_row = genomic_interval.contig_name + " " + rsid + " 0 " + std::to_string(genomic_interval.interval.first);
+
+    int sind = sample_map[coords[0]].first;
+
+    // backfill if needed
+    bool backfill = coords[1] - last_coord && last_coord != -1;
+    int add_to_prev = backfill ? sample_map.size() - (last_sample + 1) : 0;
+    int add_to_current = backfill ? sind : sind - (last_sample + 1);
+
+    if(last_coord != coords[1]) { // first in variant
+      num_variants++;
+
+      for(int i = 0; i < add_to_prev; i++) { // backfill samples missing from previous variant
+        if(make_tped) {
+          tped_file << " 0 0";
+        }
+        if(make_bed) {
+          write_to_bed(1);
+        }
+        if(make_bgen) {
+          // BGEN: backfill probability data
+          bgen_empty_cell(2, last_alleles, phased);
+        }
+      }
+      if(make_bed) {
+        flush_to_bed();
+      }
+
+      if(make_tped) {
+        if(last_sample != -1) { // first line should not have newline
+          tped_file << std::endl;
+        }
+        tped_file << rsid_row;
+      }
+
+      if(make_bgen) {
+        bgen_variant_data_block(rsid, genomic_interval, vec, phased);
+      }
+    }
+    else {
+      samples_in_column++;
+    }
+
+    for(int i = 0; i < add_to_current; i++) { // backfill samples missing from current variant
+      if(make_bed) {
+        write_to_bed(1);
+      }
+
+      if(make_tped) {
+        tped_file << " 0 0";
+      }
+
+      if(make_bgen) {
+        // BGEN: backfill probability data
+        bgen_empty_cell(2, vec.size(), phased);
+      }
+    }
+
+    // safe to update now that backfilling is over
+    last_alleles = vec.size();
+
+    if(make_bed) {
+      char gt_code;
+      if(!(gt_vec[0] || gt_vec[1])) { // homozygous for first allele
+        gt_code = 0;
+      }
+      else if(gt_vec[0] + gt_vec[1] == 1) { // heterozygous
+        gt_code = 2;
+      }
+      else if(gt_vec[0] == 1 && gt_vec[1] == 1) { // homozygous for second allele
+        gt_code = 3;
+      }
+      else { // missing genotype
+        gt_code = 1;
+      }
+
+      if(last_coord != coords[1]) {
+        bim_file << rsid_row;
+        bim_file << " " << vec[0] << " " << vec[1] << std::endl;
+      }
+      write_to_bed(gt_code);
+    }
+
+    if(make_tped) {
+      tped_file << " " << vec[gt_vec[0]] << " " << vec[gt_vec[1]];
+    }
+
+    last_sample = sample_map[coords[0]].first;
+    //last_variant = vind;
+    last_coord = coords[1];
+
+    // convert PL to BGEN format
+    std::vector<double> pl_vec;
+    bool pl_dot = false;
+
+    try {
+      for(auto& tok : split(pl_string)) {
+        if(tok == ".") pl_dot = true;
+        int val = std::stoi(tok);
+        if(val >= 0) {
+          pl_vec.push_back(val);
+        }
+        else {
+          throw std::runtime_error("PL value is negative");
+        }
+      }
+    }
+    catch(...) {
+      pl_vec.clear();
+      if(!pl_dot && verbose) {
+        logger.error("PL field for sample: {} row: {} column: {} contains a negative value or otherwise did not parse, full string: {}", sample_name, coords[0], coords[1], pl_string);
+      }
+    }
+
+    std::vector<char> pl_probs;
+
+    double pl_total = 0;
+    double epsilon = .05;
+    for(auto& a : pl_vec) {
+      double prob = std::pow(10, double(a)/-10);
+      pl_total += prob;
+      pl_probs.push_back(char(std::numeric_limits<unsigned char>::max() * prob));
+    }
+
+    // parse GL
+    std::vector<double> gl_vec;
+    bool gl_dot = false;
+
+    try {
+      for(auto& tok : split(gl_string)) {
+        if(tok == ".") gl_dot = true;
+        double val = std::stod(tok);
+        if(val <= 0) {
+          gl_vec.push_back(val);
+        }
+        else {
+          throw std::runtime_error("GL value is positive");
+        }
+      }
+    }
+    catch(...) {
+      gl_vec.clear();
+      if(!gl_dot && verbose) {
+        logger.error("GL field for sample: {} row: {} column: {} contains a strictly positive value or otherwise did not parse, full string {}", sample_name, coords[0], coords[1], gl_string);
+      }
+    }
+
+    std::vector<char> gl_probs;
+
+    double gl_total = 0;
+    for(auto& a : gl_vec) {
+      double prob = std::pow(10, a);
+      gl_total += prob;
+      gl_probs.push_back(char(std::numeric_limits<unsigned char>::max() * prob));
+    }
+
+    std::vector<char> probs;
+
+    // subtract 1 representing reference
+    auto num_genotypes = KnownFieldInfo::get_number_of_genotypes(vec.size() - 1, ploidy);
+
+    if(gl_probs.size()) { // prefer gl as it is more precise (pl is rounded)
+      if(gl_probs.size() == num_genotypes) {
+        if(std::abs(1 - gl_total) > epsilon && verbose) {
+          logger.warn("GL probabilities at sample: {} row: {} column: {} sum to {}, expected near 1. Generated BGEN may be invalid", sample_name, coords[0], coords[1], gl_total);
+        }
+        probs = gl_probs;
+      }
+      else {
+        if(verbose) {
+          logger.error("GL length at sample: {} row: {} column: {} is {}, expected {}. Defaulting to using GT to construct probabilities", sample_name, coords[0], coords[1], gl_vec.size(), num_genotypes);
+        }
+      }
+    }
+    else if(pl_probs.size()) {
+      if(pl_probs.size() == num_genotypes) {
+        if(std::abs(1 - pl_total) > epsilon && verbose) {
+          logger.warn("PL probabilities at sample: {} row: {} column: {} sum to {}, expected near 1. Generated BGEN may be invalid", sample_name, coords[0], coords[1], pl_total);
+        }
+        probs = pl_probs;
+      }
+      else {
+        if(verbose) {
+          logger.error("PL length at sample: {} row: {} column: {} is {}, expected {}. Defaulting to using GT to construct probabilities", sample_name, coords[0], coords[1], pl_vec.size(), num_genotypes);
+        }
+      }
+    }
+
+    double pq;
+    if(pq_string.length()) {
+      try {
+        pq = std::pow(10, (double)std::stoi(pq_string)/-10);
+      }
+      catch(...) {
+        pq_string.clear();
+      }
+    }
+
+    auto write_phased_probability = [&] (const std::vector<int>& v, size_t ind) {
+      char p = gt_vec[v[0]] == v[1] ? -1 : 0;
+      codec_buf.push_back(p);
+    };
+
+    auto write_unphased_probability = [&] (const std::vector<int>& v, size_t ind) {
+      char p;
+
+      if(!probs.size()) {
+        std::vector<int> counts(vec.size(), 0);
+        for(auto& g : gt_vec) {
+          counts[g]++;
+        }
+        p = counts == v ? -1 : 0;
+      }
+      else {
+        if(ind < probs.size()) {
+          p = probs[ind];
+        }
+        else {
+          // NOTE: this should never be triggered, GL/PL length is checked above
+          logger.error("BGEN generation error: GL/PL probabilies only have {} term(s), halting BGEN generation", probs.size());
+          make_bgen = 0;
+        }
+      }
+      codec_buf.push_back(p);
+    };
+
+    if(make_bgen) {
+      // store sample as not missing/ploidy info
+      if(ploidy < 64) {
+         min_ploidy = ploidy < min_ploidy ? ploidy : min_ploidy;
+        max_ploidy = ploidy > max_ploidy ? ploidy : max_ploidy;
+        char p = ploidy;
+        codec_buf[8 + sample_map[coords[0]].first] = p;
+
+        if(phased) { // phased
+          bgen_enumerate_phased(ploidy, vec.size(), write_phased_probability);
+        }
+         else { // unphased
+          bgen_enumerate_unphased(ploidy, vec.size(), write_unphased_probability);
+        }
+      }
+    }
+  }
+}
+
+void GenomicsDBPlinkProcessor::advance_state() {
+  if(!state) {
+    if(!sample_map_initialized) { // populate from callset
+      std::string str;
+      auto num_rows = query_config->get_num_rows_to_query();
+      int row;
+      for(int i = 0; i < num_rows; i++) {
+        row = query_config->get_array_row_idx_for_query_row_idx(i);
+        vid_mapper.get_callset_name(row, str);
+        sample_map.insert(std::make_pair(row, std::make_pair(-1, str)));
+      }
+    }
+
+    // associate samples with sorted position
+    int i = -1;
+    for(auto& a : sample_map) {
+      ++i;
+      a.second.first = (uint64_t)i;
+    }
+    // associate variants with sorted position
+    i = -1;
+    last_sample = -1;
+    last_coord = -1;
+  
+    if(make_bed || make_tped) {
+      // Find samples coincident with entries in fam files (if specified) and associate information with sample name
+      std::map<std::string, std::string> fam_entries;
+    
+      if(fam_list.length()) {
+        std::ifstream fam_list_file(fam_list);
+        std::string fname;
+        while(std::getline(fam_list_file, fname)) {
+          std::ifstream file(fname);
+          std::string entry;
+          while(std::getline(file, entry)) {
+            std::string fid, wfid, fthid, mthid;
+            char sex, pt;
+            std::stringstream(entry) >> fid >> wfid >> fthid >> mthid >> sex >> pt;
+            fam_entries.insert(std::make_pair(wfid, entry));
+          }
+        }
+      }
+      for(auto& s : sample_map) {
+        if(fam_entries.count(s.second.second)) {
+          fam_file << fam_entries[s.second.second] << std::endl;
+        }
+        else {
+          fam_file << s.second.second << " " << s.second.second << " 0 0 0 0" << std::endl;
+        }
+      }
+    }
+
+    if(make_bgen) {
+      // BGEN: fill in N in header
+      bgen_file.seekp(12);
+      int32_t N = sample_map.size();
+      bgen_file.write((char*)&N, 4); // BGEN: 4 byte N
+      // Fill in M at end, as first pass, which counts variants, may be skipped
+
+      // BGEN: write sample identifier block
+      bgen_file.seekp(24);
+      int32_t lsi = 0;
+      bgen_file.write((char*)&lsi, 4); // BGEN: 4 byte total length of sample identifier block, filled in last
+      bgen_file.write((char*)&N, 4); // BGEN: 4 byte N, deliberately duplicated here as per spec
+      lsi = 8; // total length includes 8 bytes metainfo
+
+      int16_t len;
+      for(auto& s : sample_map) { // BGEN: write each sample id, can potentially be combined with above foreach loop
+        len = s.second.second.length();
+        lsi += len + 2; // total length increased by length of identifier and 2 byte length field
+       
+        bgen_file.write((char*)&len, 2);
+        bgen_file.write(s.second.second.c_str(), len);
+      }
+
+      bgen_file.seekp(24);
+      bgen_file.write((char*)&lsi, 4); // BGEN: 4 byte total length of sample identifier block, now with correct value
+       bgen_file.seekp(0);
+      int32_t offset = lsi + 20;
+      bgen_file.write((char*)&offset, 4);
+      // BGEN: update initial offset to include size of sample block
+      bgen_file.seekp(24 + lsi); // seek to end of sample identifier block
+    }
+  }
+
+  if(state == 1) {
+    // if skipped some samples at end, fill with reample_map.insert(std::make_pair(sample_name, -1));
+    int add_to_current = sample_map.size() - (last_sample + 1);
+
+    for(int i = 0; i < add_to_current; i++) {
+      if(make_tped) {
+        tped_file << " 0 0";
+      }
+      if(make_bed) {
+        write_to_bed(1);
+      }
+      if(make_bgen) {
+        // BGEN: backfill last variant
+        bgen_empty_cell(2, last_alleles, last_phased);
+      }
+    }
+    if(make_bed) {
+      flush_to_bed();
+    }
+
+    if(make_tped) {
+      tped_file << std::endl;
+    }
+
+    if(sample_map.size() && make_bgen) {
+      bgen_finish_gt();
+    }
+
+    if(make_bgen) {
+      // BGEN: fill in M in header
+      bgen_file.seekp(8);
+      int32_t M = num_variants;
+      bgen_file.write((char*)&M, 4); // BGEN: 4 byte M
+    }
+  }
+  state++;
+}

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBQuery.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBQuery.java
@@ -1,6 +1,6 @@
 /*
  * The MIT License (MIT)
- * Copyright (c) 2019 Omics Data Automation, Inc.
+ * Copyright (c) 2019, 2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -137,18 +137,16 @@ public class GenomicsDBQuery {
   public long connect(final String workspace,
                       final String vidMappingFile,
                       final String callsetMappingFile,
-                      final String referenceGenome,
                       final List<String> attributes) throws GenomicsDBException {
-    return connect(workspace, vidMappingFile, callsetMappingFile, referenceGenome, attributes, defaultSegmentSize);
+    return connect(workspace, vidMappingFile, callsetMappingFile, attributes, defaultSegmentSize);
   }
 
   public long connect(final String workspace,
                       final String vidMappingFile,
                       final String callsetMappingFile,
-                      final String referenceGenome,
                       final List<String> attributes,
                       final long segmentSize) throws GenomicsDBException {
-    return jniConnect(workspace, vidMappingFile, callsetMappingFile, referenceGenome, attributes, segmentSize);
+    return jniConnect(workspace, vidMappingFile, callsetMappingFile, attributes, segmentSize);
   }
 
   public long connectJSON(final String queryJSONFile) {
@@ -193,19 +191,23 @@ public class GenomicsDBQuery {
                           final String arrayName,
                           final List<Pair> columnRanges,
                           final List<Pair> rowRanges,
+                          final String referenceGenome,
+                          final String vcfHeader,
                           final String outputFilename,
                           final String outputFormat) {
-    jniGenerateVCF(handle, arrayName, columnRanges, rowRanges, outputFilename, outputFormat, false);
+    jniGenerateVCF(handle, arrayName, columnRanges, rowRanges, referenceGenome, vcfHeader, outputFilename, outputFormat, false);
   }
 
   public void generateVCF(long handle,
                           final String arrayName,
                           final List<Pair> columnRanges,
                           final List<Pair> rowRanges,
+                          final String referenceGenome,
+                          final String vcfHeader,
                           final String outputFilename,
                           final String outputFormat,
                           final boolean overwrite) {
-    jniGenerateVCF(handle, arrayName, columnRanges, rowRanges, outputFilename, outputFormat, overwrite);
+    jniGenerateVCF(handle, arrayName, columnRanges, rowRanges, referenceGenome, vcfHeader, outputFilename, outputFormat, overwrite);
   }
 
   public void generateVCF(long handle,
@@ -229,7 +231,6 @@ public class GenomicsDBQuery {
   private static native long jniConnect(final String workspace,
                                  final String vidMappingFile,
                                  final String callsetMappingFile,
-                                 final String referenceGenome,
                                  final List<String> attributes,
                                  final long segmentSize) throws GenomicsDBException;
 
@@ -250,6 +251,8 @@ public class GenomicsDBQuery {
                                             final String arrayName,
                                             final List<Pair> columnRanges,
                                             final List<Pair> rowRanges,
+                                            final String referenceGenome,
+                                            final String vcfHeader,
                                             final String outputFilename,
                                             final String outputFormat,
                                             final boolean overwrite);

--- a/src/main/java/org/genomicsdb/spark/api/GenomicsDBQueryInputFormat.java
+++ b/src/main/java/org/genomicsdb/spark/api/GenomicsDBQueryInputFormat.java
@@ -178,9 +178,9 @@ public class GenomicsDBQueryInputFormat extends InputFormat<Interval, List<Varia
           }
           List<String> attributesList = exportConfiguration.getAttributesList();
           if (segmentSize > 0) {
-            queryHandle = query.connect(workspace, vidMappingFile, callsetMappingFile, referenceGenome, attributesList, segmentSize.longValue());
+            queryHandle = query.connect(workspace, vidMappingFile, callsetMappingFile, attributesList, segmentSize.longValue());
           } else {
-            queryHandle = query.connect(workspace, vidMappingFile, callsetMappingFile, referenceGenome, attributesList);
+            queryHandle = query.connect(workspace, vidMappingFile, callsetMappingFile, attributesList);
           }
           intervals = query.queryVariantCalls(queryHandle, exportConfiguration.getArrayName(),
                   ToColumnRangePairs(exportConfiguration.getQueryColumnRanges(0).getColumnOrIntervalListList()),

--- a/src/main/jni/include/genomicsdb_GenomicsDBQuery.h
+++ b/src/main/jni/include/genomicsdb_GenomicsDBQuery.h
@@ -28,10 +28,10 @@ JNIEXPORT jstring JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniVersion
 /*
  * Class:     org_genomicsdb_reader_GenomicsDBQuery
  * Method:    jniConnect
- * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;J)J
+ * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;J)J
  */
 JNIEXPORT jlong JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniConnect
-  (JNIEnv *, jclass, jstring, jstring, jstring, jstring, jobject, jlong);
+  (JNIEnv *, jclass, jstring, jstring, jstring, jobject, jlong);
 
 /*
  * Class:     org_genomicsdb_reader_GenomicsDBQuery
@@ -68,10 +68,10 @@ JNIEXPORT jobject JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniQueryVar
 /*
  * Class:     org_genomicsdb_reader_GenomicsDBQuery
  * Method:    jniGenerateVCF
- * Signature: (JLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Z)V
+ * Signature: (JLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
  */
 JNIEXPORT void JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF
-  (JNIEnv *, jclass, jlong, jstring, jobject, jobject, jstring, jstring, jboolean);
+  (JNIEnv *, jclass, jlong, jstring, jobject, jobject, jstring, jstring, jstring, jstring, jboolean);
 
 /*
  * Class:     org_genomicsdb_reader_GenomicsDBQuery
@@ -81,39 +81,6 @@ JNIEXPORT void JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF
 JNIEXPORT void JNICALL Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF1
   (JNIEnv *, jclass, jlong, jstring, jstring, jboolean);
 
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class org_genomicsdb_reader_GenomicsDBQuery_Interval */
-
-#ifndef _Included_org_genomicsdb_reader_GenomicsDBQuery_Interval
-#define _Included_org_genomicsdb_reader_GenomicsDBQuery_Interval
-#ifdef __cplusplus
-extern "C" {
-#endif
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class org_genomicsdb_reader_GenomicsDBQuery_VariantCall */
-
-#ifndef _Included_org_genomicsdb_reader_GenomicsDBQuery_VariantCall
-#define _Included_org_genomicsdb_reader_GenomicsDBQuery_VariantCall
-#ifdef __cplusplus
-extern "C" {
-#endif
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class org_genomicsdb_reader_GenomicsDBQuery_Pair */
-
-#ifndef _Included_org_genomicsdb_reader_GenomicsDBQuery_Pair
-#define _Included_org_genomicsdb_reader_GenomicsDBQuery_Pair
-#ifdef __cplusplus
-extern "C" {
-#endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/jni/src/genomicsdb_GenomicsDBQuery.cc
+++ b/src/main/jni/src/genomicsdb_GenomicsDBQuery.cc
@@ -1,6 +1,6 @@
 /**
  * The MIT License (MIT)
- * Copyright (c) 2019-2020 Omics Data Automation, Inc.
+ * Copyright (c) 2019-2020,2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 
@@ -215,21 +215,18 @@ Java_org_genomicsdb_reader_GenomicsDBQuery_jniConnect(JNIEnv *env,
                                                       jstring workspace,
                                                       jstring vid_mapping_file,
                                                       jstring callset_mapping_file,
-                                                      jstring reference_genome,
                                                       jobject attributes,
                                                       jlong segment_size) {
   // Convert
   auto workspace_cstr = env->GetStringUTFChars(workspace, NULL);
   auto vid_mapping_file_cstr = env->GetStringUTFChars(vid_mapping_file, NULL);
   auto callset_mapping_file_cstr = env->GetStringUTFChars(callset_mapping_file, NULL);
-  auto reference_genome_cstr = env->GetStringUTFChars(reference_genome, NULL);
 
   GenomicsDB *genomicsdb = NULL;
   try {
     genomicsdb =  new GenomicsDB(workspace_cstr,
                                  callset_mapping_file_cstr,
                                  vid_mapping_file_cstr,
-                                 reference_genome_cstr,
                                  to_string_vector(env, attributes),
                                  segment_size);
   } catch (GenomicsDBException& e) {
@@ -240,7 +237,6 @@ Java_org_genomicsdb_reader_GenomicsDBQuery_jniConnect(JNIEnv *env,
   env->ReleaseStringUTFChars(workspace, workspace_cstr);
   env->ReleaseStringUTFChars(vid_mapping_file, vid_mapping_file_cstr);
   env->ReleaseStringUTFChars(callset_mapping_file, callset_mapping_file_cstr);
-  env->ReleaseStringUTFChars(reference_genome, reference_genome_cstr);
   
   return static_cast<jlong>(reinterpret_cast<uintptr_t>(genomicsdb));
 }
@@ -395,12 +391,16 @@ Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF(JNIEnv *env,
                                                           jstring array_name,
                                                           jobject column_ranges,
                                                           jobject row_ranges,
+                                                          jstring reference_genome,
+                                                          jstring vcf_header,
                                                           jstring output,
                                                           jstring output_format,
                                                           jboolean overwrite) {
   // Convert
   GenomicsDB *genomicsdb = reinterpret_cast<GenomicsDB *>(static_cast<uintptr_t>(handle));
   auto array_name_cstr = env->GetStringUTFChars(array_name, NULL);
+  auto reference_genome_cstr = env->GetStringUTFChars(reference_genome, NULL);
+  auto vcf_header_cstr = env->GetStringUTFChars(vcf_header, NULL);
   auto output_cstr =  env->GetStringUTFChars(output, NULL);
   auto output_format_cstr = env->GetStringUTFChars(output_format, NULL);
 
@@ -408,6 +408,7 @@ Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF(JNIEnv *env,
     genomicsdb->generate_vcf(array_name_cstr,
                              to_genomicsdb_ranges_vector(env, column_ranges),
                              to_genomicsdb_ranges_vector(env, row_ranges),
+                             reference_genome_cstr, vcf_header_cstr,
                              output_cstr, output_format_cstr, overwrite);
   } catch (GenomicsDBException& e) {
     handleJNIException(env, e);
@@ -415,6 +416,8 @@ Java_org_genomicsdb_reader_GenomicsDBQuery_jniGenerateVCF(JNIEnv *env,
 
   // Cleanup
   env->ReleaseStringUTFChars(array_name, array_name_cstr);
+  env->ReleaseStringUTFChars(reference_genome, reference_genome_cstr);
+  env->ReleaseStringUTFChars(vcf_header, vcf_header_cstr);
   env->ReleaseStringUTFChars(output_format, output_format_cstr);
   env->ReleaseStringUTFChars(output, output_cstr);
 }

--- a/src/test/cpp/src/test_bgen.cc
+++ b/src/test/cpp/src/test_bgen.cc
@@ -20,20 +20,22 @@ TEST_CASE("test bgen", "[bgen]") {
 
   std::string ctests_input_dir(GENOMICSDB_CTESTS_DIR);
 
+  // basic - direct
+  std::string workspace = ctests_input_dir + "/bgen/workspace_1";
+  GenomicsDB gdb_basic(workspace, workspace+"/callset.json", workspace+"/vidmap.json", {"REF", "ALT", "DP", "GT", "ID"});
+  gdb_basic.generate_plink("1$1$249250621", SCAN_FULL, {{0,20}}, 7, 1);
+  std::string cmd_basic = "diff output.bgen " + ctests_input_dir + "/bgen/output_1.bgen > /dev/null";
+  int status = system(cmd_basic.c_str());
+  if(WEXITSTATUS(status)) {
+    throw std::runtime_error("Direct - first BGEN test output did not match reference output");
+  }
+
   // test 1 (t0_1_2_combined)
-  VariantQueryConfig query_config;
-  query_config.read_from_file(ctests_input_dir + "/bgen/query_1.json", my_world_mpi_rank);
-
-  std::string array_name = query_config.get_array_name(my_world_mpi_rank);
-
-  GenomicsDB gdb(query_config.get_workspace(my_world_mpi_rank),
-                 query_config.get_callset_mapping_file(),
-                 query_config.get_vid_mapping_file(),
-                 query_config.get_reference_genome());
-  gdb.generate_plink(array_name, &query_config, 7, 1);
+  GenomicsDB gdb(ctests_input_dir + "/bgen/query_1.json", GenomicsDB::JSON_FILE, "", my_world_mpi_rank);
+  gdb.generate_plink(7, 1);
 
   std::string cmd = "diff output.bgen " + ctests_input_dir + "/bgen/output_1.bgen > /dev/null";
-  int status = system(cmd.c_str());
+  status = system(cmd.c_str());
   if(WEXITSTATUS(status)) {
     throw std::runtime_error("first BGEN test output did not match reference output");
   }
@@ -59,17 +61,8 @@ TEST_CASE("test bgen", "[bgen]") {
   }
 
   // test 2 (min_PL_spanning_deletion)
-  
-  VariantQueryConfig query_config2;
-  query_config2.read_from_file(ctests_input_dir + "/bgen/query_2.json", my_world_mpi_rank);
-
-  array_name = query_config2.get_array_name(my_world_mpi_rank);
-
-  GenomicsDB gdb2(query_config2.get_workspace(my_world_mpi_rank),
-                 query_config2.get_callset_mapping_file(),
-                 query_config2.get_vid_mapping_file(),
-                 query_config2.get_reference_genome());
-  gdb2.generate_plink(array_name, &query_config2, 1, 1);
+  GenomicsDB gdb2(ctests_input_dir + "/bgen/query_2.json", GenomicsDB::JSON_FILE, "", my_world_mpi_rank);
+  gdb2.generate_plink(1, 1);
 
   cmd = "diff output.bgen " + ctests_input_dir + "/bgen/output_2.bgen > /dev/null";
   status = system(cmd.c_str());
@@ -78,17 +71,8 @@ TEST_CASE("test bgen", "[bgen]") {
   }
 
   // test 3 (merged tcga vcfs)
-
-  VariantQueryConfig query_config3;
-  query_config3.read_from_file(ctests_input_dir + "/bgen/query_3.json", my_world_mpi_rank);
-
-  array_name = query_config3.get_array_name(my_world_mpi_rank);
-
-  GenomicsDB gdb3(query_config3.get_workspace(my_world_mpi_rank),
-                 query_config3.get_callset_mapping_file(),
-                 query_config3.get_vid_mapping_file(),
-                 query_config3.get_reference_genome());
-  gdb3.generate_plink(array_name, &query_config3, 1, 1);
+  GenomicsDB gdb3(ctests_input_dir + "/bgen/query_3.json", GenomicsDB::JSON_FILE, "", my_world_mpi_rank);
+  gdb3.generate_plink(1, 1);
 
   cmd = "diff output.bgen " + ctests_input_dir + "/bgen/output_3.bgen > /dev/null";
   status = system(cmd.c_str());
@@ -99,16 +83,8 @@ TEST_CASE("test bgen", "[bgen]") {
   system("rm -f output.bgen");
 
   // test 4 (PL/GL with one sample empty, standard two pass generation)
-  VariantQueryConfig query_config4;
-  query_config4.read_from_file(ctests_input_dir + "/bgen/bgen_test_query_1.json", my_world_mpi_rank);
-
-  array_name = query_config4.get_array_name(my_world_mpi_rank);
-
-  GenomicsDB gdb4(query_config4.get_workspace(my_world_mpi_rank),
-                 query_config4.get_callset_mapping_file(),
-                 query_config4.get_vid_mapping_file(),
-                 query_config4.get_reference_genome());
-  gdb4.generate_plink(array_name, &query_config4, 1, 1); 
+  GenomicsDB gdb4(ctests_input_dir + "/bgen/bgen_test_query_1.json", GenomicsDB::JSON_FILE, "", my_world_mpi_rank);
+  gdb4.generate_plink(1, 1); 
 
   cmd = "diff output.bgen " + ctests_input_dir + "/bgen/bgen_test_output_1_2p.bgen > /dev/null";
   status = system(cmd.c_str());
@@ -117,16 +93,8 @@ TEST_CASE("test bgen", "[bgen]") {
   }
  
   // test 5 (PL/GL with one sample empty, one pass generation)
-  VariantQueryConfig query_config5;
-  query_config5.read_from_file(ctests_input_dir + "/bgen/bgen_test_query_1.json", my_world_mpi_rank);
-
-  array_name = query_config5.get_array_name(my_world_mpi_rank);
-
-  GenomicsDB gdb5(query_config5.get_workspace(my_world_mpi_rank),
-                 query_config5.get_callset_mapping_file(),
-                 query_config5.get_vid_mapping_file(),
-                 query_config5.get_reference_genome());
-  gdb5.generate_plink(array_name, &query_config5, 1, 1, true);
+  GenomicsDB gdb5(ctests_input_dir + "/bgen/bgen_test_query_1.json", GenomicsDB::JSON_FILE, "", my_world_mpi_rank);
+  gdb5.generate_plink(1, 1, true);
 
   cmd = "diff output.bgen " + ctests_input_dir + "/bgen/bgen_test_output_1_1p.bgen > /dev/null";
   status = system(cmd.c_str());
@@ -135,16 +103,8 @@ TEST_CASE("test bgen", "[bgen]") {
   }
 
   // test 6 (PL/GL, standard two pass generation)
-  VariantQueryConfig query_config6;
-  query_config6.read_from_file(ctests_input_dir + "/bgen/bgen_test_query_2.json", my_world_mpi_rank);
-
-  array_name = query_config6.get_array_name(my_world_mpi_rank);
-
-  GenomicsDB gdb6(query_config6.get_workspace(my_world_mpi_rank),
-                 query_config6.get_callset_mapping_file(),
-                 query_config6.get_vid_mapping_file(),
-                 query_config6.get_reference_genome());
-  gdb6.generate_plink(array_name, &query_config6, 1, 1);
+  GenomicsDB gdb6(ctests_input_dir + "/bgen/bgen_test_query_2.json", GenomicsDB::JSON_FILE, "", my_world_mpi_rank);
+  gdb6.generate_plink(1, 1);
 
   cmd = "diff output.bgen " + ctests_input_dir + "/bgen/bgen_test_output_2_2p.bgen > /dev/null";
   status = system(cmd.c_str());
@@ -153,16 +113,8 @@ TEST_CASE("test bgen", "[bgen]") {
   }
 
   // test 7 (PL/GL, one pass generation, verbose, progress interval)
-  VariantQueryConfig query_config7;
-  query_config7.read_from_file(ctests_input_dir + "/bgen/bgen_test_query_2.json", my_world_mpi_rank);
-
-  array_name = query_config7.get_array_name(my_world_mpi_rank);
-
-  GenomicsDB gdb7(query_config7.get_workspace(my_world_mpi_rank),
-                 query_config7.get_callset_mapping_file(),
-                 query_config7.get_vid_mapping_file(),
-                 query_config7.get_reference_genome());
-  gdb7.generate_plink(array_name, &query_config7, 1, 1, true, true, 1000);
+  GenomicsDB gdb7(ctests_input_dir + "/bgen/bgen_test_query_2.json", GenomicsDB::JSON_FILE, "", my_world_mpi_rank);
+  gdb7.generate_plink(1, 1, true, true, 1000);
 
   cmd = "diff output.bgen " + ctests_input_dir + "/bgen/bgen_test_output_2_1p.bgen > /dev/null";
   status = system(cmd.c_str());

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -2,7 +2,7 @@
  * src/test/cpp/src/test_genomicsdb_api.cc
  *
  * The MIT License (MIT)
- * Copyright (c) 2019-2021 Omics Data Automation, Inc.
+ * Copyright (c) 2019-2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -50,10 +50,9 @@ TEST_CASE("api empty_args", "[empty_args]") {
   std::string empty_string;
 
   // Constructor that allows workspace/callset/vidmapping/reference genome specification
-  CHECK_THROWS_AS(new GenomicsDB(empty_string, empty_string, empty_string, empty_string), std::exception);
-  CHECK_THROWS_AS(new GenomicsDB("ws", empty_string, empty_string, empty_string), std::exception);
-  CHECK_THROWS_AS(new GenomicsDB("ws", "callset", empty_string, empty_string), std::exception);
-  CHECK_THROWS_AS(new GenomicsDB("ws", "callset", "vid", empty_string), std::exception);
+  CHECK_THROWS_AS(new GenomicsDB(empty_string, empty_string, empty_string), std::exception);
+  CHECK_THROWS_AS(new GenomicsDB("ws", empty_string, empty_string), std::exception);
+  CHECK_THROWS_AS(new GenomicsDB("ws", "callset", empty_string), std::exception);
 
   // Constructor that allows json files for configuration
   CHECK_THROWS_AS(new GenomicsDB(empty_string), std::exception);
@@ -133,7 +132,7 @@ void check_query_variants_results(GenomicsDB* gdb, const std::string& array, Gen
 }
 
 TEST_CASE("api query_variants direct DP", "[query_variants]") {
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, {"DP"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, {"DP"}, 40);
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,1000000000}}, {{0,3}}));
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,1000000000}}));
   check_query_variants_results(gdb, array, gdb->query_variants(array));
@@ -141,39 +140,39 @@ TEST_CASE("api query_variants direct DP", "[query_variants]") {
 }
 
 TEST_CASE("api query_variants direct DP with huge row range", "[query_variants_huge_range]") {
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, {"DP"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, {"DP"}, 40);
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,1000000000}}, {{0,10000000000}}));
   delete gdb;
 }
 
 TEST_CASE("api query_variants direct DP with huge disjoint row ranges", "[query_variants_huge_disjoint_range]") {
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, {"DP"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, {"DP"}, 40);
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,10000000000}}, {{0, 1}, {2,1000000000}, {2000000000, 3000000000}}));
   delete gdb;
 }
 
 TEST_CASE("api query_variants direct DP with range composed of multiple points", "[query_variants_points]") {
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, {"DP"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, {"DP"}, 40);
   REQUIRE(gdb->query_variants(array, {{0,10000000000}}, {{0, 0}, {2,2}}).size() == 2);
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,10000000000}}, {{0, 0}, {2,2}, {1,1}}));
   delete gdb;
 }
 
 TEST_CASE("api query_variants direct DP with range composed of overlapping ranges", "[query_variants_overlap]") {
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, {"DP"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, {"DP"}, 40);
   REQUIRE(gdb->query_variants(array, {{0,10000000000}}, {{1000,2000}, {1, 5}, {2,2}}).size() == 3);
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,10000000000}}, {{0, 10}, {1,5}, {2,3}}));
   delete gdb;
 }
 
 TEST_CASE("api query_variants direct DP with invalid row range", "[query_variants_invalid_range]") {
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, {"DP"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, {"DP"}, 40);
   REQUIRE_THROWS(check_query_variants_results(gdb, array, gdb->query_variants(array, {{-100, 1}}, {{0,10000000000}})));
   delete gdb;
 }
 
 TEST_CASE("api query_variants direct DP and GT", "[query_variants_DP_GT]") {
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, {"DP", "GT"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, {"DP", "GT"}, 40);
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,1000000000}}, {{0,3}}));
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,1000000000}}));
   check_query_variants_results(gdb, array, gdb->query_variants(array));
@@ -181,7 +180,7 @@ TEST_CASE("api query_variants direct DP and GT", "[query_variants_DP_GT]") {
 }
 
 TEST_CASE("api query_variants direct DP and GT with PP", "[query_variants_DP_GT_with_PP]") {
-  GenomicsDB* gdb = new GenomicsDB(workspace_PP, callset_mapping, vid_mapping_PP, reference_genome, {"DP", "GT"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace_PP, callset_mapping, vid_mapping_PP, {"DP", "GT"}, 40);
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,1000000000}}, {{0,3}}));
   check_query_variants_results(gdb, array, gdb->query_variants(array, {{0,1000000000}}));
   check_query_variants_results(gdb, array, gdb->query_variants(array));
@@ -384,7 +383,7 @@ class TwoQueryIntervalsProcessor : public GenomicsDBVariantCallProcessor {
 TEST_CASE("api query_variant_calls direct", "[query_variant_calls_direct]") {
   const std::vector<std::string> attributes = {"DP"};
 
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, attributes, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, attributes, 40);
 
   gdb->query_variant_calls(array);
 
@@ -409,7 +408,7 @@ TEST_CASE("api query_variant_calls direct", "[query_variant_calls_direct]") {
 TEST_CASE("api query_variant_calls direct DP and GT", "[query_variant_calls_direct_DP_GT]") {
   const std::vector<std::string> attributes = {"GT", "DP"};
 
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, attributes, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, attributes, 40);
 
   // Default query variant call without processor, should just print the calls
   gdb->query_variant_calls(array, {{0,1000000000}}, {{0,3}});
@@ -432,7 +431,7 @@ TEST_CASE("api query_variant_calls direct DP and GT", "[query_variant_calls_dire
 TEST_CASE("api query_variant_calls direct DP and GT with PP", "[query_variant_calls_direct_DP_GT_with_PP]") {
   const std::vector<std::string> attributes = {"GT", "DP"};
 
-  GenomicsDB* gdb = new GenomicsDB(workspace_PP, callset_mapping, vid_mapping_PP, reference_genome, attributes, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace_PP, callset_mapping, vid_mapping_PP, attributes, 40);
 
   // Default query variant call without processor, should just print the calls
   gdb->query_variant_calls(array, {{0,1000000000}}, {{0,3}});
@@ -534,21 +533,21 @@ TEST_CASE("api query_variant_calls with protobuf", "[query_variant_calls_with_pr
 
 TEST_CASE("api generate_vcf direct", "[query_generate_vcf_direct]") {
   TempDir temp_dir;
-  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, reference_genome, {"DP"}, 40);
+  GenomicsDB* gdb = new GenomicsDB(workspace, callset_mapping, vid_mapping, {"DP"}, 40);
 
   const std::string vcf_file1 = temp_dir.append("1.vcf.gz");
-  gdb->generate_vcf(array, {{0,1000000000}}, {{0,3}}, vcf_file1);
+  gdb->generate_vcf(array, {{0,1000000000}}, {{0,3}}, reference_genome, "", vcf_file1);
   CHECK(TileDBUtils::is_file(vcf_file1));
   CHECK(!TileDBUtils::is_file(vcf_file1+".tbi"));
 
-  gdb->generate_vcf(array, {{0,1000000000}}, {{0,3}}, vcf_file1, "z", true);
+  gdb->generate_vcf(array, {{0,1000000000}}, {{0,3}}, reference_genome, "", vcf_file1, "z", true);
   CHECK(TileDBUtils::is_file(vcf_file1));
   CHECK(TileDBUtils::is_file(vcf_file1+".tbi"));
 
-  CHECK_THROWS_AS(gdb->generate_vcf(array, {{0,1000000000}}, {{0,3}}, vcf_file1, "z", false), std::exception);
+  CHECK_THROWS_AS(gdb->generate_vcf(array, {{0,1000000000}}, {{0,3}}, reference_genome, "", vcf_file1, "z", false), std::exception);
 
   const std::string vcf_file2 = temp_dir.append("3.vcf.gz");
-  gdb->generate_vcf(array, {{0,13000}, {13000, 1000000000}}, {{0,3}}, vcf_file2, "z", true);
+  gdb->generate_vcf(array, {{0,13000}, {13000, 1000000000}}, {{0,3}}, reference_genome, "", vcf_file2, "z", true);
   CHECK(TileDBUtils::is_file(vcf_file2));
   CHECK(TileDBUtils::is_file(vcf_file2+".tbi"));
 

--- a/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
+++ b/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
@@ -82,25 +82,19 @@ public class GenomicsDBQueryTest {
   void testGenomicsDBConnectWithEmptyRequiredParams() {
     GenomicsDBQuery query = new GenomicsDBQuery();
     try {
-      query.connect("", "", "", "", new ArrayList<String>());
+              query.connect("", "", "", new ArrayList<String>());
       Assert.fail();
     } catch (GenomicsDBException e) {
       // Expected Exception
     }
     try {
-      query.connect(workspace, "", "", "", new ArrayList<String>());
+      query.connect(workspace, "", "", new ArrayList<String>());
       Assert.fail();
     } catch (GenomicsDBException e) {
       // Expected Exception
     }
     try {
-      query.connect(workspace, vidMapping, "", "", new ArrayList<String>());
-      Assert.fail();
-    } catch (GenomicsDBException e) {
-      // Expected Exception
-    }
-    try {
-      query.connect(workspace, vidMapping, callsetMapping, "", new ArrayList<String>());
+      query.connect(workspace, vidMapping, "", new ArrayList<String>());
       Assert.fail();
     } catch (GenomicsDBException e) {
       // Expected Exception
@@ -109,7 +103,7 @@ public class GenomicsDBQueryTest {
 
   private long connect() {
     GenomicsDBQuery query = new GenomicsDBQuery();
-    long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, new ArrayList<>());
+    long handle = query.connect(workspace, vidMapping, callsetMapping, new ArrayList<>());
     Assert.assertTrue(handle > 0);
     return handle;
   }
@@ -118,7 +112,7 @@ public class GenomicsDBQueryTest {
     GenomicsDBQuery query = new GenomicsDBQuery();
     List<String> attributes = new ArrayList<>();
     attributes.add("DP");
-    long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, attributes);
+    long handle = query.connect(workspace, vidMapping, callsetMapping, attributes);
     Assert.assertTrue(handle > 0);
     return handle;
   }
@@ -128,14 +122,14 @@ public class GenomicsDBQueryTest {
     List<String> attributes = new ArrayList<>();
     attributes.add("DP");
     attributes.add("GT");
-    long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, attributes);
+    long handle = query.connect(workspace, vidMapping, callsetMapping, attributes);
     Assert.assertTrue(handle > 0);
     return handle;
   }
 
   private long connectWithSegmentSize() {
     GenomicsDBQuery query = new GenomicsDBQuery();
-    long handle = query.connect(workspace, vidMapping, callsetMapping, referenceGenome, new ArrayList<>(), 40);
+    long handle = query.connect(workspace, vidMapping, callsetMapping, new ArrayList<>(), 40);
     Assert.assertTrue(handle > 0);
     return handle;
   }
@@ -283,7 +277,7 @@ public class GenomicsDBQueryTest {
     File vcfFile = File.createTempFile("GenomicsDBQueryTest", "");
     File vcfIndexFile = new File(vcfFile + ".tbi");
 
-    query.generateVCF(genomicsDBHandle, arrayName, columnRanges, new ArrayList<>(), vcfFile.toString(), "z", true);
+    query.generateVCF(genomicsDBHandle, arrayName, columnRanges, new ArrayList<>(), referenceGenome, "", vcfFile.toString(), "z", true);
 
     Assert.assertTrue(vcfFile.exists());
     Assert.assertTrue(vcfFile.length() > 0);
@@ -291,7 +285,7 @@ public class GenomicsDBQueryTest {
     Assert.assertTrue(vcfIndexFile.length() > 0);
 
     try {
-      query.generateVCF(genomicsDBHandle, arrayName, columnRanges, new ArrayList<>(), vcfFile.toString(), "z", false);
+      query.generateVCF(genomicsDBHandle, arrayName, columnRanges, new ArrayList<>(), referenceGenome, "", vcfFile.toString(), "z", false);
       Assert.fail();
     } catch (GenomicsDBException e) {
       // Expected exception

--- a/tools/src/gt_mpi_gather.cc
+++ b/tools/src/gt_mpi_gather.cc
@@ -798,11 +798,8 @@ int main(int argc, char *argv[]) {
         print_calls(qp, query_config, command_idx, query_config.get_vid_mapper());
         break;
       case COMMAND_PLINK:
-        GenomicsDB gdb(query_config.get_workspace(my_world_mpi_rank),
-                       query_config.get_callset_mapping_file(),
-                       query_config.get_vid_mapping_file(),
-                       query_config.get_reference_genome());
-        gdb.generate_plink(array_name, &query_config, plink_formats, bgen_compression, one_pass, bgen_verbose, progress_interval, plink_prefix, fam_list);
+        GenomicsDB gdb(json_config_file, GenomicsDB::JSON_FILE, loader_json_config_file, my_world_mpi_rank);
+        gdb.generate_plink(plink_formats, bgen_compression, one_pass, bgen_verbose, progress_interval, plink_prefix, fam_list);
         break;
     }
 #ifdef USE_GPERFTOOLS_HEAP


### PR DESCRIPTION
1. Reference Genome is not required for normal queries and is moved out of the constructor into methods - `generate-vcf` when broad-type gvcf files have to be created from GenomicsDB. Also, support for vcf header templates to be specified to `generate-vcf` has been added. 
2. The plink support exposes a lot of internal classes that are not part of the release and breaks building Python/R bindings to GenomicsDB that are external to the project. Moved the support out of genomicsdb into its own header and implementation files - see genomicsdb_plink.h and genomicsdb_plink.cc. 
3. Did some refactoring and cleanup of the code, but  internal dependencies from plink need to be removed to allow for Python/R bindings. Also, the c unit test `test_bgen.cc` may need to be rewritten to use goodies from Catch2 and TempDir. Will probably have to give some thought to refactoring the bgen writer as this was mentioned in the gatk meeting. Will file Issues for these later. 