### PR TITLE
upgrade spark version to 3.4.0

### DIFF
--- a/.github/scripts/install_spark.sh
+++ b/.github/scripts/install_spark.sh
@@ -5,8 +5,8 @@
 INSTALL_DIR=${INSTALL_DIR:-/usr}
 USER=`whoami`
 
-SPARK_VER=${SPARK_VER:-3.0.1}
-SPARK=spark-$SPARK_VER-bin-hadoop${SPARK_HADOOP_VER:-2.7}
+SPARK_VER=${SPARK_VER:-3.4.0}
+SPARK=spark-$SPARK_VER-bin-hadoop${SPARK_HADOOP_VER:-3}
 SPARK_DIR=${INSTALL_DIR}/$SPARK
 SPARK_LOCAL_DIR="/usr/local/spark"
 SPARK_ENV=${SPARK_ENV:-$HOME/spark_env.sh}
@@ -55,7 +55,7 @@ configure_spark() {
   sudo echo "SPARK_MASTER_HOST=127.0.0.1" > ${SPARK_LOCAL_DIR}/conf/spark-env.sh &&
   sudo echo "SPARK_LOCAL_IP=127.0.0.1" >> ${SPARK_LOCAL_DIR}/conf/spark-env.sh &&
   sudo echo "localhost" > ${SPARK_LOCAL_DIR}/conf/slaves &&
-  sudo cp ${SPARK_LOCAL_DIR}/conf/log4j.properties.template ${SPARK_LOCAL_DIR}/conf/log4j.properties &&
+  sudo cp ${SPARK_LOCAL_DIR}/conf/log4j2.properties.template ${SPARK_LOCAL_DIR}/conf/log4j2.properties &&
   echo "configure_spark successful"
 }
 

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04,ubuntu-22.04,macos-12]
         type: [basic]
-        java: [11,17]
+        java: [17]
         include:
           - os: ubuntu-20.04
             type: hdfs
@@ -112,9 +112,6 @@ jobs:
       shell: bash
       working-directory: ${{env.GENOMICSDB_BUILD_DIR}}
       run: |
-        if [[ $JAVA_VER == '11' ]]; then
-          GENOMICSDB_MAVEN_PROFILE=java11
-        fi
         source $PREREQS_ENV
         # java tests take a very long time to run on MacOS, so limit running the tests to PRs and master/develop branches
         BRANCH=${GITHUB_REF##*/}

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -117,7 +117,7 @@ jobs:
         BRANCH=${GITHUB_REF##*/}
         if [[ ${{matrix.os}} != macos* || ${GITHUB_REF##*/} == master || ${GITHUB_REF##*/} == develop || $GITHUB_BASE_REF == master || $GITHUB_BASE_REF == develop ]]; then
           echo "cmake BUILD_JAVA set to 1"
-          JAVA_BUILD_ARGS="-DBUILD_JAVA=1 -DGENOMICSDB_MAVEN_PROFILE=$GENOMICSDB_MAVEN_PROFILE"
+          JAVA_BUILD_ARGS="-DBUILD_JAVA=1"
         fi
         cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX \
         -DCMAKE_PREFIX_PATH=$PREREQS_INSTALL_DIR -DGENOMICSDB_PROTOBUF_VERSION=$PROTOBUF_VERSION         \

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -20,8 +20,8 @@ env:
   GENOMICSDB_BUILD_DIR: ${{github.workspace}}/build
   GENOMICSDB_RELEASE_VERSION: x.y.z.test
   HADOOP_VER: 3.3.5
-  SPARK_VER: 3.0.1
-  SPARK_HADOOP_VER: 2.7
+  SPARK_VER: 3.4.0
+  SPARK_HADOOP_VER: 3
 
 jobs:
   build:
@@ -34,10 +34,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             type: hdfs
-            java: 11
+            java: 17
           - os: ubuntu-22.04
             type: hdfs
-            java: 11
+            java: 17
 
     env: 
       OS_TYPE: ${{matrix.os}} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ option(USE_GPERFTOOLS_HEAP "Collect heap profiling information using gperftools/
 
 set(GENOMICSDB_MAVEN_BUILD_DIR ${CMAKE_BINARY_DIR}/target CACHE PATH "Path to maven build directory")
 set(MAVEN_QUIET False CACHE BOOL "Do not print mvn messages")
-set(GENOMICSDB_MAVEN_PROFILE "" CACHE STRING "Profile to compile with Java 11") # used in Maven builds
+set(GENOMICSDB_MAVEN_PROFILE "" CACHE STRING "To enable the profile in Maven") # used in Maven builds
 set(GPG_PASSPHRASE "" CACHE STRING "Gpg passphrase for deploying to maven")
 
 set(IPPROOT "" CACHE PATH "Path to IPP libraries - used when intel optimized zlib is required")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,6 @@ option(USE_GPERFTOOLS_HEAP "Collect heap profiling information using gperftools/
 
 set(GENOMICSDB_MAVEN_BUILD_DIR ${CMAKE_BINARY_DIR}/target CACHE PATH "Path to maven build directory")
 set(MAVEN_QUIET False CACHE BOOL "Do not print mvn messages")
-set(GENOMICSDB_MAVEN_PROFILE "" CACHE STRING "To enable the profile in Maven") # used in Maven builds
 set(GPG_PASSPHRASE "" CACHE STRING "Gpg passphrase for deploying to maven")
 
 set(IPPROOT "" CACHE PATH "Path to IPP libraries - used when intel optimized zlib is required")
@@ -538,20 +537,12 @@ if(BUILD_JAVA)
 
       endif()
 
-      if(GENOMICSDB_MAVEN_PROFILE)
-        message(STATUS "Setting maven profile to ${GENOMICSDB_MAVEN_PROFILE}" )
-        set(MAVEN_PROFILE 
-          -P${GENOMICSDB_MAVEN_PROFILE})
-        set(MAVEN_ARGS ${MAVEN_ARGS} ${MAVEN_PROFILE})
-    else()
-        set(MAVEN_PROFILE "")
-    endif()
 
     #Maven build - depends on dynamic library
     add_custom_command(
         OUTPUT ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}.jar ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-allinone-spark.jar
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/pom.xml ${CMAKE_BINARY_DIR}/pom.xml
-        COMMAND mvn versions:set ${MAVEN_QUIET_ARGS} -DnewVersion=${GENOMICSDB_RELEASE_VERSION} ${MAVEN_PROFILE}
+        COMMAND mvn versions:set ${MAVEN_QUIET_ARGS} -DnewVersion=${GENOMICSDB_RELEASE_VERSION}
         COMMAND mvn package -DskipTests ${MAVEN_ARGS}
         DEPENDS tiledbgenomicsdb ${JAVA_SCALA_SOURCES} pom.xml
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/example/java/TestGenomicsDBSparkHDFS.java
+++ b/example/java/TestGenomicsDBSparkHDFS.java
@@ -112,6 +112,7 @@ public final class TestGenomicsDBSparkHDFS {
       }
     }
     SparkConf conf = new SparkConf().setAppName("TestGenomicsDBSparkHDFS");
+    conf.set("spark.hadoopRDD.ignoreEmptySplits","false");
 
     Path dstdir = Paths.get("").toAbsolutePath();
     Path qSrc = Paths.get(queryFile);

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
   <properties>
     <java.version>17</java.version>
     <scala.main>2.12</scala.main>
-    <spark.version>3.0.1</spark.version>
+    <spark.version>3.4.0</spark.version>
     <spark.core.artifactid>spark-core_${scala.main}</spark.core.artifactid>
     <spark.sql.artifactid>spark-sql_${scala.main}</spark.sql.artifactid>
     <spark.exclude.packages>org.genomicsdb.spark.v2</spark.exclude.packages>

--- a/pom.xml
+++ b/pom.xml
@@ -501,12 +501,4 @@
 
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>java11</id>
-      <properties>
-        <java.version>11</java.version>
-      </properties>
-      </profile>  
-  </profiles>
 </project>

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBJavaSparkFactory.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBJavaSparkFactory.java
@@ -49,6 +49,7 @@ public final class GenomicsDBJavaSparkFactory {
 
     SparkConf conf = new SparkConf();
     conf.setAppName("GenomicsDBTest using newAPIHadoopRDD");
+    conf.set("spark.hadoopRDD.ignoreEmptySplits","false");
     JavaSparkContext sc = new JavaSparkContext(conf);
 
     Configuration hadoopConf = sc.hadoopConfiguration();

--- a/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
+++ b/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
@@ -67,6 +67,7 @@ public class GenomicsDBSparkBindings {
 
     SparkConf conf = new SparkConf();
     conf.setAppName("GenomicsDB API Experimental Bindings");
+    conf.set("spark.hadoopRDD.ignoreEmptySplits","false");
     JavaSparkContext sc = new JavaSparkContext(conf);
 
     Configuration hadoopConf = sc.hadoopConfiguration();


### PR DESCRIPTION
Upgrades spark version to 3.4.0. (ToDo?) Maybe we can also remove java 11 support from workflows and move to java 17 altogether since hdfs tests are now running on java 17 anyways.