### PR TITLE
Allow for resize/retry if size_per_column_partition specified to vcf2genomicsdb is too small

### DIFF
--- a/src/main/cpp/include/config/genomicsdb_config_base.h
+++ b/src/main/cpp/include/config/genomicsdb_config_base.h
@@ -274,6 +274,13 @@ class GenomicsDBImportConfig : public GenomicsDBConfigBase {
   inline bool is_partitioned_by_column() const {
     return !m_row_based_partitioning;
   }
+  inline int64_t get_size_per_column_partition() const {
+    return m_per_partition_size;
+  }
+  inline void set_size_per_column_partition(int64_t size_per_column_partition) {
+    m_per_partition_size = size_per_column_partition;
+  }
+
   // protobuf-specific
   ContigInfo get_contig_info(const ContigPosition* contig_position);
   ColumnRange extract_contig_interval(const ContigPosition* start, const ContigPosition* end);

--- a/src/main/cpp/include/loader/tiledb_loader.h
+++ b/src/main/cpp/include/loader/tiledb_loader.h
@@ -48,7 +48,6 @@ class VCF2TileDBException : public std::exception {
 class ThreadException {
 public:
   ThreadException() {}
-#ifndef DISABLE_OPENMP
   void rethrow() {
     if (m_exception_ptr) std::rethrow_exception(m_exception_ptr);
   }
@@ -59,15 +58,8 @@ public:
   std::exception_ptr& get() {
     return m_exception_ptr;
   }
+ private:
   std::exception_ptr m_exception_ptr = nullptr;
-#else
-  // Just stubs for the non OPENMP flow
-  void rethrow() {}
-  void capture() {}
-  std::exception_ptr& get() {
-    return nullptr;
-  }
-#endif
 };
 
 //Used to exchange info between loader and converter

--- a/src/main/cpp/include/loader/tiledb_loader.h
+++ b/src/main/cpp/include/loader/tiledb_loader.h
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -366,7 +367,6 @@ class VCF2TileDBLoader : public VCF2TileDBLoaderConverterBase {
                                        const bool enable_shared_posixfs_optimzations=false);
  private:
   void common_constructor_initialization(
-    const std::string& config_filename,
     const std::vector<BufferStreamInfo>& buffer_stream_info_vec,
     const std::string& buffer_stream_callset_mapping_json_string,
     const int idx);

--- a/src/main/cpp/include/loader/tiledb_loader.h
+++ b/src/main/cpp/include/loader/tiledb_loader.h
@@ -274,6 +274,9 @@ class VCF2TileDBLoader : public VCF2TileDBLoaderConverterBase {
   VCF2TileDBLoader(
     const std::string& config_filename,
     const int idx);
+  VCF2TileDBLoader (
+    const GenomicsDBImportConfig& config,
+    int idx);
   VCF2TileDBLoader(
     const std::string& config_filename,
     const std::vector<BufferStreamInfo>& buffer_stream_info_vec,

--- a/src/main/cpp/src/config/pb_config.cc
+++ b/src/main/cpp/src/config/pb_config.cc
@@ -376,8 +376,9 @@ void GenomicsDBConfigBase::read_from_PB(const genomicsdb_pb::ExportConfiguration
       }
     }
   }
-  if(export_config->has_reference_genome())
+  if(export_config->has_reference_genome()) {
     m_reference_genome = export_config->reference_genome();
+  }
   //Limit on max #alt alleles so that PL fields get re-computed
   m_max_diploid_alt_alleles_that_can_be_genotyped = export_config->has_max_diploid_alt_alleles_that_can_be_genotyped()
     ? export_config->max_diploid_alt_alleles_that_can_be_genotyped() : MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED;

--- a/src/main/cpp/src/config/pb_config.cc
+++ b/src/main/cpp/src/config/pb_config.cc
@@ -118,7 +118,7 @@ void GenomicsDBImportConfig::read_from_PB(const genomicsdb_pb::ImportConfigurati
 
   // Store the begins for every partition for lookup later
   std::unordered_map<int64_t, unsigned> begin_to_idx;
-  auto partition_idx = 0u;
+  auto partition_idx = 0;
   for (auto partition: partitions) {
     if (partition.has_workspace()) {
       if (m_workspaces.size() == 0) {
@@ -165,7 +165,7 @@ void GenomicsDBImportConfig::read_from_PB(const genomicsdb_pb::ImportConfigurati
   }
 
   if ((m_single_workspace_path && m_workspaces.size() != 1) ||
-      (!m_single_workspace_path && m_workspaces.size() != partitions.size())) {
+      (!m_single_workspace_path && (int64_t)m_workspaces.size() != partitions.size())) {
     logger.fatal(GenomicsDBConfigException("List of workspaces should either be one for a single workspace or have workspaces specified for every partition"));
   }
 

--- a/src/main/cpp/src/genomicsdb/query_variants.cc
+++ b/src/main/cpp/src/genomicsdb/query_variants.cc
@@ -976,8 +976,10 @@ void VariantQueryProcessor::gt_fill_row(
   assert(query_config.get_first_normal_field_query_idx() >= 1u);
   assert(query_config.get_first_normal_field_query_idx() != UNDEFINED_ATTRIBUTE_IDX_VALUE);
   //Variables to store special fields
+#if VERBOSE>1
   //Num alternate alleles
   unsigned num_ALT_alleles = 0u;
+#endif
   //Iterate over attributes
   auto attr_iter = cell.begin();
   ++attr_iter;  //skip the END field
@@ -991,9 +993,12 @@ void VariantQueryProcessor::gt_fill_row(
   }
   //Initialize ALT field, if needed
   const auto* ALT_field_ptr = get_known_field_if_queried<VariantFieldALTData, true>(curr_call, query_config, GVCF_ALT_IDX);
+#if VERBOSE>1
   if (ALT_field_ptr && ALT_field_ptr->is_valid()) {
     num_ALT_alleles = ALT_field_ptr->get().size();   //ALT field data is vector<string>
   }
+  logger.info("[query_variants:gt_fill_row] row={} col={} num_ALT_alleles={}", row, column, num_ALT_alleles);
+#endif
   //Go over all normal query fields and fetch data
   for (auto i=query_config.get_first_normal_field_query_idx(); i<query_config.get_num_queried_attributes(); ++i, ++attr_iter) {
     assert(attr_iter != cell.end());

--- a/src/main/cpp/src/loader/tiledb_loader.cc
+++ b/src/main/cpp/src/loader/tiledb_loader.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -448,7 +449,6 @@ VCF2TileDBLoader::VCF2TileDBLoader(
       idx) {
   std::vector<BufferStreamInfo> empty_vec;
   common_constructor_initialization(
-    config_filename,
     empty_vec,
     "",
     idx);
@@ -463,14 +463,12 @@ VCF2TileDBLoader::VCF2TileDBLoader(
       config_filename,
       idx) {
   common_constructor_initialization(
-    config_filename,
     buffer_stream_info_vec,
     buffer_stream_callset_mapping_json_string,
     idx);
 }
 
 void VCF2TileDBLoader::common_constructor_initialization(
-  const std::string& config_filename,
   const std::vector<BufferStreamInfo>& buffer_stream_info_vec,
   const std::string& buffer_stream_callset_mapping_json_string,
   const int idx) {

--- a/src/main/cpp/src/loader/tiledb_loader.cc
+++ b/src/main/cpp/src/loader/tiledb_loader.cc
@@ -454,6 +454,19 @@ VCF2TileDBLoader::VCF2TileDBLoader(
     idx);
 }
 
+VCF2TileDBLoader::VCF2TileDBLoader (
+    const GenomicsDBImportConfig& config,
+    int idx)
+  : VCF2TileDBLoaderConverterBase(
+      config,
+      idx) {
+  std::vector<BufferStreamInfo> empty_vec;
+  common_constructor_initialization(
+    empty_vec,
+    "",
+    idx);
+}
+
 VCF2TileDBLoader::VCF2TileDBLoader(
   const std::string& config_filename,
   const std::vector<BufferStreamInfo>& buffer_stream_info_vec,

--- a/src/main/cpp/src/loader/tiledb_loader.cc
+++ b/src/main/cpp/src/loader/tiledb_loader.cc
@@ -319,7 +319,7 @@ void VCF2TileDBConverter::read_next_batch(const unsigned exchange_idx) {
   assert(exchange_idx < m_exchanges.size());
   auto& curr_exchange = *(m_exchanges[exchange_idx]);
   for (auto partition_idx=0u; partition_idx<m_partition_batch.size(); ++partition_idx) {
-    if (!m_thread_exception.m_exception_ptr && curr_exchange.is_partition_requested_by_loader(partition_idx)) {
+    if (!m_thread_exception.get() && curr_exchange.is_partition_requested_by_loader(partition_idx)) {
       activate_next_batch(exchange_idx, partition_idx);
       //Find callsets which still have new data in this partition
       int64_t idx_offset = curr_exchange.get_idx_offset_for_partition(partition_idx);

--- a/src/main/cpp/src/loader/tiledb_loader_file_base.cc
+++ b/src/main/cpp/src/loader/tiledb_loader_file_base.cc
@@ -211,6 +211,8 @@ bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, in
 template
 bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, int64_t& buffer_offset,
     const int64_t buffer_offset_limit, const double val, bool print_sep);
+//This is an explict instantiation after an explicit specialization for std::string and char *, clang
+//puts out a warning, commenting out for now
 //template
 //bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, int64_t& buffer_offset,
 //    const int64_t buffer_offset_limit, const std::string& val, bool print_sep);

--- a/src/main/cpp/src/loader/tiledb_loader_file_base.cc
+++ b/src/main/cpp/src/loader/tiledb_loader_file_base.cc
@@ -440,7 +440,7 @@ void File2TileDBBinaryBase::read_next_batch(std::vector<uint8_t>& buffer,
       }
       has_data = seek_and_fetch_position(partition_info, is_read_buffer_exhausted, false, true);  //no need to re-seek, use next_line() directly, advance file pointer
     } else if (!read_one_line_fully) {
-      logger.fatal(SizePerColumnPartitionTooSmallException("Buffer(size_per_column_partition) did not have space to hold a line fully - increase buffer size", buffer.size()), "Current buffer size in read_next_batch = {}", buffer.size());
+      logger.fatal(SizePerColumnPartitionTooSmallException("Buffer(size_per_column_partition) did not have space to hold a line fully - increase buffer size", buffer.size()));
     }
   }
   //put Tiledb NULL for row_idx as end-of-batch marker

--- a/src/main/cpp/src/loader/tiledb_loader_file_base.cc
+++ b/src/main/cpp/src/loader/tiledb_loader_file_base.cc
@@ -64,6 +64,7 @@ void File2TileDBBinaryColumnPartitionBase::initialize_base_class_members(const i
 
 #ifdef PRODUCE_BINARY_CELLS
 
+
 template<class FieldType>
 bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, int64_t& buffer_offset, const int64_t buffer_offset_limit, const FieldType val, bool print_sep) {
   int64_t add_size = sizeof(FieldType);
@@ -210,12 +211,12 @@ bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, in
 template
 bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, int64_t& buffer_offset,
     const int64_t buffer_offset_limit, const double val, bool print_sep);
-template
-bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, int64_t& buffer_offset,
-    const int64_t buffer_offset_limit, const char* val, bool print_sep);
-template
-bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, int64_t& buffer_offset,
-    const int64_t buffer_offset_limit, const std::string& val, bool print_sep);
+//template
+//bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, int64_t& buffer_offset,
+//    const int64_t buffer_offset_limit, const std::string& val, bool print_sep);
+//template
+//bool File2TileDBBinaryBase::tiledb_buffer_print(std::vector<uint8_t>& buffer, int64_t& buffer_offset,
+//    const int64_t buffer_offset_limit, const char* val, bool print_sep);
 template
 void File2TileDBBinaryBase::tiledb_buffer_resize_if_needed_and_print(std::vector<uint8_t>& buffer,
     int64_t& buffer_offset, const uint64_t val, bool print_sep);

--- a/src/main/cpp/src/loader/tiledb_loader_file_base.cc
+++ b/src/main/cpp/src/loader/tiledb_loader_file_base.cc
@@ -1,6 +1,26 @@
-#include "tiledb_loader_file_base.h"
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2023 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
 
-#define VERIFY_OR_THROW(X) if(!(X)) throw File2TileDBBinaryException(#X);
+#include "tiledb_loader_file_base.h"
 
 //Move constructor
 File2TileDBBinaryColumnPartitionBase::File2TileDBBinaryColumnPartitionBase(File2TileDBBinaryColumnPartitionBase&& other) {
@@ -419,8 +439,8 @@ void File2TileDBBinaryBase::read_next_batch(std::vector<uint8_t>& buffer,
         break;
       }
       has_data = seek_and_fetch_position(partition_info, is_read_buffer_exhausted, false, true);  //no need to re-seek, use next_line() directly, advance file pointer
-    } else {
-      VERIFY_OR_THROW(read_one_line_fully && "Buffer did not have space to hold a line fully - increase buffer size");
+    } else if (!read_one_line_fully) {
+      logger.fatal(SizePerColumnPartitionTooSmallException("Buffer(size_per_column_partition) did not have space to hold a line fully - increase buffer size", buffer.size()), "Current buffer size in read_next_batch = {}", buffer.size());
     }
   }
   //put Tiledb NULL for row_idx as end-of-batch marker

--- a/src/main/cpp/src/utils/vid_mapper.cc
+++ b/src/main/cpp/src/utils/vid_mapper.cc
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
- * Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ * Copyright (c) 2018-2020, 2023 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -1343,11 +1343,9 @@ void FileBasedVidMapper::parse_type_descriptor(FieldInfo& field_info, const rapi
   //So, the JSON must specify the data type used in the VCF in addition to the real type
   const char* type_descriptor_json_attribute_names[] = { "type", "vcf_type" };
   VERIFY_OR_THROW(field_info_json_dict.HasMember("type"));
-  auto has_vcf_type_attribute = false;
   for (auto i=0u; i<2u; ++i) {
     const auto curr_attribute_name = type_descriptor_json_attribute_names[i];
     if (field_info_json_dict.HasMember(curr_attribute_name)) {
-      has_vcf_type_attribute = (i == 1u);
       auto& type_json_value = field_info_json_dict[curr_attribute_name];
       if (!(type_json_value.IsString() || type_json_value.IsArray()))
         throw FileBasedVidMapperException(std::string("Attribute '")+curr_attribute_name

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -361,6 +361,8 @@ run_command "vcf2genomicsdb $WORKSPACE/loader.json" OK
 
 # Test with too small size_per_column_partition
 sed -i -e 's/"size_per_column_partition": 700/"size_per_column_partition": 70/g' $WORKSPACE/loader.json
+run_command "vcf2genomicsdb $WORKSPACE/loader.json" OK
+sed -i -e 's/"size_per_column_partition": 70/"size_per_column_partition": 0/g' $WORKSPACE/loader.json
 run_command "vcf2genomicsdb $WORKSPACE/loader.json" ERR
 
 # Test --progress switch with an interval

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -359,7 +359,12 @@ run_command "vcf2genomicsdb $WORKSPACE/loader.json" OK
 sed -i -e 's|"workspace": "'${WORKSPACE}'"|"workspace": "'${WORKSPACE}'", "vcf_header_filename": "'${WORKSPACE}'/vcfheader.vcf", "vcf_output_filename": "'${WORKSPACE}'/out"|g' $WORKSPACE/loader.json
 run_command "vcf2genomicsdb $WORKSPACE/loader.json" OK
 
+# Test with too small size_per_column_partition
+sed -i -e 's/"size_per_column_partition": 700/"size_per_column_partition": 70/g' $WORKSPACE/loader.json
+run_command "vcf2genomicsdb $WORKSPACE/loader.json" ERR
+
 # Test --progress switch with an interval
+create_template_loader_json
 run_command "vcf2genomicsdb_init -w $WORKSPACE -S $SAMPLE_DIR -o -t $TEMPLATE"
 run_command "vcf2genomicsdb --progress=2 $WORKSPACE/loader.json"
 run_command "vcf2genomicsdb_init -w $WORKSPACE -S $SAMPLE_DIR -o -t $TEMPLATE"

--- a/tools/src/vcf2genomicsdb.cc
+++ b/tools/src/vcf2genomicsdb.cc
@@ -21,7 +21,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include "genomicsdb_status.h"
+#include "common.h"
 #include "tiledb_loader.h"
 #include "vcf2binary.h"
 
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
   int my_world_mpi_rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &my_world_mpi_rank);
 
-  rc = GENOMICSDB_OK;
+  rc = OK;
   // Define long options
   static struct option long_options[] = {
     {"tmp-directory",1,0,'T'},
@@ -188,7 +188,7 @@ int main(int argc, char** argv) {
 
       if (loader_config.is_partitioned_by_row()) {
         std::cerr << "Splitting` is available for column partitioning, row partitioning should be trivial if samples are scattered across files. See wiki page https://github.com/GenomicsDB/GenomicsDB/wiki/Dealing-with-multiple-GenomicsDB-partitions for more information\n";
-        return GENOMICSDB_ERR;
+        return ERR;
       }
       VidMapper id_mapper = loader_config.get_vid_mapper(); //copy
       //Might specify more VCF files from the command line
@@ -214,14 +214,14 @@ int main(int argc, char** argv) {
             results_directory, (produce_all_partitions ? column_partitions.size() : 1u), my_world_mpi_rank);
     } else {
       //Loader object
-      rc = GENOMICSDB_ERR;
+      rc = ERR;
       int max_iterations = 10;
       int iterations = max_iterations;
       while (rc && iterations) {
         try {
           VCF2TileDBLoader loader(loader_config, my_world_mpi_rank);
           loader.read_all();
-          rc = GENOMICSDB_OK;
+          rc = OK;
           if (iterations < max_iterations) {
             g_logger.info("Successful import!");
           }

--- a/tools/src/vcf2genomicsdb.cc
+++ b/tools/src/vcf2genomicsdb.cc
@@ -187,8 +187,8 @@ int main(int argc, char** argv) {
       std::cout << "Split files" << std::endl;
 
       if (loader_config.is_partitioned_by_row()) {
-        std::cerr << "Splitting` is available for column partitioning, row partitioning should be trivial if samples are scattered across files. See wiki page https://github.com/GenomicsDB/GenomicsDB/wiki/Dealing-with-multiple-GenomicsDB-partitions for more information\n";
-        return ERR;
+        std::cerr << "Splitting is available for column partitioning, row partitioning should be trivial if samples are scattered across files. See wiki page https://github.com/GenomicsDB/GenomicsDB/wiki/Dealing-with-multiple-GenomicsDB-partitions for more information\n";
+        return 0;
       }
       VidMapper id_mapper = loader_config.get_vid_mapper(); //copy
       //Might specify more VCF files from the command line


### PR DESCRIPTION
If the `size_per_column_partition` specified via protobuf/loader.json to vcf2genomicsdb is too small, the tool was logging an error and aborting. The tiledb loader now throws a `SizePerColumnPartitionTooSmallException` when the buffer based on `size_per_column_partition` is not sufficient. It would have been ideal to resize and continue, but this buffer is split among the samples that are getting ingested and it is not easy to resize without re-architecting in a major way. For now, we are just catching the exception in `vcf2genomicsdb` and adaptively setting `size_per_column_partition` for a total of 10 tries. Each try uses a `10-index` multiplier to the existing size before aborting.

Note that `OpenMP` does not allow for exceptions to propagate as they are thrown on different threads. Have resorted to a `ThreadException` class for threads to register their exceptions if captured and then allow for the exception to be re-thrown on the main thread. 