### PR TITLE
Install genomicsdb_status.h, update snapshot version and copyrights

### DIFF
--- a/.github/scripts/install_hadoop.sh
+++ b/.github/scripts/install_hadoop.sh
@@ -83,7 +83,7 @@ install_hadoop() {
       export HADOOP_ROOT_LOGGER=ERROR,console &&
       echo "download hadoop with download successful"
   fi
-  if [[ $? != 0 ]];
+  if [[ $? != 0 ]]; then
     echo "Hadoop did not install successfully. Aborting"
     exit 1
   fi

--- a/.github/scripts/install_hadoop.sh
+++ b/.github/scripts/install_hadoop.sh
@@ -80,7 +80,12 @@ install_hadoop() {
       setup_paths &&
       cp -fr $GITHUB_WORKSPACE/.github/resources/hadoop/* $HADOOP_DIR/etc/hadoop &&
       mkdir -p $HADOOP_DIR/logs &&
-      export HADOOP_ROOT_LOGGER=ERROR,console
+      export HADOOP_ROOT_LOGGER=ERROR,console &&
+      echo "download hadoop with download successful"
+  fi
+  if [[ $? != 0 ]];
+    echo "Hadoop did not install successfully. Aborting"
+    exit 1
   fi
   source $HADOOP_ENV &&
     configure_hadoop &&
@@ -88,5 +93,4 @@ install_hadoop() {
 }
 
 echo "INSTALL_DIR=$INSTALL_DIR"
-echo "INSTALL_TYPE=$INSTALL_TYPE"
 install_hadoop

--- a/.github/scripts/install_hadoop.sh
+++ b/.github/scripts/install_hadoop.sh
@@ -81,7 +81,7 @@ install_hadoop() {
       cp -fr $GITHUB_WORKSPACE/.github/resources/hadoop/* $HADOOP_DIR/etc/hadoop &&
       mkdir -p $HADOOP_DIR/logs &&
       export HADOOP_ROOT_LOGGER=ERROR,console &&
-      echo "download hadoop with download successful"
+      echo "install_hadoop with download successful"
   fi
   if [[ $? != 0 ]]; then
     echo "Hadoop did not install successfully. Aborting"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2019-2022 Omics Data Automation, Inc.
+# Copyright (c) 2019-2023 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -51,7 +51,7 @@ execute_process(
     )
 
 #Build parameters/options
-set(GENOMICSDB_RELEASE_VERSION "1.4.5-SNAPSHOT" CACHE STRING "GenomicsDB release version") #used in Maven builds
+set(GENOMICSDB_RELEASE_VERSION "1.5.0-SNAPSHOT" CACHE STRING "GenomicsDB release version") #used in Maven builds
 set(GENOMICSDB_VERSION "${GENOMICSDB_RELEASE_VERSION}-${GIT_COMMIT_HASH}" CACHE STRING "GenomicsDB full version string")
 
 option(BUILD_DISTRIBUTABLE_LIBRARY "Build the GenomicsDB library with minimal runtime dependencies")

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2019-2020,2022 Omics Data Automation, Inc.
+# Copyright (c) 2019-2020,2022-2023 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -128,7 +128,8 @@ endif()
 #endif()
 
 install(TARGETS genomicsdb tiledbgenomicsdb LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
-install(FILES cpp/include/api/genomicsdb.h  cpp/include/api/genomicsdb_exception.h cpp/include/api/genomicsdb_utils.h DESTINATION include)
+install(FILES cpp/include/api/genomicsdb.h  cpp/include/api/genomicsdb_exception.h cpp/include/api/genomicsdb_status.h cpp/include/api/genomicsdb_utils.h
+        DESTINATION include)
 if(BUILD_FOR_PYTHON)
   install(FILES ${PROTOBUF_GENERATED_PYTHON_SRCS} DESTINATION genomicsdb/protobuf/python)
 endif()


### PR DESCRIPTION
Install genomicsdb_status.h as this is used in the Python/R bindings.
Also, updated snapshot default version and copyrights.
Added some minor debugging echo statements to install_hadoop.sh as it was failing in the download phase initially, seems to have resolved itself.