### PR TITLE
Exclude spark from core jar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,14 @@ jobs:
 
       - name: Set version number
         run: echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
+      
+      - name: Set tag messsage
+        run: | 
+          git fetch --tags --force
+          echo "TAG_MESSAGE=$(git tag -l --sort=-taggerdate --format='%(contents)' $(git describe --tags $(git branch --show-current) ))" >> $GITHUB_ENV
+        
+      - name: Check tag messsage
+        run: echo ${TAG_MESSAGE}
 
       - name: Install Prerequisites
         shell: bash
@@ -62,10 +70,11 @@ jobs:
       dylib_artifact: libtiledbgenomicsdb.dylib.${{ github.ref_name }}
 
   test:
-    needs: [release-jar]
+    needs: [build-and-push-mac-dylib, release-jar]
     uses: ./.github/workflows/release_test.yml
     with:
       release_artifact: release.${{ github.ref_name }}
+      tag_message: ${{ needs.build-and-push-mac-dylib.outputs.tag_message }}
 
   publish:
     needs: [test]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ env:
 jobs:
   build-and-push-mac-dylib:
     runs-on: macos-11
+    outputs: 
+      tag_message: ${{env.TAG_MESSAGE}}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
           git fetch --tags --force
           echo "TAG_MESSAGE=$(git tag -l --sort=-taggerdate --format='%(contents)' $(git describe --tags $(git branch --show-current) ))" >> $GITHUB_ENV
         
-      - name: Check tag messsage
-        run: echo ${TAG_MESSAGE}
 
       - name: Install Prerequisites
         shell: bash

--- a/.github/workflows/release_jar.yml
+++ b/.github/workflows/release_jar.yml
@@ -46,7 +46,7 @@ jobs:
           docker create -it --name genomicsdb ghcr.io/genomicsdb/genomicsdb:release bash
           docker cp genomicsdb:/build/GenomicsDB/build/src/main/libtiledbgenomicsdb.so .
           docker cp genomicsdb:/build/GenomicsDB/build/target/genomicsdb-${VERSION_NUMBER}.jar .
-          docker cp genomicsdb:/build/GenomicsDB/build/target/genomicsdb-${VERSION_NUMBER}-allinone.jar .
+          docker cp genomicsdb:/build/GenomicsDB/build/target/genomicsdb-${VERSION_NUMBER}-allinone-spark.jar .
           docker cp genomicsdb:/build/GenomicsDB/build/target/genomicsdb-${VERSION_NUMBER}-sources.jar .
           docker cp genomicsdb:/build/GenomicsDB/build/target/genomicsdb-${VERSION_NUMBER}-javadoc.jar .
           docker cp genomicsdb:/build/GenomicsDB/pom.xml genomicsdb-${VERSION_NUMBER}.pom

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -78,7 +78,7 @@ jobs:
               stagingRepoId=$(mvn nexus-staging:rc-list -DnexusUrl=https://oss.sonatype.org/ -DserverId=ossrh | grep orggenomicsdb|cut -f2 -d' ')
               echo $stagingRepoId
               mvn nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}.pom
-              mvn nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}.pom
+              mvn nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-spark-${VERSION_NUMBER}.pom
           fi
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -65,16 +65,17 @@ jobs:
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
             -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
             -Dtypes=jar \
+          cp genomicsdb-${VERSION_NUMBER}.pom genomicsdb-${VERSION_NUMBER}-spark.pom
           echo mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb-spark -Dversion=${VERSION_NUMBER} \
-            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}-spark.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
             -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
             -Dtypes=jar \
             -Dclassifiers=allinone-spark
           mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb-spark -Dversion=${VERSION_NUMBER} \
-            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}-spark.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
             -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
             -Dtypes=jar \
@@ -83,7 +84,8 @@ jobs:
               mvn nexus-staging:rc-list -DnexusUrl=https://oss.sonatype.org/ -DserverId=ossrh -f genomicsdb-${VERSION_NUMBER}.pom
               stagingRepoId=$(mvn nexus-staging:rc-list -DnexusUrl=https://oss.sonatype.org/ -DserverId=ossrh | grep orggenomicsdb|cut -f2 -d' ')
               echo $stagingRepoId
-              mvn nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}.pom
+              mvn -X nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}.pom
+              mvn nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}-spark.pom
           fi
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.release_artifact }}
-
+        
       - name: Deploy Maven Central
         shell: bash
         run: |
@@ -57,35 +57,28 @@ jobs:
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb -Dversion=${VERSION_NUMBER} \
             -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
-            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
-            -Dtypes=jar \
+            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar 
           mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}.jar \
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb -Dversion=${VERSION_NUMBER} \
             -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
-            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
-            -Dtypes=jar \
-          cp genomicsdb-${VERSION_NUMBER}.pom genomicsdb-${VERSION_NUMBER}-spark.pom
+            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar 
           echo mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb-spark -Dversion=${VERSION_NUMBER} \
-            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}-spark.pom -DrepositoryId=$REPO_ID \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
-            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
-            -Dtypes=jar \
-            -Dclassifiers=allinone-spark
+            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar 
           mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb-spark -Dversion=${VERSION_NUMBER} \
-            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}-spark.pom -DrepositoryId=$REPO_ID \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
-            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
-            -Dtypes=jar \
-            -Dclassifiers=allinone-spark
+            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar 
           if [[ ${VERSION_NUMBER} != *SNAPSHOT ]]; then
               mvn nexus-staging:rc-list -DnexusUrl=https://oss.sonatype.org/ -DserverId=ossrh -f genomicsdb-${VERSION_NUMBER}.pom
               stagingRepoId=$(mvn nexus-staging:rc-list -DnexusUrl=https://oss.sonatype.org/ -DserverId=ossrh | grep orggenomicsdb|cut -f2 -d' ')
               echo $stagingRepoId
-              mvn -X nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}.pom
-              mvn nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}-spark.pom
+              mvn nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}.pom
+              mvn nexus-staging:rc-close -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/ -DstagingRepositoryId=$stagingRepoId -f genomicsdb-${VERSION_NUMBER}.pom
           fi
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -58,17 +58,17 @@ jobs:
             -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
             -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
-            -Dfiles=genomicsdb-${VERSION_NUMBER}-allinone.jar \
+            -Dfiles=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
             -Dtypes=jar \
-            -Dclassifiers=allinone
+            -Dclassifiers=allinone-spark
           mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}.jar \
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb -Dversion=${VERSION_NUMBER} \
             -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
             -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
-            -Dfiles=genomicsdb-${VERSION_NUMBER}-allinone.jar \
+            -Dfiles=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
             -Dtypes=jar \
-            -Dclassifiers=allinone
+            -Dclassifiers=allinone-spark
           if [[ ${VERSION_NUMBER} != *SNAPSHOT ]]; then
               mvn nexus-staging:rc-list -DnexusUrl=https://oss.sonatype.org/ -DserverId=ossrh -f genomicsdb-${VERSION_NUMBER}.pom
               stagingRepoId=$(mvn nexus-staging:rc-list -DnexusUrl=https://oss.sonatype.org/ -DserverId=ossrh | grep orggenomicsdb|cut -f2 -d' ')

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -58,15 +58,25 @@ jobs:
             -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
             -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
-            -Dfiles=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
             -Dtypes=jar \
-            -Dclassifiers=allinone-spark
           mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}.jar \
             -DgroupId=org.genomicsdb -DartifactId=genomicsdb -Dversion=${VERSION_NUMBER} \
             -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
             -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
             -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
-            -Dfiles=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
+            -Dtypes=jar \
+          echo mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
+            -DgroupId=org.genomicsdb -DartifactId=genomicsdb-spark -Dversion=${VERSION_NUMBER} \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
+            -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
+            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
+            -Dtypes=jar \
+            -Dclassifiers=allinone-spark
+          mvn gpg:sign-and-deploy-file -Durl=$URL -Dfile=genomicsdb-${VERSION_NUMBER}-allinone-spark.jar \
+            -DgroupId=org.genomicsdb -DartifactId=genomicsdb-spark -Dversion=${VERSION_NUMBER} \
+            -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom -DrepositoryId=$REPO_ID \
+            -Djavadoc=genomicsdb-${VERSION_NUMBER}-javadoc.jar \
+            -Dsources=genomicsdb-${VERSION_NUMBER}-sources.jar \
             -Dtypes=jar \
             -Dclassifiers=allinone-spark
           if [[ ${VERSION_NUMBER} != *SNAPSHOT ]]; then

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Set version number
         run: |
+          echo ${{github.ref_name}}
           echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
           echo GENOMICSDB_VERSION=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
 
@@ -50,7 +51,8 @@ jobs:
             -Dpackaging=jar -DpomFile=genomicsdb-${VERSION_NUMBER}.pom
           ./test_genomicsdbjar.sh
 #
-#      - name: Checkout GATK
+#     - name: Checkout GATK
+#        if: ${{github.ref_name}} != *" skip-gatk-it"*
 #        uses: actions/checkout@v3
 #        with:
 #          repository: broadinstitute/gatk

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -6,6 +6,9 @@ on:
       release_artifact:
         required: true
         type: string
+      tag_message:
+        required: false
+        type: string
 
 jobs:
   test-jar:
@@ -33,6 +36,11 @@ jobs:
           echo GENOMICSDB_VERSION=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
           echo GENOMICSDB_MIN_TAG=v1.5.0-SNAPSHOT >> $GITHUB_ENV
 
+      - name: Check tag messsage
+        run: |
+          echo "tag message is"
+          echo ${{inputs.tag_message}}
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -55,16 +63,17 @@ jobs:
         shell: bash
         run: GENOMICSDB_TAG=${GENOMICSDB_MIN_TAG} ./test_genomicsdbjar.sh
 
-#
-#     - name: Checkout GATK
-#        if: ${{github.ref_name}} != *" skip-gatk-it"*
-#        uses: actions/checkout@v3
-#        with:
-#          repository: broadinstitute/gatk
-#          lfs: 'true'
-#
-#      - name: Try GATK integration test
-#        shell: bash
-#        run: |
-#          ./gradlew installDist -Dgenomicsdb.version=${VERSION_NUMBER}
-#          ./gradlew test --tests *GenomicsDB*
+
+     - name: Checkout GATK
+        if: ${{inputs.tag_message}} != *"skip-gatk-it"*
+        uses: actions/checkout@v3
+        with:
+          repository: broadinstitute/gatk
+          lfs: 'true'
+
+      - name: Try GATK integration test
+        if: ${{inputs.tag_message}} != *"skip-gatk-it"*
+        shell: bash
+        run: |
+          ./gradlew installDist -Dgenomicsdb.version=${VERSION_NUMBER}
+          ./gradlew test --tests *GenomicsDB*

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -64,7 +64,7 @@ jobs:
         run: GENOMICSDB_TAG=${GENOMICSDB_MIN_TAG} ./test_genomicsdbjar.sh
 
 
-     - name: Checkout GATK
+      - name: Checkout GATK
         if: ${{inputs.tag_message}} != *"skip-gatk-it"*
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -36,10 +36,6 @@ jobs:
           echo GENOMICSDB_VERSION=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
           echo GENOMICSDB_MIN_TAG=v1.5.0-SNAPSHOT >> $GITHUB_ENV
 
-      - name: Check tag messsage
-        run: |
-          echo "tag message is"
-          echo ${{inputs.tag_message}}
 
       - uses: actions/setup-java@v3
         with:
@@ -65,14 +61,14 @@ jobs:
 
 
       - name: Checkout GATK
-        if: ${{inputs.tag_message}} != *"skip-gatk-it"*
+        if: ${{ !contains(inputs.tag_message,'skip-gatk-it') }}
         uses: actions/checkout@v3
         with:
           repository: broadinstitute/gatk
           lfs: 'true'
 
       - name: Try GATK integration test
-        if: ${{inputs.tag_message}} != *"skip-gatk-it"*
+        if: ${{ !contains(inputs.tag_message,'skip-gatk-it') }}
         shell: bash
         run: |
           ./gradlew installDist -Dgenomicsdb.version=${VERSION_NUMBER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,14 +548,14 @@ if(BUILD_JAVA)
 
     #Maven build - depends on dynamic library
     add_custom_command(
-        OUTPUT ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}.jar ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-allinone.jar
+        OUTPUT ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}.jar ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-allinone-spark.jar
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/pom.xml ${CMAKE_BINARY_DIR}/pom.xml
         COMMAND mvn versions:set ${MAVEN_QUIET_ARGS} -DnewVersion=${GENOMICSDB_RELEASE_VERSION} ${MAVEN_PROFILE}
         COMMAND mvn package -DskipTests ${MAVEN_ARGS}
         DEPENDS tiledbgenomicsdb ${JAVA_SCALA_SOURCES} pom.xml
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-    install(FILES ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}.jar ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-allinone.jar DESTINATION bin)
+    install(FILES ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}.jar ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-allinone-spark.jar DESTINATION bin)
 
     execute_process(
       COMMAND ln -sf ${CMAKE_SOURCE_DIR}/tests ${CMAKE_BINARY_DIR})
@@ -575,7 +575,7 @@ if(BUILD_JAVA)
     add_jar(genomicsdb-${GENOMICSDB_RELEASE_VERSION}-examples
         SOURCES ${GENOMICSDB_EXAMPLE_SOURCES}
                 log4j.properties
-        INCLUDE_JARS ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-allinone.jar
+        INCLUDE_JARS ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-allinone-spark.jar
         OUTPUT_DIR ${GENOMICSDB_MAVEN_BUILD_DIR})
 
     #Deploy to Maven central

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,13 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>${spark.core.artifactid}</artifactId>
       <version>${spark.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>${spark.sql.artifactid}</artifactId>
       <version>${spark.version}</version>
+      <optional>true</optional>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>
@@ -193,29 +195,6 @@
           </testExcludes>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <id>unzip-test-artifacts</id>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <target>
-                <mkdir dir="${genomicsdb_build_directory}/test" />
-                <copy file="${test_source_directory}/../inputs/test.tgz" tofile="${genomicsdb_build_directory}/test/test.tar.gz" />
-                <gunzip src="${genomicsdb_build_directory}/test/test.tar.gz" />
-                <untar src="${genomicsdb_build_directory}/test/test.tar" dest="${genomicsdb_build_directory}/test/"/>
-                <replace file="${genomicsdb_build_directory}/test/inputs/query.json" token="inputs/" value="${genomicsdb_build_directory}/test/inputs/" />
-                <replace file="${genomicsdb_build_directory}/test/inputs/loader.json" token="inputs/" value="${genomicsdb_build_directory}/test/inputs/" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
 
       <!-- Jacoco adapted from 
            https://www.petrikainulainen.net/programming/maven/creating-code-coverage-reports-for-unit-and-integration-tests-with-the-jacoco-maven-plugin/ -->
@@ -296,6 +275,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>spark-excluded</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>spark</classifier>
+                <excludes>
+                  <exclude>org/genomicsdb/spark/**</exclude>
+                </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin> 
       <plugin> 
         <groupId>org.apache.maven.plugins</groupId> 
         <artifactId>maven-shade-plugin</artifactId>  
@@ -308,7 +306,7 @@
             </goals> 
             <configuration> 
             <shadedArtifactAttached>true</shadedArtifactAttached> 
-            <shadedClassifierName>allinone</shadedClassifierName> 
+            <shadedClassifierName>allinone-spark</shadedClassifierName> 
             <filters>
               <filter>
                 <artifact>*:*</artifact>
@@ -330,6 +328,42 @@
           </execution>  
         </executions> 
       </plugin> 
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>unzip-test-artifacts</id>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <target>
+                <mkdir dir="${genomicsdb_build_directory}/test" />
+                <copy file="${test_source_directory}/../inputs/test.tgz" tofile="${genomicsdb_build_directory}/test/test.tar.gz" />
+                <gunzip src="${genomicsdb_build_directory}/test/test.tar.gz" />
+                <untar src="${genomicsdb_build_directory}/test/test.tar" dest="${genomicsdb_build_directory}/test/"/>
+                <replace file="${genomicsdb_build_directory}/test/inputs/query.json" token="inputs/" value="${genomicsdb_build_directory}/test/inputs/" />
+                <replace file="${genomicsdb_build_directory}/test/inputs/loader.json" token="inputs/" value="${genomicsdb_build_directory}/test/inputs/" />
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>replace-core-jar</id>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <move file="${project.build.directory}/genomicsdb-${genomicsdb.version}-spark.jar"
+                  tofile="${project.build.directory}/genomicsdb-${genomicsdb.version}.jar" />
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>                
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
+++ b/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
@@ -42,19 +42,19 @@ import java.util.List;
 
 /**
  * Example Invocation
- * spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-1.3.1-SNAPSHOT-allinone.jar loader.json querypb.json true
+ * spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-1.3.1-SNAPSHOT-allinone-spark.jar loader.json querypb.json true
  *      querypb.json should be parseable by GenomicsDBExportConfiguration.ExportConfiguration
  *  OR
- *  spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-1.3.1-SNAPSHOT-allinone.jar loader.json query.json false
+ *  spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-1.3.1-SNAPSHOT-allinone-spark.jar loader.json query.json false
  *  OR
- *  spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-1.3.1-SNAPSHOT-allinone.jar loader.json query.json
+ *  spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-1.3.1-SNAPSHOT-allinone-spark.jar loader.json query.json
  */
 public class GenomicsDBSparkBindings {
   List<VariantCall> variantCalls;
 
   public static void main(String[] args) throws IOException, ClassNotFoundException {
     if (args.length < 2) {
-      throw new RuntimeException("Usage: spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-<VERSION>-allinone.jar <loader.json> <query.json> [<is_serialized_pb>]"+
+      throw new RuntimeException("Usage: spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-<VERSION>-allinone-spark.jar <loader.json> <query.json> [<is_serialized_pb>]"+
               "Optional Argument 2 - <is_serialized_pb=True|False, default is false, if is_serialized_pb then query.json is a protobuf serialized file.");
     }
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -55,7 +55,7 @@ def __find_genomicsdb_jar(target_dir, jar_file_name):
 
 def setup_classpath(build_dir):
     target_dir=os.path.join(build_dir,'target')
-    allinone_jar=__find_genomicsdb_jar(target_dir,'genomicsdb-*allinone.jar')
+    allinone_jar=__find_genomicsdb_jar(target_dir,'genomicsdb-*allinone-spark.jar')
     examples_jar=__find_genomicsdb_jar(target_dir,'genomicsdb-*examples.jar')
     if 'CLASSPATH' in os.environ:
         classpath=os.environ['CLASSPATH']
@@ -94,7 +94,7 @@ def setup_jacoco(build_dir, build_type):
             if e.errno != errno.EEXIST:
                 __error_exit('could not create jacoco-reports dir:'+e.errno+' '+e.filename+' '+e.strerror)
         genomicsdb_classes_dir = os.path.join(target_dir, 'jacoco-classes')
-        allinone_archive = zipfile.ZipFile(__find_genomicsdb_jar(target_dir,'genomicsdb-*allinone.jar'))
+        allinone_archive = zipfile.ZipFile(__find_genomicsdb_jar(target_dir,'genomicsdb-*allinone-spark.jar'))
         for file in allinone_archive.namelist():
             if file.startswith('org/genomicsdb'):
                 allinone_archive.extract(file, genomicsdb_classes_dir)

--- a/tests/run_spark_hdfs.py
+++ b/tests/run_spark_hdfs.py
@@ -222,7 +222,7 @@ def sanity_test_spark_bindings(tmpdir, lib_path, jar_dir, jacoco, genomicsdb_ver
     substitute_placeholders(querypb_json, sanity_test_dir)
 
     # Expected exception when run without json files
-    spark_cmd = 'spark-submit --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M  --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --class org.genomicsdb.spark.api.GenomicsDBSparkBindings '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone.jar'
+    spark_cmd = 'spark-submit --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M  --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --class org.genomicsdb.spark.api.GenomicsDBSparkBindings '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone-spark.jar'
     pid = subprocess.Popen(spark_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout_string, stderr_string = pid.communicate()
     if(pid.returncode == 0):
@@ -231,7 +231,7 @@ def sanity_test_spark_bindings(tmpdir, lib_path, jar_dir, jacoco, genomicsdb_ver
 
     output_string = "[row=0 col=12140 HG00141 1:12141-12295 {REF=C, DP_FORMAT=2, MIN_DP=0, ALT=[<NON_REF>], GQ=0, PL=[0, 0, 0], GT=0/0}, row=1 col=12144 HG01958 1:12145-12277 {REF=C, DP_FORMAT=3, MIN_DP=0, ALT=[<NON_REF>], GQ=0, PL=[0, 0, 0], GT=0/0}, row=0 col=17384 HG00141 1:17385-17385 {MQRankSum=-0.329000, AD=[58, 22, 17], MQ=31.719999, DP_FORMAT=80, ALT=[A, <NON_REF>], BaseQRankSum=-2.096000, GQ=99, PID=17385_G_A, ReadPosRankSum=0.005000, MQ0=8, GT=0/1, SB=[58, 0, 22, 0], RAW_MQ=5.500000, REF=G, ClippingRankSum=-1.859000, PL=[504, 0, 9807, 678, 1870, 2548], PGT=0|1}, row=1 col=17384 HG01958 1:17385-17385 {MQRankSum=-1.369000, AD=[0, 120, 37], MQ=29.820000, DP_FORMAT=120, ALT=[T, <NON_REF>], BaseQRankSum=-2.074000, GQ=99, PID=17385_G_T, ReadPosRankSum=-0.101000, DP=120, MQ0=3, GT=1/1, SB=[0, 0, 0, 0], RAW_MQ=2.500000, REF=G, ClippingRankSum=0.555000, PL=[3336, 358, 0, 4536, 958, 7349], PGT=0|1}, row=2 col=17384 HG01530 1:17385-17385 {MQRankSum=-0.432000, AD=[40, 36, 0], MQ=59.369999, DP_FORMAT=76, ALT=[A, <NON_REF>], BaseQRankSum=1.046000, GQ=99, ReadPosRankSum=2.055000, DP=76, MQ0=0, GT=0/1, SB=[9, 31, 13, 23], REF=G, ClippingRankSum=-2.242000, PL=[1018, 0, 1116, 1137, 1224, 2361]}]"
 
-    spark_cmd = 'spark-submit --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M  --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --class org.genomicsdb.spark.api.GenomicsDBSparkBindings '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone.jar '+loader_json+' '+query_json
+    spark_cmd = 'spark-submit --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M  --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --class org.genomicsdb.spark.api.GenomicsDBSparkBindings '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone-spark.jar '+loader_json+' '+query_json
     pid = subprocess.Popen(spark_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout_string, stderr_string = pid.communicate()
     if(pid.returncode != 0):
@@ -241,7 +241,7 @@ def sanity_test_spark_bindings(tmpdir, lib_path, jar_dir, jacoco, genomicsdb_ver
         sys.stderr.write('Expected output not found in sanity test with query.json\n')
         print_error_and_exit(namenode, tmpdir, stdout_string, stderr_string)
 
-    spark_cmd = 'spark-submit --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M  --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --class org.genomicsdb.spark.api.GenomicsDBSparkBindings '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone.jar '+loader_json+' '+querypb_json+' true'
+    spark_cmd = 'spark-submit --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M  --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --class org.genomicsdb.spark.api.GenomicsDBSparkBindings '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone-spark.jar '+loader_json+' '+querypb_json+' true'
     pid = subprocess.Popen(spark_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout_string, stderr_string = pid.communicate()
     if(pid.returncode != 0):
@@ -475,7 +475,7 @@ def main():
                 with open(query_json_filename, 'w') as fptr:
                     json.dump(test_query_dict, fptr, indent=4, separators=(',', ': '));
                     fptr.close();
-                spark_cmd = 'spark-submit --class TestGenomicsDBSparkHDFS --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M --conf "spark.yarn.executor.memoryOverhead=3700" --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --jars '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone.jar '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-examples.jar --loader '+loader_json_filename+' --query '+query_json_filename+' --template_vcf_header '+template_vcf_header_path+' --spark_master '+spark_master+' --jar_dir '+jar_dir;
+                spark_cmd = 'spark-submit --class TestGenomicsDBSparkHDFS --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M --conf "spark.yarn.executor.memoryOverhead=3700" --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --jars '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone-spark.jar '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-examples.jar --loader '+loader_json_filename+' --query '+query_json_filename+' --template_vcf_header '+template_vcf_header_path+' --spark_master '+spark_master+' --jar_dir '+jar_dir;
                 if (test_name == "t6_7_8"):
                     spark_cmd = spark_cmd + ' --use-query-protobuf';
                 if (test_name == "t0_1_2_combined"):
@@ -512,7 +512,7 @@ def main():
                     vid_path_final=vid_path+query_param_dict['vid_mapping_file'];
                 else:
                     vid_path_final=vid_path+"inputs"+os.path.sep+"vid.json";
-                spark_cmd_v2 = 'spark-submit --class TestGenomicsDBSource --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M --conf "spark.yarn.executor.memoryOverhead=3700" --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --jars '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone.jar '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-examples.jar --loader '+loader_json_filename+' --query '+query_json_filename+' --vid '+vid_path_final+' --spark_master '+spark_master;
+                spark_cmd_v2 = 'spark-submit --class TestGenomicsDBSource --master '+spark_master+' --deploy-mode '+spark_deploy+' --total-executor-cores 1 --executor-memory 512M --conf "spark.yarn.executor.memoryOverhead=3700" --conf "spark.executor.extraJavaOptions='+jacoco+'" --conf "spark.driver.extraJavaOptions='+jacoco+'" --jars '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-allinone-spark.jar '+jar_dir+'/genomicsdb-'+genomicsdb_version+'-examples.jar --loader '+loader_json_filename+' --query '+query_json_filename+' --vid '+vid_path_final+' --spark_master '+spark_master;
                 if (gdb_datasource != ""):
                   spark_cmd_v2 += ' --gdb_datasource=' + gdb_datasource
                 if (test_name == "t6_7_8"):


### PR DESCRIPTION
Excludes spark files by executing maven-jar plugin once more to create a jar without spark. After maven-shade creates uber jar, replacing the excluded one with regular jar. 