### PR TITLE
First pass at implementing a bypass mechanism for intersecting intervals mode for fast, fuzzy queries based on just simple traversal

### DIFF
--- a/src/main/cpp/include/config/genomicsdb_config_base.h
+++ b/src/main/cpp/include/config/genomicsdb_config_base.h
@@ -133,6 +133,9 @@ class GenomicsDBConfigBase {
   const bool produce_GT_with_min_PL_value_for_spanning_deletions() const {
     return m_produce_GT_with_min_PL_value_for_spanning_deletions;
   }
+  const bool bypass_intersecting_intervals_phase() const {
+    return m_bypass_intersecting_intervals_phase;
+  }
   const VidMapper& get_vid_mapper() const {
     return m_vid_mapper;
   }
@@ -221,6 +224,9 @@ class GenomicsDBConfigBase {
   unsigned m_max_diploid_alt_alleles_that_can_be_genotyped;
   //Max #genotypes for which fields whose length is equal to the number of genotypes can be produced (such as PL)
   unsigned m_max_genotype_count;
+  //Bypass the first intersecting interval phase and use just the simple traversal mode for a fast
+  //fuzzy search if that is acceptable
+  bool m_bypass_intersecting_intervals_phase;
   //Buffer size for combined vcf records
   size_t m_combined_vcf_records_buffer_size_limit;
   //VidMapper

--- a/src/main/cpp/src/config/genomicsdb_config_base.cc
+++ b/src/main/cpp/src/config/genomicsdb_config_base.cc
@@ -48,6 +48,7 @@ GenomicsDBConfigBase::GenomicsDBConfigBase() {
     m_index_output_VCF = false;
     m_sites_only_query = false;
     m_produce_GT_with_min_PL_value_for_spanning_deletions = false;
+    m_bypass_intersecting_intervals_phase = false;
     //Lower and upper bounds of callset row idx to import in this invocation
     m_lb_callset_row_idx = 0;
     m_ub_callset_row_idx = INT64_MAX-1;

--- a/src/main/cpp/src/config/json_config.cc
+++ b/src/main/cpp/src/config/json_config.cc
@@ -640,7 +640,10 @@ void GenomicsDBConfigBase::read_from_JSON(const rapidjson::Document& json_doc, c
   //when producing GT, use the min PL value GT for spanning deletions
   m_produce_GT_with_min_PL_value_for_spanning_deletions = (json_doc.HasMember("produce_GT_with_min_PL_value_for_spanning_deletions")
       && json_doc["produce_GT_with_min_PL_value_for_spanning_deletions"].GetBool());
-
+  //Bypass the first intersecting interval phase and use just the simple traversal mode for a fast
+  //fuzzy search if that is acceptable
+  m_bypass_intersecting_intervals_phase = (json_doc.HasMember("bypass_intersecting_intervals_phase")
+      && json_doc["bypass_intersecting_intervals_phase"].GetBool());
   //Shared posixfs(e.g. NFS/Lustre) optimizations - passed via storage manager
   set_config_field(json_doc, "enable_shared_posixfs_optimizations", m_enable_shared_posixfs_optimizations);
 }

--- a/src/main/cpp/src/config/pb_config.cc
+++ b/src/main/cpp/src/config/pb_config.cc
@@ -212,6 +212,10 @@ void GenomicsDBConfigBase::read_from_PB(const genomicsdb_pb::ExportConfiguration
   m_produce_GT_with_min_PL_value_for_spanning_deletions =
     export_config->has_produce_gt_with_min_pl_value_for_spanning_deletions()
     ? export_config->produce_gt_with_min_pl_value_for_spanning_deletions() : false;
+  //Bypass the first intersecting interval phase and use just the simple traversal mode for a fast
+  //fuzzy search if that is acceptable
+  m_bypass_intersecting_intervals_phase =
+      export_config->has_bypass_intersecting_intervals_phase() ? export_config->bypass_intersecting_intervals_phase() : false;
   //Enable Shared PosixFS Optimizations in TileDB
   m_enable_shared_posixfs_optimizations = export_config->has_enable_shared_posixfs_optimizations()
     ? export_config->enable_shared_posixfs_optimizations() : false;

--- a/src/main/cpp/src/genomicsdb/genomicsdb_iterators.cc
+++ b/src/main/cpp/src/genomicsdb/genomicsdb_iterators.cc
@@ -195,11 +195,8 @@ void SingleCellTileDBIterator::begin_new_query_column_interval(TileDB_CTX* tiled
           return;
         }
       }
-      if (m_query_config->bypass_intersecting_intervals_phase()) {
-        m_in_simple_traversal_mode = true;
-      } else {
-        m_in_find_intersecting_intervals_mode = true;
-      }
+      m_in_simple_traversal_mode = m_query_config->bypass_intersecting_intervals_phase();
+      m_in_find_intersecting_intervals_mode = !m_query_config->bypass_intersecting_intervals_phase();
     }
     auto smallest_row_idx_in_array = m_query_config->get_smallest_row_idx_in_array();
     //Range of the query

--- a/src/main/cpp/src/genomicsdb/genomicsdb_iterators.cc
+++ b/src/main/cpp/src/genomicsdb/genomicsdb_iterators.cc
@@ -177,9 +177,11 @@ void SingleCellTileDBIterator::begin_new_query_column_interval(TileDB_CTX* tiled
     std::vector<const char*>* attribute_names) {
   do {
     //This can happen iff in the previous iteration intersecting intervals were searched OR
-    //full array scan is requested and this is the first time a read is being performed
+    //full array scan is requested and this is the first time a read is being performed OR
+    //if only a single pass simple traversal is desired
     if (m_in_find_intersecting_intervals_mode
-        || (m_first_read_from_TileDB && (m_query_config->get_num_column_intervals() == 0u)))
+        || (m_first_read_from_TileDB && (m_query_config->get_num_column_intervals() == 0u
+                                         || m_query_config->bypass_intersecting_intervals_phase())))
       move_into_simple_traversal_mode();
     else {
       reset_for_next_query_interval();
@@ -193,7 +195,11 @@ void SingleCellTileDBIterator::begin_new_query_column_interval(TileDB_CTX* tiled
           return;
         }
       }
-      m_in_find_intersecting_intervals_mode = true;
+      if (m_query_config->bypass_intersecting_intervals_phase()) {
+        m_in_simple_traversal_mode = true;
+      } else {
+        m_in_find_intersecting_intervals_mode = true;
+      }
     }
     auto smallest_row_idx_in_array = m_query_config->get_smallest_row_idx_in_array();
     //Range of the query
@@ -204,8 +210,9 @@ void SingleCellTileDBIterator::begin_new_query_column_interval(TileDB_CTX* tiled
     if (m_query_config->get_num_column_intervals() > 0u) {
       assert(m_query_column_interval_idx < m_query_config->get_num_column_intervals());
       query_range[2] = m_query_config->get_column_begin(m_query_column_interval_idx);
-      if (m_in_simple_traversal_mode)
+      if (m_in_simple_traversal_mode) {
         query_range[3] = m_query_config->get_column_end(m_query_column_interval_idx);
+      }
     }
     auto status = -1;
     if (m_tiledb_array == 0) {

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -101,7 +101,8 @@ message ExportConfiguration {
   optional uint32 segment_size = 26;
   optional uint32 combined_vcf_records_buffer_size_limit = 27;
   optional bool enable_shared_posixfs_optimizations = 28;
-  optional SparkConfig spark_config = 29;
-  repeated AnnotationSource annotation_source = 30;
-  optional uint32 annotation_buffer_size = 31 [default = 10240];
+  optional bool bypass_intersecting_intervals_phase = 29;
+  optional SparkConfig spark_config = 30;
+  repeated AnnotationSource annotation_source = 31;
+  optional uint32 annotation_buffer_size = 32 [default = 10240];
 }

--- a/src/test/cpp/src/test_config.cc
+++ b/src/test/cpp/src/test_config.cc
@@ -127,6 +127,7 @@ TEST_CASE("Check configuration with json file", "[basic_config_check]") {
   CHECK(query_config_from_file.produce_GT_field() == false);
   CHECK(query_config_from_file.produce_FILTER_field() ==  false);
   CHECK(query_config_from_file.sites_only_query() == false);
+  CHECK(query_config_from_file.bypass_intersecting_intervals_phase() == false);
   CHECK(query_config_from_file.index_output_VCF() ==  false);
   CHECK(query_config_from_file.produce_GT_with_min_PL_value_for_spanning_deletions() == false);
   CHECK(query_config_from_file.get_vid_mapper().is_initialized() ==  true);
@@ -187,6 +188,7 @@ TEST_CASE("Compare configuration with json file and string", "[compare_json_type
   CHECK(query_config_from_file.produce_GT_field() == query_config_from_str.produce_GT_field());
   CHECK(query_config_from_file.produce_FILTER_field() ==  query_config_from_str.produce_FILTER_field());
   CHECK(query_config_from_file.sites_only_query() == query_config_from_str.sites_only_query());
+  CHECK(query_config_from_file.bypass_intersecting_intervals_phase() == query_config_from_str.bypass_intersecting_intervals_phase());
   CHECK(query_config_from_file.index_output_VCF() == query_config_from_str.index_output_VCF());
   CHECK(query_config_from_file.produce_GT_with_min_PL_value_for_spanning_deletions() == query_config_from_str.produce_GT_with_min_PL_value_for_spanning_deletions());
   CHECK(query_config_from_file.get_vid_mapper().is_initialized() == query_config_from_str.get_vid_mapper().is_initialized());

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -375,9 +375,9 @@ run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-call
 # $4 Error Message
 diff_gt_mpi_gather_output() {
   sed "1 d" $1 > $1.cut
-  sed -i '/MD5/d' $1.cut
+  sed -i -e '/MD5/d' $1.cut
   sed "1 d" $2 > $2.cut
-  sed -i '/MD5/d' $2.cut
+  sed -i -e '/MD5/d' $2.cut
   DIFF_RESULT=$(diff $1.cut $2.cut)
   if [[ ! -z  $DIFF_RESULT && $3 == OK ]]; then
     echo "gt_mpi_gather results differ : $4"

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -209,9 +209,9 @@ run_command() {
 }
 
 time_command() {
-  START=$(date -u +%s%N)
+  START=$(date -u +%s)
   run_command "$@"
-  END=$(date -u +%s%N)
+  END=$(date -u +%s)
   TIME=$(($END-$START))
 }
 

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -152,17 +152,16 @@ EOF
 EOF
 }
 
-# create_query_json with two intervals
-#    (Optional) $1 additional json entries
-create_query_json_with_two_intervals() {
+# create_query_json with intervals
+#    $1 is the query interval specification
+#    (Optional) $2 additional json entries
+create_query_json_with_intervals() {
   QUERY_JSON=$TEMP_DIR/query_json_$RANDOM
   cat > $QUERY_JSON  << EOF
 {
     "workspace": "$WORKSPACE",
     "generate_array_name_from_partition_bounds": true,
-    "query_contig_intervals": [
-        {"contig": "1", "begin": 1, "end":100 },
-        {"contig": "1", "begin": 17385 }],
+    $1,
     "query_row_ranges": [{
         "range_list": [{
             "low" : 0,
@@ -170,13 +169,13 @@ create_query_json_with_two_intervals() {
         }]
      }],
 EOF
-  if [[ $# -ge 1 ]]; then
+  if [[ $# -ge 2 ]]; then
     cat >> $QUERY_JSON  << EOF
-    $1,
+    $2,
 EOF
   fi
   cat >> $QUERY_JSON << EOF
-    "attributes" : [ "REF", "ALT", "BaseQRankSum", "MQ", "RAW_MQ", "MQ0", "ClippingRankSum", "MQRankSum", "ReadPosRankSum", "DP", "GT", "GQ", "SB", "AD", "PL", "DP_FORMAT", "MIN_DP", "PID", "PGT" ]
+    "attributes" : [ "REF", "ALT", "BaseQRankSum", "MQ", "RAW_MQ", "MQ0", "ClippingRankSum", "MQRankSum", "ReadPosRankSum", "DP", "GT", "GQ", "SB", "AD", "PL", "DP_FORMAT", "MIN_DP", "PGT" ]
 }
 EOF
 }
@@ -220,6 +219,7 @@ time_command() {
   TIME=$(($END-$START))
 }
 
+OK=0
 ERR=1
 
 # Sanity Checks for Tools
@@ -368,35 +368,68 @@ run_command "gt_mpi_gather -A "non-existent-array" $WORKSPACE/loader.json -j $QU
 run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
 run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-calls"
 
+# Diff results from two gt_mpi_gather invocations
+# $1 Results from 1st invocation
+# $2 Results from 2nd invocation
+# $3 Expected Result(OK or ERR)
+# $4 Error Message
+diff_gt_mpi_gather_output() {
+  sed "1 d" $1 > $1.cut
+  sed -i '/MD5/d' $1.cut
+  sed "1 d" $2 > $2.cut
+  sed -i '/MD5/d' $2.cut
+  DIFF_RESULT=$(diff $1.cut $2.cut)
+  if [[ ! -z  $DIFF_RESULT && $3 == OK ]]; then
+    echo "gt_mpi_gather results differ : $4"
+    echo "First output:"
+    cat $1.cut
+    echo "Second output:"
+    cat $2.cut
+    STATUS=1
+  elif [[ -z $DIFF_RESULT && $3 == ERR ]]; then
+    echo "gt_mpi_gather results should differ but were identical : $4"
+    STATUS=1
+  fi
+}
+
+# $1 : intervals
+test_bypass_intersecting_intervals_phase() {
+  create_query_json_with_intervals "$1"
+  time_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
+  DIFF=$TIME
+  mv -f $TEMP_DIR/output $TEMP_DIR/output.without_bypass
+  create_query_json_with_intervals "$1" "\"bypass_intersecting_intervals_phase\": true"
+  time_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
+  if [ $DIFF -lt $TIME ]; then
+    echo "Bypass intersecting intervals phase took longer than the normal two pass iterator"
+    STATUS=1
+  fi
+}
+
 # Test bypass of intersecting intervals phase in the genomicsdb iterators
-time_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
-DIFF=$TIME
-create_query_json "\"bypass_intersecting_intervals_phase\": true"
-time_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
-if [ $DIFF -lt $TIME ]; then
-  echo "Bypass intersecting intervals phase took longer than the normal two pass iterator"
-  STATUS=1
-fi
+INTERVALS="\"query_contig_intervals\": [{\"contig\": \"1\", \"begin\": 1, \"end\":100 }]"
+test_bypass_intersecting_intervals_phase "$INTERVALS"
+diff_gt_mpi_gather_output $TEMP_DIR/output.without_bypass $TEMP_DIR/output OK "Setting bypass intersecting intervals should not affect gt_mpi_gather for $INTERVALS for t0.vcf.gz"
 
 # Test bypass of intersecting intervals phase in the genomicsds iterators with two intervals
-create_query_json_with_two_intervals
-time_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
-DIFF=$TIME
-create_query_json_with_two_intervals "\"bypass_intersecting_intervals_phase\": true"
-time_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
-if [ $DIFF -lt $TIME ]; then
-  echo "Bypass intersecting intervals phase for two intervals took longer than the normal two pass iterator"
-  STATUS=1
-fi
+INTERVALS="\"query_contig_intervals\": [{\"contig\": \"1\", \"begin\": 1, \"end\":100 }, {\"contig\": \"1\", \"begin\": 17385 }]"
+test_bypass_intersecting_intervals_phase "$INTERVALS"
+diff_gt_mpi_gather_output $TEMP_DIR/output.without_bypass $TEMP_DIR/output OK "Setting bypass intersecting intervals should not affect gt_mpi_gather for $INTERVALS for t0.vcf.gz"
 
-# Fail if there is no reference genome file specified
-run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --produce-Broad-GVCF" ERR
+# Test bypass of intersecting intervals phase missing indels not in the query region
+create_sample_list t6_asa.vcf.gz
+run_command "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -o"
+run_command "vcf2genomicsdb $WORKSPACE/loader.json"
+INTERVALS="\"query_contig_intervals\": [{\"contig\": \"1\", \"begin\": 8029501 }]"
+test_bypass_intersecting_intervals_phase "$INTERVALS"
+diff_gt_mpi_gather_output $TEMP_DIR/output.without_bypass $TEMP_DIR/output ERR "Setting bypass intersecting intervals should cause gt_mpi_gather to be different for $INTERVALS for t6_asa.vcf.gz"
 
-# Fail if the reference genome is pointing to a non-existent file
-create_query_json "\"reference_genome\" : non-exisitent-reference-genome"
-run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --produce-Broad-GVCF" ERR
 
 # Fail if the reference genome cannot be parsed by htslib for any reason
+create_sample_list t0.vcf.gz
+run_command "vcf2genomicsdb_init -w $WORKSPACE -s $SAMPLE_LIST -o"
+run_command "vcf2genomicsdb $WORKSPACE/loader.json"
+
 create_query_json "\"reference_genome\" : $WORKSPACE/loader.json"
 run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --produce-Broad-GVCF" ERR
 
@@ -405,22 +438,12 @@ create_query_json "\"reference_genome\" : \"$REFERENCE_GENOME\""
 run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --produce-Broad-GVCF"
 
 # Test consolidate_genomicsdb_array and gt_mpi_gather after consolidation
-diff_gt_output() {
-  sed "1 d" $1 > $1.cut
-  sed "1 d" $2 > $2.cut
-  DIFF_RESULT=$(diff $1.cut $2.cut)
-  if [[ ! -z  $DIFF_RESULT ]]; then
-     echo "gt_mpi_gather results for Test $3 differ after consolidation"
-     STATUS=1
-  fi
-}
-
 run_consolidation_and_check_results() {
   run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
   mv -f $TEMP_DIR/output $TEMP_DIR/output.no.consolidation
   run_command "$1"
   run_command "gt_mpi_gather -l $WORKSPACE/loader.json -j $QUERY_JSON --print-AC"
-  diff_gt_output  $TEMP_DIR/output.no.consolidation $TEMP_DIR/output $2
+  diff_gt_mpi_gather_output  $TEMP_DIR/output.no.consolidation $TEMP_DIR/output $2 OK "After consolidation"
 }
 
 ARRAY="1\$1\$249250621"

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -209,9 +209,14 @@ run_command() {
 }
 
 time_command() {
-  START=$(date -u +%s)
+  if [[ $(uname) == "Darwin" ]]; then
+    DT="date -u +%s"
+  else
+    DT="date -u +%s%N"
+  fi
+  START=$($DT)
   run_command "$@"
-  END=$(date -u +%s)
+  END=$($DT)
   TIME=$(($END-$START))
 }
 


### PR DESCRIPTION
Rationale behind this bypass mechanism is as follows (thanks @mlathara) -
- in most (all?) cohort queries by genes, there is usually some padding in the regions for the gene and that should suffice to return all the sites that are relevant. this is especially true for omics data from clinical testing
- for specific mutations, missing the indels for the variant is fine, because by definition, that's not meeting the query criteria
- for sample sizes that are super large, a cohort search being a bit of a fuzzy match is OK as long as the downstream processing is aware that this is a fast, fuzzy query and they can always resort to the two pass iterator if all the results are desired.