### PR TITLE
Disable gatk IT for release pipeline

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -49,15 +49,15 @@ jobs:
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb -Dversion=${VERSION_NUMBER} \
             -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom
           ./test_genomicsdbjar.sh
-
-      - name: Checkout GATK
-        uses: actions/checkout@v3
-        with:
-          repository: broadinstitute/gatk
-          lfs: 'true'
-
-      - name: Try GATK integration test
-        shell: bash
-        run: |
-          ./gradlew installDist -Dgenomicsdb.version=${VERSION_NUMBER}
-          ./gradlew test --tests *GenomicsDB*
+#
+#      - name: Checkout GATK
+#        uses: actions/checkout@v3
+#        with:
+#          repository: broadinstitute/gatk
+#          lfs: 'true'
+#
+#      - name: Try GATK integration test
+#        shell: bash
+#        run: |
+#          ./gradlew installDist -Dgenomicsdb.version=${VERSION_NUMBER}
+#          ./gradlew test --tests *GenomicsDB*


### PR DESCRIPTION
These are failing for the current master because changes made [here](https://github.com/GenomicsDB/GenomicsDB/pull/238) also need to be pulled into GATK. 

We'll need to think about how to handle cases like this, where we potentially change something which requires a corresponding change in GATK...maybe the tag message could include something like skip_ci, and we key off that to skip the GATK IT. In fact, that seems simple enough that maybe I should make that change here? Thoughts?