### PR TITLE
Explicit Coverage Step for C++ sources as codecov/codecov-action@v3 not handling it well

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -155,7 +155,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install jsondiff
         source $SPARK_ENV
-        python tests/run_spark_hdfs.py $GENOMICSDB_BUILD_DIR $CMAKE_INSTALL_PREFIX local hdfs://localhost:9000/ client $GENOMICSDB_RELEASE_VERSION $GITHUB_WORKSPACE/tests Coverage
+        python tests/run_spark_hdfs.py $GENOMICSDB_BUILD_DIR $CMAKE_INSTALL_PREFIX local hdfs://localhost:9000/ client $GENOMICSDB_RELEASE_VERSION $GITHUB_WORKSPACE/tests "" Coverage
         $GITHUB_WORKSPACE/.github/scripts/test_hdfs_htslib_support.sh
 
     - name: Coverage

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -158,5 +158,15 @@ jobs:
         python tests/run_spark_hdfs.py $GENOMICSDB_BUILD_DIR $CMAKE_INSTALL_PREFIX local hdfs://localhost:9000/ client $GENOMICSDB_RELEASE_VERSION $GITHUB_WORKSPACE/tests Coverage
         $GITHUB_WORKSPACE/.github/scripts/test_hdfs_htslib_support.sh
 
+    - name: Coverage
+      shell: bash
+      working-directory: ${{env.GENOMICSDB_BUILD_DIR}}
+      run: |
+        lcov --directory . --capture --output-file coverage.info
+        lcov --remove coverage.info '/opt*' '/usr*' '*/dependencies/*' '*/src/test*' '*.pb.h' '*.pb.cc' '*/protobuf-install/*' '*/awssdk-install/*' '*/gcssdk-install/*' 'v1/*' '/Library/*' -o coverage.info
+
     - name: Upload Coverage to CodeCov
       uses: codecov/codecov-action@v3
+      with:
+        files: build/coverage.info, build/target/jacoco-reports/jacoco-ut/jacoco.xml, build/target/jacoco-reports/jacoco-ci/jacoco-ci.xml
+        verbose: true

--- a/scripts/prereqs/system/install_macos_prereqs.sh
+++ b/scripts/prereqs/system/install_macos_prereqs.sh
@@ -32,6 +32,7 @@ brew list mpich &>/dev/null || brew install mpich
 brew list ossp-uuid &>/dev/null || brew install ossp-uuid
 brew list libcsv &>/dev/null || brew install libcsv
 brew list automake &> /dev/null || brew install automake
+brew list lcov &> /dev/null || brew install lcov
 brew list openssl@1.1 &> /dev/null || brew install openssl@1.1
 brew list zstd &> /dev/null || brew install zstd
 echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $PREREQS_ENV


### PR DESCRIPTION
After pulling in PR #277, noticed that codecov had stopped covering C++ sources. I could get it working again in a convoluted way. But, given  the fragility of `codecov/codecov-action@v3`  for C++/gcov, have resorted to generating the coverage info manually using `lcov` before uploading the coverage to `CodeCov`.

@mlathara, there is a lot of [spark-related code not covered](https://app.codecov.io/gh/GenomicsDB/GenomicsDB/tree/ng_codecov_0323/src/main/java/org/genomicsdb) by the tests. Is the code being used from other downstream code? What are they?