### PR TITLE
Protobuf cleanup to allow for import/export from other languages via prototype buffers

### DIFF
--- a/example/java/TestGenomicsDB.java
+++ b/example/java/TestGenomicsDB.java
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 

--- a/example/java/TestGenomicsDB.java
+++ b/example/java/TestGenomicsDB.java
@@ -20,8 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import com.googlecode.protobuf.format.JsonFormat;
-
+import org.genomicsdb.shaded.com.google.protobuf.util.JsonFormat;
 import gnu.getopt.Getopt;
 import gnu.getopt.LongOpt;
 
@@ -39,7 +38,6 @@ import org.genomicsdb.importer.GenomicsDBImporter;
 import org.genomicsdb.model.GenomicsDBExportConfiguration;
 import org.genomicsdb.reader.GenomicsDBFeatureReader;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -53,11 +51,11 @@ public final class TestGenomicsDB
     return new String(encoded, encoding);
   }
 
-  private static GenomicsDBExportConfiguration.ExportConfiguration resolveExportConfigurationFromJsonString(String jsonString) throws JsonFormat.ParseException {
+  private static GenomicsDBExportConfiguration.ExportConfiguration resolveExportConfigurationFromJsonString(String jsonString) {
     GenomicsDBExportConfiguration.ExportConfiguration.Builder exportConfigurationBuilder =
             GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
     try {
-      new JsonFormat().merge(new ByteArrayInputStream(jsonString.getBytes()), exportConfigurationBuilder);
+      JsonFormat.parser().merge(jsonString, exportConfigurationBuilder);
     } catch (IOException e) {
       System.err.println(String.format("Could not resolve export for given json string: %s", e.getMessage()));
       System.exit(1);

--- a/example/java/TestGenomicsDBSource.java
+++ b/example/java/TestGenomicsDBSource.java
@@ -51,7 +51,7 @@ import static org.apache.spark.sql.functions.bround;
 import static org.apache.spark.sql.functions.col;
 
 import org.genomicsdb.shaded.com.google.protobuf.Message;
-import com.googlecode.protobuf.format.JsonFormat;
+import org.genomicsdb.shaded.com.google.protobuf.util.JsonFormat;
 
 public final class TestGenomicsDBSource implements JsonFileExtensions {
 
@@ -70,7 +70,7 @@ public final class TestGenomicsDBSource implements JsonFileExtensions {
   }
 
   public static StructType getSchemaFromQuery(File query, String vidmapping) 
-      throws IOException, ParseException {
+      throws ParseException, IOException {
     try {
       JSONParser qparser = new JSONParser();
       FileReader queryJsonReader = new FileReader(query);
@@ -124,14 +124,13 @@ public final class TestGenomicsDBSource implements JsonFileExtensions {
     }
   }
 
-  public VidMappingPB getVidMapPBFromLoaderPB(String file) 
-      throws com.googlecode.protobuf.format.JsonFormat.ParseException {
+  public VidMappingPB getVidMapPBFromLoaderPB(String file) {
     GenomicsDBImportConfiguration.ImportConfiguration.Builder loader = 
         GenomicsDBImportConfiguration.ImportConfiguration.newBuilder();
     
     String jsonString = GenomicsDBUtils.readEntireFile(file);
     try {
-      new JsonFormat().merge(new ByteArrayInputStream(jsonString.getBytes()), loader);
+      JsonFormat.parser().merge(jsonString, loader);
     } catch (IOException e) {
       System.err.println(String.format("Could not get Json format for file %s", file));
       System.exit(1);
@@ -244,7 +243,7 @@ public final class TestGenomicsDBSource implements JsonFileExtensions {
       }
       StructType querySchema = getSchemaFromQuery(new File(queryFile), vidMapping);
       schema = schemaBuilder.buildSchemaWithVid(querySchema.fields());
-    } catch (com.googlecode.protobuf.format.JsonFormat.ParseException e) {
+    } catch (IOException e) {
       e.printStackTrace();
     }
 

--- a/example/java/TestGenomicsDBSource.java
+++ b/example/java/TestGenomicsDBSource.java
@@ -1,5 +1,6 @@
 /**
- * The MIT License (MIT) Copyright (c) 2019 Omics Data Automation
+ * The MIT License (MIT)
+ * Copyright (c) 2019, 2023 Omics Data Automation
  *
  * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
  * and associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/example/java/TestGenomicsDBSparkHDFS.java
+++ b/example/java/TestGenomicsDBSparkHDFS.java
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2018 Univeristy of Caifornia, Los Angeles and Intel Corporation
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 
@@ -11,7 +12,6 @@
  *
  * The above copyright notice and this permission notice shall be included in all 
  * copies or substantial portions of the Software.
- *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 

--- a/example/java/TestGenomicsDBSparkHDFS.java
+++ b/example/java/TestGenomicsDBSparkHDFS.java
@@ -50,8 +50,7 @@ import java.util.List;
 import java.util.Base64;
 
 import org.genomicsdb.shaded.com.google.protobuf.Message;
-import com.googlecode.protobuf.format.JsonFormat;
-import com.googlecode.protobuf.format.JsonFormat.ParseException;
+import org.genomicsdb.shaded.com.google.protobuf.util.JsonFormat;
 
 public final class TestGenomicsDBSparkHDFS {
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,6 @@
       <version>${protobuf.version}</version>
     </dependency>
     <dependency>
-      <!--Required to convert protocol buffer to JSON string conversion
-         using for JsonFormat.printToString-->
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
       <version>${protobuf.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,11 @@
     <spark.exclude.files>**/org/genomicsdb/spark/v2/**.java</spark.exclude.files>
     <htsjdk.version>3.0.1</htsjdk.version>
     <json.simple.version>[1.1.1,)</json.simple.version>
+    <gson.version>[2.8.9,)</gson.version>
     <log4j.version>[2.17.0,)</log4j.version>
     <!-- Sync the protobuf.version with GENOMICSDB_PROTOBUF_VERSION in CMakeLists.txt -->
     <protobuf.version>3.21.7</protobuf.version>
-    <protobuf_shade_version>org.genomicsdb.shaded.com.google.protobuf</protobuf_shade_version>
+    <google_shade_version>org.genomicsdb.shaded.com.google</google_shade_version>
     <testng.version>6.10</testng.version>
     <gnu.getopt.version>1.0.13</gnu.getopt.version>
     <surefire.plugin.version>2.22.2</surefire.plugin.version>
@@ -113,6 +114,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>${log4j.version}</version>
@@ -130,9 +136,9 @@
     <dependency>
       <!--Required to convert protocol buffer to JSON string conversion
          using for JsonFormat.printToString-->
-      <groupId>com.googlecode.protobuf-java-format</groupId>
-      <artifactId>protobuf-java-format</artifactId>
-      <version>1.4</version>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
@@ -318,8 +324,8 @@
             </filters>
             <relocations> 
               <relocation> 
-                <pattern>com.google.protobuf</pattern> 
-                <shadedPattern>${protobuf_shade_version}</shadedPattern> 
+                <pattern>com.google</pattern>
+                <shadedPattern>${google_shade_version}</shadedPattern>
               </relocation> 
             </relocations> 
             </configuration>  

--- a/src/main/cpp/include/api/genomicsdb_status.h
+++ b/src/main/cpp/include/api/genomicsdb_status.h
@@ -1,0 +1,39 @@
+/**
+ * @file genomicsdb_status.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Header file to return code for genomicsdb functionality
+ *
+ **/
+
+#pragma once
+
+/**@{*/
+/** Return codes for some GenomicsDB functions */
+#define GENOMICSDB_OK 0
+#define GENOMICSDB_ERR -1
+/**@}*/

--- a/src/main/cpp/include/api/genomicsdb_status.h
+++ b/src/main/cpp/include/api/genomicsdb_status.h
@@ -5,7 +5,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 Omics Data Automation, Inc.
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/cpp/include/api/genomicsdb_utils.h
+++ b/src/main/cpp/include/api/genomicsdb_utils.h
@@ -5,7 +5,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 Omics Data Automation, Inc.
+ * Copyright (c) 2022-2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/cpp/include/api/genomicsdb_utils.h
+++ b/src/main/cpp/include/api/genomicsdb_utils.h
@@ -40,12 +40,7 @@
 #endif
 
 #include <string>
-
-/**@{*/
-/** Return code. */
-#define GENOMICSDB_OK 0
-#define GENOMICSDB_ERR -1
-/**@}*/
+#include "genomicsdb_status.h"
 
 namespace genomicsdb {
 

--- a/src/main/cpp/include/config/genomicsdb_config_base.h
+++ b/src/main/cpp/include/config/genomicsdb_config_base.h
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/cpp/include/loader/tiledb_loader_file_base.h
+++ b/src/main/cpp/include/loader/tiledb_loader_file_base.h
@@ -147,7 +147,7 @@ class BufferReaderBase : public virtual GenomicsDBImportReaderBase {
     if (src == 0)
       return 0u;
     if (m_num_valid_bytes_in_buffer+num_bytes > m_buffer.size()) {
-      logger.debug("Buffer resized from {} bytes to {}", m_buffer.size(), m_num_valid_bytes_in_buffer+num_bytes);
+      logger.debug("Buffer(segment_size) resized from {} bytes to {}", m_buffer.size(), m_num_valid_bytes_in_buffer+num_bytes);
       m_buffer.resize(m_num_valid_bytes_in_buffer+num_bytes);
     }
     return append_all_data(src, num_bytes);

--- a/src/main/cpp/include/loader/tiledb_loader_file_base.h
+++ b/src/main/cpp/include/loader/tiledb_loader_file_base.h
@@ -147,7 +147,7 @@ class BufferReaderBase : public virtual GenomicsDBImportReaderBase {
     if (src == 0)
       return 0u;
     if (m_num_valid_bytes_in_buffer+num_bytes > m_buffer.size()) {
-      logger.debug("Buffer(segment_size) resized from {} bytes to {}", m_buffer.size(), m_num_valid_bytes_in_buffer+num_bytes);
+      logger.debug("Buffer resized from {} bytes to {}", m_buffer.size(), m_num_valid_bytes_in_buffer+num_bytes);
       m_buffer.resize(m_num_valid_bytes_in_buffer+num_bytes);
     }
     return append_all_data(src, num_bytes);

--- a/src/main/cpp/src/config/genomicsdb_config_base.cc
+++ b/src/main/cpp/src/config/genomicsdb_config_base.cc
@@ -164,9 +164,9 @@ void GenomicsDBConfigBase::set_query_column_ranges(const std::vector<ColumnRange
 GenomicsDBImportConfig::GenomicsDBImportConfig()
   : GenomicsDBConfigBase() {
   m_standalone_converter_process = false;
-  m_treat_deletions_as_intervals = false;
+  m_treat_deletions_as_intervals = true;
   m_produce_combined_vcf = false;
-  m_produce_tiledb_array = false;
+  m_produce_tiledb_array = true;
   m_compress_tiledb_array = true;
   m_disable_synced_writes = false;
   m_delete_and_create_tiledb_array = false;

--- a/src/main/cpp/src/config/json_config.cc
+++ b/src/main/cpp/src/config/json_config.cc
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2018 Intel Corporation
- * Copyright (c) 2021 Omics Data Automation Inc.
+ * Copyright (c) 2021, 2023 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/cpp/src/config/pb_config.cc
+++ b/src/main/cpp/src/config/pb_config.cc
@@ -1,6 +1,6 @@
 /**
  * The MIT License (MIT)
- * Copyright (c) 2019 Omics Data Automation, Inc
+ * Copyright (c) 2019, 2023 Omics Data Automation, Inc
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/cpp/src/config/pb_config.cc
+++ b/src/main/cpp/src/config/pb_config.cc
@@ -149,6 +149,9 @@ void GenomicsDBImportConfig::read_from_PB(const genomicsdb_pb::ImportConfigurati
     m_sorted_column_partitions[partition_idx].first = m_column_ranges[partition_idx][0].first;
     m_sorted_column_partitions[partition_idx].second = m_column_ranges[partition_idx][0].second;
     begin_to_idx[m_column_ranges[partition_idx][0].first] = partition_idx;
+
+    if (partition.has_vcf_output_filename() && partition_idx == rank) m_vcf_output_filename = partition.vcf_output_filename();
+
     partition_idx++;
   }
 
@@ -186,7 +189,7 @@ void GenomicsDBImportConfig::read_from_PB(const genomicsdb_pb::ImportConfigurati
   // vcf generate options
   if (import_config->has_produce_combined_vcf()) {
     m_produce_combined_vcf = import_config->produce_combined_vcf();
-    m_vcf_output_filename = "-"; // stdout, TODO: hardcoded for now, protobuf has it as part of partition
+    if (m_vcf_output_filename.empty()) m_vcf_output_filename="-";
     if (import_config->has_reference_genome()) {
       m_reference_genome = import_config->reference_genome();
     } else {

--- a/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
+++ b/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
- * Copyright (c) 2018-2022 Omics Data Automation, Inc.
+ * Copyright (c) 2018-2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
+++ b/src/main/cpp/src/genomicsdb/variant_storage_manager.cc
@@ -544,8 +544,11 @@ int VariantStorageManager::open_array(const std::string& array_name, const VidMa
   auto mode_int = (*mode_iter).second;
 
   std::string array_path = SLASHIFY(m_workspace) + array_name;
-  if (mode_int == TILEDB_ARRAY_READ && !is_array(m_tiledb_ctx, array_path)) {
-    logger.error("Array {} in workspace {} does not seem to exist{}", array_name,  m_workspace, PRINT_TILEDB_ERRMSG);
+  if (!is_array(m_tiledb_ctx, array_path)) {
+    if (mode_int == TILEDB_ARRAY_READ) {
+      logger.error("Array {} in workspace {} does not seem to exist{}",
+                   array_name,  m_workspace, PRINT_TILEDB_ERRMSG);
+    }
     return -1;
   }
 

--- a/src/main/cpp/src/loader/tiledb_loader_file_base.cc
+++ b/src/main/cpp/src/loader/tiledb_loader_file_base.cc
@@ -419,9 +419,10 @@ void File2TileDBBinaryBase::read_next_batch(std::vector<uint8_t>& buffer,
         break;
       }
       has_data = seek_and_fetch_position(partition_info, is_read_buffer_exhausted, false, true);  //no need to re-seek, use next_line() directly, advance file pointer
-    } else
-      VERIFY_OR_THROW(read_one_line_fully && "Buffer did not have space to hold a line fully - increase buffer size")
+    } else {
+      VERIFY_OR_THROW(read_one_line_fully && "Buffer(size_per_column_partition) did not have space to hold a line fully - increase buffer size");
     }
+  }
   //put Tiledb NULL for row_idx as end-of-batch marker
   for (auto i=0ull; i<static_cast<size_t>(partition_file_batch.get_num_orders()); ++i) {
 #ifdef PRODUCE_BINARY_CELLS

--- a/src/main/cpp/src/loader/tiledb_loader_file_base.cc
+++ b/src/main/cpp/src/loader/tiledb_loader_file_base.cc
@@ -420,7 +420,7 @@ void File2TileDBBinaryBase::read_next_batch(std::vector<uint8_t>& buffer,
       }
       has_data = seek_and_fetch_position(partition_info, is_read_buffer_exhausted, false, true);  //no need to re-seek, use next_line() directly, advance file pointer
     } else {
-      VERIFY_OR_THROW(read_one_line_fully && "Buffer(size_per_column_partition) did not have space to hold a line fully - increase buffer size");
+      VERIFY_OR_THROW(read_one_line_fully && "Buffer did not have space to hold a line fully - increase buffer size");
     }
   }
   //put Tiledb NULL for row_idx as end-of-batch marker

--- a/src/main/cpp/src/utils/vid_mapper_pb.cc
+++ b/src/main/cpp/src/utils/vid_mapper_pb.cc
@@ -49,7 +49,12 @@ int VidMapper::parse_callset_protobuf(
     std::string callset_name = it->sample_name();
     int64_t row_idx = sample_info.row_idx();
     int64_t idx_in_file = sample_info.idx_in_file();
-    std::string stream_name = sample_info.has_stream_name() ? sample_info.stream_name() : "";
+    std::string filename;
+    if (sample_info.has_filename()) {
+      filename = sample_info.filename();
+    } else {
+      filename = sample_info.has_stream_name() ? sample_info.stream_name() : "";
+    }
 
     if (m_callset_name_to_row_idx.find(callset_name) !=
         m_callset_name_to_row_idx.end()) {
@@ -66,8 +71,7 @@ int VidMapper::parse_callset_protobuf(
     }
 
     m_max_callset_row_idx = std::max(m_max_callset_row_idx, row_idx);
-
-    auto file_idx = get_or_append_global_file_idx(stream_name);
+    auto file_idx = get_or_append_global_file_idx(filename);
     if (static_cast<size_t>(row_idx) >= m_row_idx_to_info.size())
       m_row_idx_to_info.resize(static_cast<size_t>(row_idx)+1u);
     const auto& curr_row_info = m_row_idx_to_info[row_idx];
@@ -81,10 +85,10 @@ int VidMapper::parse_callset_protobuf(
         throw ProtoBufBasedVidMapperException(
           std::string("Callset/sample ")
           + callset_name
-          + " has multiple stream names: "
+          + " has multiple file/stream names: "
           + m_file_idx_to_info[curr_row_info.m_file_idx].m_name
           + ", "
-          + stream_name);
+          + filename);
       if (curr_row_info.m_idx_in_file != idx_in_file)
         throw ProtoBufBasedVidMapperException(
           std::string("Conflicting values of \"idx_in_file\" ")
@@ -103,7 +107,7 @@ int VidMapper::parse_callset_protobuf(
 	    row_idx,
 	    other_row_idx);
 	if (!added_successfully)
-	  throw ProtoBufBasedVidMapperException(std::string("Attempting to import a sample from file/stream ")+stream_name
+	  throw ProtoBufBasedVidMapperException(std::string("Attempting to import a sample from file/stream ")+filename
 	      +" multiple times under aliases '"+m_row_idx_to_info[other_row_idx].m_name
 	      +"' and '"+callset_name+"' with row indexes "+std::to_string(other_row_idx)
 	      +" and "+std::to_string(row_idx)+" respectively");

--- a/src/main/cpp/src/utils/vid_mapper_pb.cc
+++ b/src/main/cpp/src/utils/vid_mapper_pb.cc
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/java/org/genomicsdb/importer/GenomicsDBImporter.java
+++ b/src/main/java/org/genomicsdb/importer/GenomicsDBImporter.java
@@ -22,7 +22,6 @@
 
 package org.genomicsdb.importer;
 
-import com.googlecode.protobuf.format.JsonFormat;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -180,10 +179,8 @@ public class GenomicsDBImporter extends GenomicsDBImporterJni implements JsonFil
      *
      * @param config Parallel import configuration
      * @throws FileNotFoundException when files could not be read/written
-     * @throws JsonFormat.ParseException when existing callset jsons are invalid. incremental case
      */
-    public GenomicsDBImporter(final ImportConfig config) throws FileNotFoundException,
-            JsonFormat.ParseException, GenomicsDBException {
+    public GenomicsDBImporter(final ImportConfig config) throws FileNotFoundException, GenomicsDBException {
         this.config = config;
         this.config.setImportConfiguration(addExplicitValuesToImportConfiguration(config));
         long lbRowIdx = this.config.getImportConfiguration().hasLbCallsetRowIdx()

--- a/src/main/java/org/genomicsdb/importer/GenomicsDBImporter.java
+++ b/src/main/java/org/genomicsdb/importer/GenomicsDBImporter.java
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/java/org/genomicsdb/importer/extensions/CallSetMapExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/CallSetMapExtensions.java
@@ -1,6 +1,29 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2023 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+
 package org.genomicsdb.importer.extensions;
 
-import com.google.gson.stream.JsonReader;
 import com.google.protobuf.util.JsonFormat;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -9,11 +32,8 @@ import org.genomicsdb.model.GenomicsDBCallsetsMapProto;
 import org.genomicsdb.GenomicsDBUtils;
 import org.genomicsdb.exception.GenomicsDBException;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.StringReader;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public interface CallSetMapExtensions {

--- a/src/main/java/org/genomicsdb/importer/extensions/CallSetMapExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/CallSetMapExtensions.java
@@ -1,6 +1,6 @@
 /*
  * The MIT License (MIT)
- * Copyright (c) 2023 Omics Data Automation, Inc.
+ * Copyright (c) 2018-2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/java/org/genomicsdb/importer/extensions/JsonFileExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/JsonFileExtensions.java
@@ -1,6 +1,6 @@
 /*
  * The MIT License (MIT)
- * Copyright (c) 2023 Omics Data Automation, Inc.
+ * Copyright (c) 2018-2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/java/org/genomicsdb/importer/extensions/JsonFileExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/JsonFileExtensions.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2023 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package org.genomicsdb.importer.extensions;
 
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -52,7 +74,7 @@ public interface JsonFileExtensions {
      * It needs to be called explicitly if the user wants these objects
      * to be written. Called explicitly from GATK-4 GenomicsDBImport tool
      *
-     * @param outputCallsetMapJSONFilePath Full path ofcat  file to be written
+     * @param outputCallsetMapJSONFilePath Full path of file to be written
      * @param callsetMappingPB             Protobuf callset map object
      */
     default void writeCallsetMapJSONFile(final String outputCallsetMapJSONFilePath,

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -27,21 +27,18 @@ import htsjdk.tribble.*;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.vcf.VCFContigHeaderLine;
 import htsjdk.variant.vcf.VCFHeader;
-
-import org.genomicsdb.model.Coordinates;
-import org.genomicsdb.model.GenomicsDBVidMapProto;
-import org.genomicsdb.model.GenomicsDBExportConfiguration;
 import org.genomicsdb.importer.extensions.JsonFileExtensions;
+import org.genomicsdb.model.Coordinates;
+import org.genomicsdb.model.GenomicsDBExportConfiguration;
+import org.genomicsdb.model.GenomicsDBVidMapProto;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 import static org.genomicsdb.Constants.CHROMOSOME_FOLDER_DELIMITER_SYMBOL_REGEX;
-import static org.genomicsdb.GenomicsDBUtils.listGenomicsDBArrays;
 import static org.genomicsdb.GenomicsDBUtils.getArrayColumnBounds;
-import static com.googlecode.protobuf.format.JsonFormat.ParseException;
+import static org.genomicsdb.GenomicsDBUtils.listGenomicsDBArrays;
 
 /**
  * A reader for GenomicsDB that implements {@link htsjdk.tribble.FeatureReader}
@@ -169,22 +166,17 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
                     && contigInterval.getEnd() >= Integer.parseInt(ref[1]));
         }
         else {
-            try {
-                GenomicsDBVidMapProto.VidMappingPB vidPB = this.exportConfiguration.hasVidMapping() ?
-                        this.exportConfiguration.getVidMapping() :
-                        generateVidMapFromFile(this.exportConfiguration.getVidMappingFile());
-                long[] bounds = getArrayColumnBounds(workspace, array);
-                // here we only check if contig starts within column bounds
-                // this works because currently the contig coalescing respects contig boundaries
-                // that is, we are guaranteed that entire contigs reside in the same array
-                // if that changes we need to get smarter here
-                return checkVidIfContigStartsWithinColumnBounds(vidPB, bounds, contigInterval);
-            } catch (ParseException e) {
-                throw new RuntimeException("Error parsing vid from file");
-            }
+            GenomicsDBVidMapProto.VidMappingPB vidPB = this.exportConfiguration.hasVidMapping() ?
+                    this.exportConfiguration.getVidMapping() :
+                    generateVidMapFromFile(this.exportConfiguration.getVidMappingFile());
+            long[] bounds = getArrayColumnBounds(workspace, array);
+            // here we only check if contig starts within column bounds
+            // this works because currently the contig coalescing respects contig boundaries
+            // that is, we are guaranteed that entire contigs reside in the same array
+            // if that changes we need to get smarter here
+            return checkVidIfContigStartsWithinColumnBounds(vidPB, bounds, contigInterval);
         }
     }
-
 
     private void generateHeadersForQuery(final String randomExistingArrayName) throws IOException {
         GenomicsDBExportConfiguration.ExportConfiguration.Builder fullExportConfigurationBuilder =

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  * Copyright (c) 2016-2018 Intel Corporation
- * Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * Copyright (c) 2018-2019, 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBSchemaFactory.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBSchemaFactory.java
@@ -1,6 +1,6 @@
 /*
  * The MIT License (MIT)
- * Copyright (c) 2020 Omics Data Automation
+ * Copyright (c) 2020, 2023 Omics Data Automation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBSchemaFactory.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBSchemaFactory.java
@@ -91,7 +91,7 @@ public class GenomicsDBSchemaFactory implements JsonFileExtensions {
       if (config.hasProtoLoader()) {
         GenomicsDBImportConfiguration.ImportConfiguration.Builder importConfigurationBuilder = 
                GenomicsDBImportConfiguration.ImportConfiguration.newBuilder();
-        GenomicsDBImportConfiguration.ImportConfiguration importPB = 
+        GenomicsDBImportConfiguration.ImportConfiguration importPB =
             (GenomicsDBImportConfiguration.ImportConfiguration)JsonFileExtensions.getProtobufFromBase64EncodedString(
                 importConfigurationBuilder, 
                 config.getLoaderPB());
@@ -106,7 +106,7 @@ public class GenomicsDBSchemaFactory implements JsonFileExtensions {
       else {
         this.vidMap = buildVidSchemaMap(config.getLoaderJsonFile());
       }
-    } catch(com.googlecode.protobuf.format.JsonFormat.ParseException | InvalidProtocolBufferException e ) {
+    } catch(InvalidProtocolBufferException e ) {
       throw new GenomicsDBException("Error parsing protobuf:", e);
     }
   }

--- a/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
+++ b/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
@@ -1,3 +1,25 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2020, 2023 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package org.genomicsdb.spark.api;
 
 import com.google.protobuf.util.JsonFormat;

--- a/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
+++ b/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
@@ -1,5 +1,6 @@
 package org.genomicsdb.spark.api;
 
+import com.google.protobuf.util.JsonFormat;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
@@ -16,8 +17,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
-
-import com.googlecode.protobuf.format.JsonFormat;
 
 /**
  * Example Invocation
@@ -56,7 +55,7 @@ public class GenomicsDBSparkBindings {
     if (isPB) {
       String queryPBString = FileUtils.readFileToString(new File(queryJsonFile));
       final GenomicsDBExportConfiguration.ExportConfiguration.Builder builder = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
-      new JsonFormat().merge(new ByteArrayInputStream(queryPBString.getBytes()), builder);
+      JsonFormat.parser().merge(queryPBString, builder);
       queryPBString = Base64.getEncoder().encodeToString(builder.build().toByteArray());
       hadoopConf.set(GenomicsDBConfiguration.QUERYPB, queryPBString);
     } else {

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2020-2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -98,10 +98,10 @@ message ExportConfiguration {
   optional bool sites_only_query = 23;
   optional bool produce_GT_with_min_PL_value_for_spanning_deletions = 24;
   optional bool scan_full = 25;
-  optional uint32 segment_size = 26;
+  optional uint32 segment_size = 26 [default = 10485760];
   optional uint32 combined_vcf_records_buffer_size_limit = 27;
-  optional bool enable_shared_posixfs_optimizations = 28;
-  optional bool bypass_intersecting_intervals_phase = 29;
+  optional bool enable_shared_posixfs_optimizations = 28 [default = false];
+  optional bool bypass_intersecting_intervals_phase = 29 [default = false];
   optional SparkConfig spark_config = 30;
   repeated AnnotationSource annotation_source = 31;
   optional uint32 annotation_buffer_size = 32 [default = 10240];

--- a/src/resources/genomicsdb_import_config.proto
+++ b/src/resources/genomicsdb_import_config.proto
@@ -81,11 +81,16 @@ message ImportConfiguration {
   optional bool consolidate_tiledb_array_after_load = 20 [default = false];
   optional bool disable_synced_writes = 21 [default = true];
   optional bool ignore_cells_not_in_partition = 22;
+
   optional int64 lb_callset_row_idx = 23 [ default = 0 ];
   optional int64 ub_callset_row_idx = 24;
+
   optional bool enable_shared_posixfs_optimizations = 27 [ default = false ];
   optional bool disable_delta_encode_for_offsets = 28 [ default = false ];
   optional bool disable_delta_encode_for_coords = 29 [ default = false ];
   optional bool enable_bit_shuffle_gt = 30 [ default = false ];
-  optional bool enable_lz4_compression_gt = 31 [ default = false ];    
+  optional bool enable_lz4_compression_gt = 31 [ default = false ];
+  
+  optional string reference_genome = 32;
+  optional string vcf_header_filename = 33;
 }

--- a/src/resources/genomicsdb_import_config.proto
+++ b/src/resources/genomicsdb_import_config.proto
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 
@@ -49,6 +50,7 @@ message Partition {
     bool generate_array_name_from_partition_bounds = 4;
   }
   optional string vcf_output_filename = 5;
+  optional string vcf_header_filename = 7;
   optional GenomicsDBColumn end = 6;
 }
 

--- a/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2018-2021, 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -22,7 +22,6 @@
 
 package org.genomicsdb.importer;
 
-import com.googlecode.protobuf.format.JsonFormat;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.variant.bcf2.BCF2Codec;
@@ -98,7 +97,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     }
 
     @Test(expectedExceptions = GenomicsDBException.class)
-    public void testWriteVidMapJSONToNonexistentFolders() throws FileNotFoundException, JsonFormat.ParseException, InterruptedException {
+    public void testWriteVidMapJSONToNonexistentFolders() throws FileNotFoundException, InterruptedException {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
                 GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
         Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
@@ -113,7 +112,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     }
 
     @Test(expectedExceptions = GenomicsDBException.class)
-    public void testWriteCallsetJSONToNonexistentFolders() throws FileNotFoundException, JsonFormat.ParseException, InterruptedException {
+    public void testWriteCallsetJSONToNonexistentFolders() throws FileNotFoundException, InterruptedException {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
                 GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
         Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
@@ -127,7 +126,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     }
 
     @Test(expectedExceptions = GenomicsDBException.class)
-    public void testVCFHeaderToNonexistentFolders() throws FileNotFoundException, JsonFormat.ParseException, InterruptedException {
+    public void testVCFHeaderToNonexistentFolders() throws FileNotFoundException, InterruptedException {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
                 GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
         Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
@@ -180,7 +179,13 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
             for (Object cObject : callsetArray) {
                 JSONObject sampleObject = (JSONObject) cObject;
                 String sampleName_B = (String) sampleObject.get("sample_name");
-                Long tiledbRowIndex_B = (Long) sampleObject.get("row_idx");
+                Long tiledbRowIndex_B;
+                try {
+                    tiledbRowIndex_B = (Long) sampleObject.get("row_idx");
+                } catch (java.lang.ClassCastException e) {
+                    // Parse 64-bit integers stored as strings in protobuf-generated JSONs
+                    tiledbRowIndex_B = Long.parseLong((String)sampleObject.get("row_idx"));
+                }
                 String stream_name_B = (String) sampleObject.get("stream_name");
 
                 String sampleName_A = callsetMappingPB_A.getCallsets(index).getSampleName();
@@ -625,8 +630,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     }
 
     private GenomicsDBImporter getGenomicsDBImporterForMultipleImport(String incrementalImport,
-            String inputVCF, boolean noVid) throws FileNotFoundException,
-            com.googlecode.protobuf.format.JsonFormat.ParseException {
+            String inputVCF, boolean noVid) throws FileNotFoundException {
         String vidArgument = "--vidmap-output " + tempVidJsonFile.getAbsolutePath() + " ";
         if (noVid) {
             vidArgument = "";

--- a/tools/src/vcf2genomicsdb.cc
+++ b/tools/src/vcf2genomicsdb.cc
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
       GenomicsDBImportConfig loader_config;
       loader_config.read_from_file(loader_json_config_file, my_world_mpi_rank);
       if (loader_config.is_partitioned_by_row()) {
-        std::cerr << "Splitting is available for column partitioning, row partitioning should be trivial if samples are scattered across files. See wiki page https://github.com/Intel-HLS/GenomicsDB/wiki/Dealing-with-multiple-GenomicsDB-partitions for more information\n";
+        std::cerr << "Splitting is available for column partitioning, row partitioning should be trivial if samples are scattered across files. See wiki page https://github.com/GenomicsDB/GenomicsDB/wiki/Dealing-with-multiple-GenomicsDB-partitions for more information\n";
         return 0;
       }
       VidMapper id_mapper = loader_config.get_vid_mapper(); //copy

--- a/tools/src/vcf2genomicsdb.cc
+++ b/tools/src/vcf2genomicsdb.cc
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
- * Copyright (c) 2021-2022 Omics Data Automation, Inc.
+ * Copyright (c) 2021-2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Protobuf cleanup to allow for bindings from other languages to pass import/export via prototype buffers rather than plain json files. As part of this change -
1. Move to using `com.google.protobuf.util.JsonFormat` that is version matched with  `com.google.protobuf.java` rather than `com.googlecode.format.JsonFormat`.
2. Moved some defaults to the `GenomicsDBImport` constructor to allow reads from JSON and protobuf be interchangeable.
3. Extend import protobuf definitions to support `produce_combined_vcf`.
4. Removed `USE_PROTOBUF_V_3_0_0_BETA_1` ifdefs as we no longer use or support those versions.
5. Since reading to and from protobuf bypasses the [int64 issue,](https://github.com/protocolbuffers/protobuf/issues/2679)  import/export config files are parsed as protobuf's first and only on failure they are parsed as json files using `rapidjson`. Basically, non-protobuf json files support is deprecated and will be removed in the future.

What is left to be done is to pass protobuf binary strings from the Java layer to C++ instead of persisting them as json files first. The `genomicsdb` api layer on the other hand allows for protobuf binary strings when instantiating `GenomicsDB` for queries.