### PR TITLE
Use ubuntu 20.04 explicitly for GitHub Actions and other release specific cleanup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master, develop, ng_codeql_1 ]
     paths:
       - '**/CMakeLists.txt'
       - 'pom.xml'
@@ -40,7 +40,7 @@ env:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read
@@ -52,11 +52,11 @@ jobs:
       # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         config-file: ./.github/resources/codeql-config.yml
         languages: cpp, java
@@ -66,7 +66,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Cache built prerequisites for ubuntu
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{env.PREREQS_INSTALL_DIR}}
@@ -95,4 +95,4 @@ jobs:
     #  uses: github/codeql-action/autobuild@v1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, develop, ng_codeql_1 ]
+    branches: [ master, develop ]
     paths:
       - '**/CMakeLists.txt'
       - 'pom.xml'
@@ -76,7 +76,9 @@ jobs:
           ~/protobuf-install
         key: ubuntu-codeql-cache-prereqs-v1
 
-    - run: |
+    - name: Build GenomicsDB
+      shell: bash
+      run: |
         $GITHUB_WORKSPACE/.github/scripts/cleanup_hosts.sh
         echo "Install Prerequisites for Linux.."
         pushd $GITHUB_WORKSPACE/scripts/prereqs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,17 +24,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cache built prerequisites
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{env.PREREQS_INSTALL_DIR}}
-            ~/.m2/repository
-            ~/awssdk-install
-            ~/gcssdk-install
-            ~/protobuf-install/${{env.PROTOBUF_VERSION}}
-          key: ${{matrix.os}}-cache-prereqs-v5
-
       - name: Set version number
         run: echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache built prerequisites
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{env.PREREQS_INSTALL_DIR}}

--- a/scripts/prereqs/install_prereqs.sh
+++ b/scripts/prereqs/install_prereqs.sh
@@ -24,13 +24,15 @@
 set -e
 
 # Arguments to the script
-#  $1 - BUILD_DISTRIBUTABLE_LIBRARY, if true will build/install OpenSSL/CURL/UUID/Intel zlib libs
-#  $2 - 'full' if build prerequisites should be installed, 'release' if only runtime prerequisites should be installed
+#  $1 - 'full' if build prerequisites should be installed, 'release' if only runtime prerequisites should be installed
 
 OPENSSL_VERSION=1.1.1o
 MAVEN_VERSION=3.6.3
 CURL_VERSION=7.83.1
 UUID_VERSION=1.0.3
+
+# BUILD_DISTRIBUTABLE_LIBRARY, if true will build/install OpenSSL/CURL/UUID/Intel zlib libs
+BUILD_DISTRIBUTABLE_LIBRARY=${BUILD_DISTRIBUTABLE_LIBRARY:-false}
 
 # Check for the following overriding env variables
 #    $INSTALL_PREFIX allows for dependencies maven/protobuf/etc. that are built to be installed to $INSTALL_PREFIX for user installs
@@ -54,8 +56,6 @@ if [ -f $PREREQS_ENV ]; then
   rm -f $PREREQS_ENV
 fi
 touch $PREREQS_ENV
-
-BUILD_DISTRIBUTABLE_LIBRARY=${1:-false}
 
 if [[ `uname` == "Darwin" && $BUILD_DISTRIBUTABLE_LIBRARY == true ]]; then
   export MACOSX_DEPLOYMENT_TARGET=10.13


### PR DESCRIPTION
We need to stay with ubuntu 20.04 for now as 22.04 has moved to using OpenSSL 3 by default for Github workflows. Also, removed caches for release workflows as we want to build everything from scratch and cleaned up use of `BUILD_DISTRIBUTABLE_LIBRARY` in release.yml.