### PR TITLE
Expose some of the TileDB filesystem functionality in GenomicsDB for use in Python/R and probably Java bindings

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -68,6 +68,7 @@ set(GenomicsDB_library_sources
     cpp/src/api/genomicsdb.cc
     cpp/src/api/genomicsdb_field.cc
     cpp/src/api/genomicsdb_plink.cc
+    cpp/src/api/genomicsdb_utils.cc
     )
 
 include_directories(${PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS})
@@ -127,7 +128,7 @@ endif()
 #endif()
 
 install(TARGETS genomicsdb tiledbgenomicsdb LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
-install(FILES cpp/include/api/genomicsdb.h  cpp/include/api/genomicsdb_exception.h DESTINATION include)
+install(FILES cpp/include/api/genomicsdb.h  cpp/include/api/genomicsdb_exception.h cpp/include/api/genomicsdb_utils.h DESTINATION include)
 if(BUILD_FOR_PYTHON)
   install(FILES ${PROTOBUF_GENERATED_PYTHON_SRCS} DESTINATION genomicsdb/protobuf/python)
 endif()

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -34,6 +34,7 @@
 #define GENOMICSDB_H
 
 #include "genomicsdb_exception.h"
+#include "genomicsdb_utils.h"
 
 #include <map>
 #include <set>
@@ -47,13 +48,7 @@
 #include <vector>
 #include <functional>
 
-// Override project visibility set to hidden for api
-#if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
-#  define GENOMICSDB_EXPORT __attribute__((visibility("default")))
-#else
-#  define GENOMICSDB_EXPORT
-#endif
-
+[[deprecated("Use genomicsdb::version instead")]]
 GENOMICSDB_EXPORT std::string genomicsdb_version();
 
 typedef std::pair<uint64_t, uint64_t> interval_t;
@@ -323,7 +318,7 @@ class GenomicsDB {
   /**
    * Constructor to the GenomicsDB Query API with configuration json files
    *   query_configuration - describe the query configuration in either a JSON file or string
-   *   query_configuration_type - type of query configuration, could be a JSON_FILE or JSON_STRING
+   *   query_configuration_type - type of query confi1guration, could be a JSON_FILE or JSON_STRING
    *   loader_config_json_file, optional - describe the loader configuration in a JSON file.
    *           If a configuration key exists in both the query and the loader configuration, the query
    *           configuration takes precedence

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -318,7 +318,7 @@ class GenomicsDB {
   /**
    * Constructor to the GenomicsDB Query API with configuration json files
    *   query_configuration - describe the query configuration in either a JSON file or string
-   *   query_configuration_type - type of query confi1guration, could be a JSON_FILE or JSON_STRING
+   *   query_configuration_type - type of query configuration, could be a JSON_FILE or JSON_STRING
    *   loader_config_json_file, optional - describe the loader configuration in a JSON file.
    *           If a configuration key exists in both the query and the loader configuration, the query
    *           configuration takes precedence

--- a/src/main/cpp/include/api/genomicsdb_utils.h
+++ b/src/main/cpp/include/api/genomicsdb_utils.h
@@ -1,0 +1,83 @@
+/**
+ * @file genomicsdb_utils.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Header file to genomicsdb utilities
+ *
+ **/
+
+#pragma once
+
+// Override project visibility set to hidden for api
+#if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
+#  define GENOMICSDB_EXPORT __attribute__((visibility("default")))
+#else
+#  define GENOMICSDB_EXPORT
+#endif
+
+#include <string>
+
+/**@{*/
+/** Return code. */
+#define GENOMICSDB_OK 0
+#define GENOMICSDB_ERR -1
+/**@}*/
+
+namespace genomicsdb {
+
+/**
+ * Get version of the native GenomicsDB Library
+ * @return version string of GenomicsDB Library 
+ */
+GENOMICSDB_EXPORT std::string version();
+
+/**
+ * Check if file referenced by filename exists as a file.
+ * @param filename Filename could be a file in the local filesystem or could be a cloud URI(s3, gcs or azure)
+ * @return true if file exists, false otherwise
+ */
+GENOMICSDB_EXPORT bool is_file(const std::string& filename);
+
+/**
+ * Get size of file referenced by filename
+ * @param filename Filename could be a file in the local filesystem or could be a cloud URI(s3, gcs or azure)
+ * @return size of file if it exists, -1 otherwise
+ */
+GENOMICSDB_EXPORT ssize_t file_size(const std::string& filename);
+
+/**
+ * Read contents of file referenced by filename
+ * @param filename Filename could be a file in the local filesystem or could be a cloud URI(s3, gcs or azure)
+ * @param buffer Reference to a buffer pointer. buffer is malloc'ed and has to be freed by calling function
+ * @param length Reference to length of buffer.
+ * @return GENOMICSDB_OK for success, GENOMICSDB_ERR otherwise
+ */
+GENOMICSDB_EXPORT int read_entire_file(const std::string& filename, void **buffer, size_t *length);
+
+}
+
+

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -65,7 +65,7 @@
 
 
 std::string genomicsdb_version() {
-  return GENOMICSDB_VERSION;
+  return genomicsdb::version();
 }
 
 #define VERIFY(X) if(!(X)) throw GenomicsDBException(#X);

--- a/src/main/cpp/src/api/genomicsdb_utils.cc
+++ b/src/main/cpp/src/api/genomicsdb_utils.cc
@@ -1,0 +1,54 @@
+/**
+ * @file genomicsdb_utils.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * genomicsdb utilities
+ *
+ **/
+#include "genomicsdb_utils.h"
+#include "tiledb_utils.h"
+
+
+namespace genomicsdb {
+
+std::string version() {
+  return GENOMICSDB_VERSION;
+}
+
+bool is_file(const std::string& filename) {
+  return TileDBUtils::is_file(filename);
+}
+
+ssize_t file_size(const std::string& filename) {
+  return TileDBUtils::file_size(filename);
+}
+
+int read_entire_file(const std::string& filename, void **buffer, size_t *length) {
+  return TileDBUtils::read_entire_file(filename, buffer, length);
+}
+
+}

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -29,6 +29,7 @@
 
 #include "genomicsdb.h"
 #include "genomicsdb_config_base.h"
+#include "genomicsdb_utils.h"
 #include "tiledb_utils.h"
 #include "genomicsdb_logger.h" // REMOVE
 
@@ -40,6 +41,28 @@
 #include <string>
 #include <thread>
 #include <utility>
+
+TEST_CASE_METHOD(TempDir, "utils", "[genomicsdb_utils]") {
+  REQUIRE(genomicsdb::version().size() > 0);
+  REQUIRE_THAT(genomicsdb::version(), Catch::Equals(GENOMICSDB_VERSION));
+
+  std::string hello_world = "Hello World";
+  std::string filename =  append("hello.txt");
+  CHECK(TileDBUtils::write_file(filename, hello_world.data(), hello_world.length(), true) == TILEDB_OK);
+
+  CHECK(genomicsdb::is_file(filename));
+  CHECK(!genomicsdb::is_file(filename+".nonexistent"));
+  
+  CHECK(genomicsdb::file_size(filename) == 11);
+  CHECK(genomicsdb::file_size(filename+".new") == -1);
+  
+  char *txt;
+  size_t length;
+  CHECK(genomicsdb::read_entire_file(filename, (void **)&txt, &length) == GENOMICSDB_OK);
+  CHECK(length == 11);
+  CHECK(hello_world == txt);
+  CHECK(genomicsdb::read_entire_file(filename+".another", (void **)txt, &length) == TILEDB_ERR);
+}
 
 TEST_CASE("api get_version", "[get_version]") {
   REQUIRE(genomicsdb_version().size() > 0);

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -29,7 +29,6 @@
 
 #include "genomicsdb.h"
 #include "genomicsdb_config_base.h"
-#include "genomicsdb_utils.h"
 #include "tiledb_utils.h"
 #include "genomicsdb_logger.h" // REMOVE
 


### PR DESCRIPTION
Introduced a `genomicsdb_utils api` for accessing TileDB filesystem functionality from other languages. Only functions needed by `GDBPythonAPI` are wrapped for now to replace `fsspec`.
1. Introduced a `genomicsdb` namespace to define utility functions and to avoid clashes with other similarly named functions.
2. Deprecated `genomicsdb_version` and moved the `version()` functionality to the `genomicsdb` namespace.
3. Tried to document the new api Javadoc style for use with doxygen. We should eventually move `genomicsdb.h` to follow this style so `genomicsdb.readthedocs.io` looks cleaner for C/C++.