### PR TITLE
Minor release fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 env:
   PREREQS_ENV: ${{github.workspace}}/prereqs.sh
   PREREQS_INSTALL_DIR: ${{github.workspace}}/prereqs
-  PROTOBUF_VERSION: 3.8.0
+  PROTOBUF_VERSION: 3.19.4
   CMAKE_INSTALL_PREFIX: ${{github.workspace}}/install
   GENOMICSDB_BUILD_DIR: ${{github.workspace}}/build
   BUILD_DISTRIBUTABLE_LIBRARY: true

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -508,24 +508,7 @@ GENOMICSDB_EXPORT const genomicsdb_variant_call_t* GenomicsDBResults<genomicsdb_
 template<>
 GENOMICSDB_EXPORT void GenomicsDBResults<genomicsdb_variant_call_t>::free();
 
-// include base template definition in header so compiler is able to link
 template<class VariantOrVariantCall>
-std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config) {
-  std::vector<genomic_field_t> fields;
-  auto index = 0u;
-  for (const auto& field: get_fields(variant_or_variant_call)) {
-    if (field && field->is_valid()) {
-      std::string name = get_query_attribute_name(variant_or_variant_call, query_config, index);
-      void* ptr = const_cast<void *>(field->get_raw_pointer());
-      genomic_field_t field_vec(name,
-                                ptr,
-                                field->length());
-      fields.push_back(field_vec);
-    }
-    index++;
-  }
-  return fields;
-}
-
+std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config);
 
 #endif /* GENOMICSDB_H */

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -508,5 +508,24 @@ GENOMICSDB_EXPORT const genomicsdb_variant_call_t* GenomicsDBResults<genomicsdb_
 template<>
 GENOMICSDB_EXPORT void GenomicsDBResults<genomicsdb_variant_call_t>::free();
 
+// include base template definition in header so compiler is able to link
+template<class VariantOrVariantCall>
+std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config) {
+  std::vector<genomic_field_t> fields;
+  auto index = 0u;
+  for (const auto& field: get_fields(variant_or_variant_call)) {
+    if (field && field->is_valid()) {
+      std::string name = get_query_attribute_name(variant_or_variant_call, query_config, index);
+      void* ptr = const_cast<void *>(field->get_raw_pointer());
+      genomic_field_t field_vec(name,
+                                ptr,
+                                field->length());
+      fields.push_back(field_vec);
+    }
+    index++;
+  }
+  return fields;
+}
+
 
 #endif /* GENOMICSDB_H */

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -576,9 +576,6 @@ void GenomicsDB::generate_vcf(const std::string& array, VariantQueryConfig* quer
   delete query_processor;
 }
 
-template<class VariantOrVariantCall>
-std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config);
-
 // Template to get the mapped interval from the GenomicsDB array for the Variant(Call)
 template<class VariantOrVariantCall>
 interval_t get_interval_for(const VariantOrVariantCall* variant_or_variant_call) {
@@ -642,24 +639,6 @@ inline std::string get_query_attribute_name(const Variant* variant, VariantQuery
 template<>
 inline std::string get_query_attribute_name(const VariantCall* variant_call, VariantQueryConfig *query_config, uint index) {
   return query_config->get_query_attribute_name(index);
-}
-
-template<class VariantOrVariantCall>
-std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config) {
-  std::vector<genomic_field_t> fields;
-  auto index = 0u;
-  for (const auto& field: get_fields(variant_or_variant_call)) {
-    if (field && field->is_valid()) {
-      std::string name = get_query_attribute_name(variant_or_variant_call, query_config, index);
-      void* ptr = const_cast<void *>(field->get_raw_pointer());
-      genomic_field_t field_vec(name,
-                                ptr,
-                                field->length());
-      fields.push_back(field_vec);
-    }
-    index++;
-  }
-  return fields;
 }
 
 VariantQueryConfig* GenomicsDB::get_query_config_for(const std::string& array) {

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -641,6 +641,29 @@ inline std::string get_query_attribute_name(const VariantCall* variant_call, Var
   return query_config->get_query_attribute_name(index);
 }
 
+template<class VariantOrVariantCall>
+std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config) {
+  std::vector<genomic_field_t> fields;
+  auto index = 0u;
+  for (const auto& field: get_fields(variant_or_variant_call)) {
+    if (field && field->is_valid()) {
+      std::string name = get_query_attribute_name(variant_or_variant_call, query_config, index);
+      void* ptr = const_cast<void *>(field->get_raw_pointer());
+      genomic_field_t field_vec(name,
+                                ptr,
+                                field->length());
+      fields.push_back(field_vec);
+    }
+    index++;
+  }
+  return fields;
+}
+
+template
+std::vector<genomic_field_t> get_genomic_fields_for<Variant>(const std::string& array, const Variant* variant_or_variant_call, VariantQueryConfig* query_config);
+template
+std::vector<genomic_field_t> get_genomic_fields_for<VariantCall>(const std::string& array, const VariantCall* variant_or_variant_call, VariantQueryConfig* query_config);
+
 VariantQueryConfig* GenomicsDB::get_query_config_for(const std::string& array) {
   auto query_config_for_array = m_query_configs_map.find(array);
   if (query_config_for_array != m_query_configs_map.end()) {

--- a/src/main/cpp/src/api/genomicsdb_plink.cc
+++ b/src/main/cpp/src/api/genomicsdb_plink.cc
@@ -49,9 +49,6 @@
 // Prototypes to internal methods in genomicsdb.cc declared here instead of header to keep the api opaque
 std::map<std::string, genomic_field_type_t> create_genomic_field_types(const VariantQueryConfig &query_config,
                                                    void *annotation_service, bool change_alt_to_string=false);
-template<class VariantOrVariantCall>
-std::vector<genomic_field_t> get_genomic_fields_for(const std::string& array, const VariantOrVariantCall* variant_or_variant_call, VariantQueryConfig* query_config);
-
 void GenomicsDB::generate_plink(const std::string& array,
                                 genomicsdb_ranges_t column_ranges,
                                 genomicsdb_ranges_t row_ranges,


### PR DESCRIPTION
I need these changed to get the compiler to explicitly instantiate the relevant templates otherwise the call to `get_genomic_fields_for` from `genomicsdb_plink.cc` doesn't find the definition.

Release pipeline is still building...but hopefully this change is otherwise kosher...