### PR TITLE
Remove incompatible log4j in pom.xml and surefire causing build issues and cleanup mvn warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <htsjdk.version>3.0.5</htsjdk.version>
     <json.simple.version>[1.1.1,)</json.simple.version>
     <gson.version>[2.10.1,)</gson.version>
-    <log4j.version>[2.20.0,)</log4j.version>
+    <log4j.version>2.19.0</log4j.version>
     <!-- Sync the protobuf.version with GENOMICSDB_PROTOBUF_VERSION in CMakeLists.txt -->
     <protobuf.version>3.21.7</protobuf.version>
     <google_shade_version>org.genomicsdb.shaded.com.google</google_shade_version>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,9 @@
         <configuration>
           <show>private</show>
           <nohelp>true</nohelp>
-          <source>8</source>
+          <doclint>all,-missing</doclint>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
           <sourceFileExcludes>
             <sourceFileExclude>**/Coordinates.java</sourceFileExclude>
             <sourceFileExclude>**/GenomicsDBVidMapProto.java</sourceFileExclude>

--- a/scripts/prereqs/system/install_macos_prereqs.sh
+++ b/scripts/prereqs/system/install_macos_prereqs.sh
@@ -32,7 +32,15 @@ brew list mpich &>/dev/null || brew install mpich
 brew list ossp-uuid &>/dev/null || brew install ossp-uuid
 brew list libcsv &>/dev/null || brew install libcsv
 brew list automake &> /dev/null || brew install automake
-brew list lcov &> /dev/null || brew install lcov
+
+# brew has started installing lcov 2.0 and some GenomicsDB sources are erroring out while running lcov
+# For example -
+# geninfo: ERROR: "/Users/runner/work/GenomicsDB/GenomicsDB/src/main/cpp/include/query_operations/variant_operations.h":50: function _ZN23RemappedDataWrapperBaseC2Ev end line 37 less than start line
+# The errors can be suppressed, but installing the older version 1.16 explicitly for now
+wget https://github.com/Homebrew/homebrew-core/raw/e92d2ae54954ebf485b484d8522104700b144fee/Formula/lcov.rb
+brew list lcov &> /dev/null && brew uninstall lcov
+brew install -s lcov
+
 brew list openssl@1.1 &> /dev/null || brew install openssl@1.1
 brew list zstd &> /dev/null || brew install zstd
 brew list openjdk@17 &> /dev/null || brew install openjdk@17

--- a/scripts/prereqs/system/install_macos_prereqs.sh
+++ b/scripts/prereqs/system/install_macos_prereqs.sh
@@ -27,6 +27,7 @@ PREREQS_ENV=${PREREQS_ENV:-$HOME/genomicsdb_prereqs.sh}
 
 # Install GenomicsDB Dependencies
 HOMEBREW_NO_AUTO_UPDATE=1
+HOMEBREW_NO_INSTALL_CLEANUP=1
 brew list cmake &>/dev/null || brew install cmake
 brew list mpich &>/dev/null || brew install mpich
 brew list ossp-uuid &>/dev/null || brew install ossp-uuid
@@ -39,7 +40,7 @@ brew list automake &> /dev/null || brew install automake
 # The errors can be suppressed, but installing the older version 1.16 explicitly for now
 wget https://github.com/Homebrew/homebrew-core/raw/e92d2ae54954ebf485b484d8522104700b144fee/Formula/lcov.rb
 brew list lcov &> /dev/null && brew uninstall lcov
-brew install -s lcov
+brew install -s lcov.rb
 
 brew list openssl@1.1 &> /dev/null || brew install openssl@1.1
 brew list zstd &> /dev/null || brew install zstd

--- a/src/main/cpp/src/genomicsdb/genomicsdb_iterators.cc
+++ b/src/main/cpp/src/genomicsdb/genomicsdb_iterators.cc
@@ -517,7 +517,7 @@ bool SingleCellTileDBIterator::advance_to_next_useful_cell(const uint64_t min_nu
     std::vector<void *> buffers;
     std::vector<size_t> buffer_sizes;
     std::vector<int64_t> positions;
-    for (auto i=0; i<m_fields.size(); i++) {
+    for (auto i=0u; i<m_fields.size(); i++) {
       auto& genomicsdb_columnar_field = m_fields[i];
       auto buffer = get_buffer_and_index(i);
       if (genomicsdb_columnar_field.is_variable_length_field()) {

--- a/src/main/java/org/genomicsdb/importer/extensions/VidMapExtensions.java
+++ b/src/main/java/org/genomicsdb/importer/extensions/VidMapExtensions.java
@@ -250,7 +250,7 @@ public interface VidMapExtensions {
 	    currList = fieldNameToDuplicateCheckInfo.get(vcfFieldName);
 	else {
 	    //Why 3? VCF header can have FILTER/INFO/FORMAT fields of the same name
-	    List<DuplicateFieldInfoTrackClass> init = new ArrayList(3);
+	    List<DuplicateFieldInfoTrackClass> init = new ArrayList<DuplicateFieldInfoTrackClass>(3);
 	    for(int i=0;i<3;++i)
 		init.add(new DuplicateFieldInfoTrackClass());
 	    fieldNameToDuplicateCheckInfo.put(vcfFieldName, init);

--- a/src/main/java/org/genomicsdb/reader/GenomicsDBQuery.java
+++ b/src/main/java/org/genomicsdb/reader/GenomicsDBQuery.java
@@ -171,13 +171,13 @@ public class GenomicsDBQuery {
 
   public List<Interval> queryVariantCalls(long handle,
                                           final String arrayName) {
-    return jniQueryVariantCalls(handle, arrayName, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+    return jniQueryVariantCalls(handle, arrayName, Collections.emptyList(), Collections.emptyList());
   }
 
   public List<Interval> queryVariantCalls(long handle,
                                           final String arrayName,
                                           final List<Pair> columnRanges) {
-    return jniQueryVariantCalls(handle, arrayName, columnRanges, Collections.EMPTY_LIST);
+    return jniQueryVariantCalls(handle, arrayName, columnRanges, Collections.emptyList());
   }
 
   public List<Interval> queryVariantCalls(long handle,

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
@@ -22,27 +22,20 @@
 
 package org.genomicsdb.spark;
 
-import org.genomicsdb.model.*;
-
 import org.apache.spark.sql.types.StructType;
-
+import org.genomicsdb.model.Coordinates;
+import org.genomicsdb.model.GenomicsDBExportConfiguration;
 import org.genomicsdb.spark.sources.GenomicsDBInputPartition;
-import org.json.simple.JSONObject;
 import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.FileReader;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
-import java.lang.RuntimeException;
-import java.lang.InstantiationException;
-import java.lang.IllegalAccessException;
-import java.lang.ClassNotFoundException;
 
 /**
  * The input class represents all the data being queried from GenomicsDB.

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInput.java
@@ -26,6 +26,7 @@ import org.genomicsdb.model.*;
 
 import org.apache.spark.sql.types.StructType;
 
+import org.genomicsdb.spark.sources.GenomicsDBInputPartition;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
@@ -36,6 +37,7 @@ import java.io.FileWriter;
 import java.io.FileReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.lang.RuntimeException;
 import java.lang.InstantiationException;
@@ -98,34 +100,12 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
    */
   private T createInputInstance() {
     try {
-      return clazz.newInstance();
+      return clazz.getConstructor().newInstance();
     }
-    catch (IllegalAccessException | InstantiationException e) {
+    catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
       e.printStackTrace();
     }
     return null;
-  }
-
-  /**
-   * Creates a fallback plan for the datasource API for older spark versions
-   * @throws RuntimeException thrown if class is not GenomicsDBInputPartition
-   * @return Class found from the proper spark version package.
-   **/
-  private Class setDatasourceClass() throws RuntimeException {
-    Class c;
-    try {
-      c = Class.forName("org.genomicsdb.spark.sources.GenomicsDBInputPartition");
-    }
-    catch (ClassNotFoundException ex1) {
-      try{
-        c = Class.forName("org.genomicsdb.spark.v2.GenomicsDBInputPartition");
-      }
-      catch (ClassNotFoundException ex2) {
-        throw new RuntimeException("Warning: Could not find GenomicsDBInputPartition. " +
-                                   "Datasourceapi only works with >= Spark 2.4.0");       
-        }
-    }
-    return c;
   }
 
   /**
@@ -145,8 +125,7 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
       return instance;
     }
     else {
-      Class c = setDatasourceClass();
-      if (c.isAssignableFrom(clazz)) {
+      if (GenomicsDBInputPartition.class.isAssignableFrom(clazz)) {
           instance.setGenomicsDBConf(genomicsDBConfiguration);
           instance.setGenomicsDBSchema(schema);
           instance.setGenomicsDBVidSchema(vMap);
@@ -178,8 +157,7 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
       return instance;
     }
     else {
-      Class c = setDatasourceClass();
-      if (c.isAssignableFrom(clazz)) {
+      if (GenomicsDBInputPartition.class.isAssignableFrom(clazz)) {
         instance.setPartitionInfo(part);
         instance.setQueryInfoList(qrangeList);
         instance.setGenomicsDBConf(genomicsDBConfiguration);
@@ -210,6 +188,7 @@ public class GenomicsDBInput<T extends GenomicsDBInputInterface> {
     * @return Returns list of "work chunks" (either InputSplits or
     * InputPartitions)
     */
+  @SuppressWarnings("deprecation")
   public List<T> divideInput() {
 
     if (genomicsDBConfiguration.hasProtoLoader()){

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBInputFormat.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBInputFormat.java
@@ -71,7 +71,7 @@ public class GenomicsDBInputFormat<VCONTEXT extends Feature, SOURCE>
    * @return  Returns a list of input splits
    * @throws FileNotFoundException  Thrown if creaing configuration object fails
    */
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   @Override
   public List<InputSplit> getSplits(JobContext jobContext) throws FileNotFoundException {
 
@@ -163,6 +163,7 @@ public class GenomicsDBInputFormat<VCONTEXT extends Feature, SOURCE>
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public RecordReader<String, VCONTEXT>
     createRecordReader(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
       throws IOException, InterruptedException {

--- a/src/main/java/org/genomicsdb/spark/GenomicsDBJavaSparkFactory.java
+++ b/src/main/java/org/genomicsdb/spark/GenomicsDBJavaSparkFactory.java
@@ -40,7 +40,7 @@ import java.util.List;
  */
 public final class GenomicsDBJavaSparkFactory {
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   public static void usingNewAPIHadoopRDD(String[] args) {
     
     String loaderJsonFile = args[0];

--- a/src/main/java/org/genomicsdb/spark/api/GenomicsDBQueryInputFormat.java
+++ b/src/main/java/org/genomicsdb/spark/api/GenomicsDBQueryInputFormat.java
@@ -29,6 +29,7 @@ public class GenomicsDBQueryInputFormat extends InputFormat<Interval, List<Varia
   private GenomicsDBInput<GenomicsDBInputSplit> input;
 
   @Override
+  @SuppressWarnings({"unchecked", "deprecation"})
   public List<InputSplit> getSplits(JobContext jobContext) throws IOException, InterruptedException {
     GenomicsDBConfiguration genomicsDBConfiguration = new GenomicsDBConfiguration(configuration);
 
@@ -61,6 +62,7 @@ public class GenomicsDBQueryInputFormat extends InputFormat<Interval, List<Varia
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public RecordReader<Interval, List<VariantCall>> createRecordReader(
       InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
       throws IOException, InterruptedException {

--- a/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
+++ b/src/main/java/org/genomicsdb/spark/api/GenomicsDBSparkBindings.java
@@ -33,10 +33,8 @@ import org.genomicsdb.reader.GenomicsDBQuery.Interval;
 import org.genomicsdb.reader.GenomicsDBQuery.VariantCall;
 import org.genomicsdb.spark.GenomicsDBConfiguration;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 
@@ -50,8 +48,7 @@ import java.util.List;
  *  spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-1.3.1-SNAPSHOT-allinone-spark.jar loader.json query.json
  */
 public class GenomicsDBSparkBindings {
-  List<VariantCall> variantCalls;
-
+  @SuppressWarnings({"unchecked", "deprecation"})
   public static void main(String[] args) throws IOException, ClassNotFoundException {
     if (args.length < 2) {
       throw new RuntimeException("Usage: spark-submit --class org.genomicsdb.spark.api.GenomicsDBSparkBindings genomicsdb-<VERSION>-allinone-spark.jar <loader.json> <query.json> [<is_serialized_pb>]"+
@@ -62,7 +59,7 @@ public class GenomicsDBSparkBindings {
     String queryJsonFile = args[1];
     boolean isPB = false;
     if (args.length == 3) {
-      isPB = new Boolean(args[2]).booleanValue();
+      isPB = Boolean.valueOf(args[2]);
     }
 
     SparkConf conf = new SparkConf();
@@ -76,7 +73,7 @@ public class GenomicsDBSparkBindings {
     }
 
     if (isPB) {
-      String queryPBString = FileUtils.readFileToString(new File(queryJsonFile));
+      String queryPBString = FileUtils.readFileToString(new File(queryJsonFile), "UTF-8");
       final GenomicsDBExportConfiguration.ExportConfiguration.Builder builder = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
       JsonFormat.parser().merge(queryPBString, builder);
       queryPBString = Base64.getEncoder().encodeToString(builder.build().toByteArray());
@@ -90,7 +87,7 @@ public class GenomicsDBSparkBindings {
             GenomicsDBQueryInputFormat.class, Interval.class, variantCallListClass);
 
     System.out.println("Number of variants "+variants.count());
-    List variantList = variants.collect();
+    List<scala.Tuple2<Interval, List<VariantCall>>> variantList = variants.collect();
     for (Object variantObj : variantList) {
       System.out.println(variantObj);
     }

--- a/src/main/java/org/genomicsdb/spark/sources/GenomicsDBBatch.java
+++ b/src/main/java/org/genomicsdb/spark/sources/GenomicsDBBatch.java
@@ -53,6 +53,7 @@ public class GenomicsDBBatch implements Batch, JsonFileExtensions {
     setSchemaOptions(options, schema);
   }
 
+  @SuppressWarnings("deprecation")
   private void setSchemaOptions(CaseInsensitiveStringMap options, StructType schema)
       throws RuntimeException {
 
@@ -66,7 +67,7 @@ public class GenomicsDBBatch implements Batch, JsonFileExtensions {
       finalSchema = GenomicsDBSchemaFactory.defaultSchema();
     }
 
-    Long blocksize = new Long(1);
+    Long blocksize = Long.valueOf(1);
     Long maxblock = Long.MAX_VALUE;
     if (options.get("genomicsdb.minqueryblocksize") != null){
       blocksize = Long.valueOf(options.get("genomicsdb.minqueryblocksize"));

--- a/src/test/java/org/genomicsdb/GenomicsDBUtilsTest.java
+++ b/src/test/java/org/genomicsdb/GenomicsDBUtilsTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 public class GenomicsDBUtilsTest {
+  @SuppressWarnings("deprecation")
   @Test void testGenomicsDBCreateTileDBWorkspace() throws IOException {
     File tmpDir = Files.createTempDir();
     tmpDir.deleteOnExit();

--- a/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/org/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -101,7 +101,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     public void testWriteVidMapJSONToNonexistentFolders() throws FileNotFoundException, InterruptedException {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
                 GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
-        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
+        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet<VCFHeaderLine>();
         String inputVCF = "tests/inputs/vcfs/t6.vcf.gz";
         GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport("", inputVCF, false);
         File nonExistentFolder = new File(WORKSPACE, "non-existent-folder");
@@ -116,7 +116,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     public void testWriteCallsetJSONToNonexistentFolders() throws FileNotFoundException, InterruptedException {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
                 GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
-        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
+        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet<VCFHeaderLine>();
         String inputVCF = "tests/inputs/vcfs/t6.vcf.gz";
         GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport("", inputVCF, false);
         File nonExistentFolder = new File(WORKSPACE, "non-existent-folder");
@@ -130,7 +130,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     public void testVCFHeaderToNonexistentFolders() throws FileNotFoundException, InterruptedException {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A  =
                 GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder().build();
-        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet();
+        Set<VCFHeaderLine> mergedHeader = new LinkedHashSet<VCFHeaderLine>();
         String inputVCF = "tests/inputs/vcfs/t6.vcf.gz";
         GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport("", inputVCF, false);
         File nonExistentFolder = new File(WORKSPACE, "non-existent-folder");
@@ -216,6 +216,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     }
 
     @Test(testName = "should run parallel import with multiple chromosome intervals and one GVCF")
+    @SuppressWarnings("unchecked")
     public void testShouldRunParallelImportWithMultipleChromosomeIntervalsAndOneGvcf() throws IOException, InterruptedException {
         //Given
         String inputVCF = "tests/inputs/vcfs/t0.vcf.gz";
@@ -265,6 +266,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     }
 
     @Test(testName = "should be able to query using specific array name")
+    @SuppressWarnings("unchecked")
     public void testShouldBeAbleToQueryUsingSpecificArrayName() throws IOException, InterruptedException {
         //Given
         String inputVCF = "tests/inputs/vcfs/t0.vcf.gz";
@@ -296,6 +298,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     }
 
     @Test(testName = "should be able to query using specific chromosome interval")
+    @SuppressWarnings("unchecked")
     public void testShouldBeAbleToQueryUsingSpecificChromosomeInterval() throws IOException, InterruptedException {
         //Given
         String inputVCF = "tests/inputs/vcfs/t0.vcf.gz";
@@ -330,6 +333,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     @Test(testName = "genomicsdb incremental import check jsons and query",
             dataProvider = "vcfFiles",
             dataProviderClass = GenomicsDBTestUtils.class)
+    @SuppressWarnings("unchecked")
     public void testIncrementalImportJsonAndQuery(Map<String, FeatureReader<VariantContext>> sampleToReaderMap)
             throws IOException, InterruptedException {
         // get a subset of the map for initial import
@@ -410,6 +414,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     @Test(testName = "genomicsdb incremental import batch size",
             dataProvider = "vcfFiles",
             dataProviderClass = GenomicsDBTestUtils.class)
+    @SuppressWarnings("unchecked")
     public void testIncrementalImportBatchSize(Map<String, FeatureReader<VariantContext>> sampleToReaderMap)
             throws IOException, InterruptedException {
         // get a subset of the map for initial import
@@ -493,6 +498,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
     @Test(testName = "genomicsdb multiple incremental imports",
             dataProvider = "vcfFiles",
             dataProviderClass = GenomicsDBTestUtils.class)
+    @SuppressWarnings("unchecked")
     public void testMultipleIncrementalImport(Map<String, FeatureReader<VariantContext>> sampleToReaderMap)
             throws IOException, InterruptedException {
         String inputVCF = "tests/inputs/vcfs/t6.vcf.gz";
@@ -547,6 +553,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions, VidMa
             dataProvider = "vcfFiles",
             dataProviderClass = GenomicsDBTestUtils.class,
             expectedExceptions = GenomicsDBException.class)
+    @SuppressWarnings("unchecked")
     public void testIncrementalImportSameSample(Map<String, FeatureReader<VariantContext>> sampleToReaderMap)
             throws IOException, InterruptedException {
         String inputVCF = "tests/inputs/vcfs/t6.vcf.gz";

--- a/src/test/java/org/genomicsdb/model/ImportConfigSpec.java
+++ b/src/test/java/org/genomicsdb/model/ImportConfigSpec.java
@@ -62,7 +62,7 @@ public class ImportConfigSpec {
         boolean validateSampleToReaderMap = true;
         boolean passAsVcf = true;
         int batchSize = 1000;
-        Set<VCFHeaderLine> mergedHeader = new HashSet();
+        Set<VCFHeaderLine> mergedHeader = new HashSet<VCFHeaderLine>();
         Map<String, URI> sampleNameToVcfPath = new TreeMap<>();
         ImportConfig.Func<Map<String, URI>, Integer, Integer,
                 Map<String, FeatureReader<VariantContext>>> sampleToReaderMap = (a, b, c) -> new TreeMap<>();

--- a/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
+++ b/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
@@ -144,6 +144,22 @@ public class GenomicsDBQueryTest {
   }
 
   @Test
+  void TestQueryGuardantWorkspace() {
+    long startTime = System.nanoTime();
+
+    GenomicsDBQuery query = new GenomicsDBQuery();
+    long genomicsDBHandle = query.connectJSON("/Users/nalini/GenomicsDB/build/perf_query.json");
+    List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, "allcontigs$1$3095677412");
+
+    for (Interval interval: intervals) {
+      System.out.println("Number of calls in intervals" + interval.calls.size());
+    }
+
+    long endTime = System.nanoTime();
+    System.out.println("Duration in seconds="+(endTime - startTime)/1000000000);  //divide by 1000000 to get milliseconds.
+  }
+
+  @Test
   void testGenomicsDBBasicConnectDisconnect() throws GenomicsDBException {
     GenomicsDBQuery query = new GenomicsDBQuery();
     long genomicsDBHandle = connect();

--- a/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
+++ b/src/test/java/org/genomicsdb/reader/GenomicsDBQueryTest.java
@@ -144,22 +144,6 @@ public class GenomicsDBQueryTest {
   }
 
   @Test
-  void TestQueryGuardantWorkspace() {
-    long startTime = System.nanoTime();
-
-    GenomicsDBQuery query = new GenomicsDBQuery();
-    long genomicsDBHandle = query.connectJSON("/Users/nalini/GenomicsDB/build/perf_query.json");
-    List<Interval> intervals = query.queryVariantCalls(genomicsDBHandle, "allcontigs$1$3095677412");
-
-    for (Interval interval: intervals) {
-      System.out.println("Number of calls in intervals" + interval.calls.size());
-    }
-
-    long endTime = System.nanoTime();
-    System.out.println("Duration in seconds="+(endTime - startTime)/1000000000);  //divide by 1000000 to get milliseconds.
-  }
-
-  @Test
   void testGenomicsDBBasicConnectDisconnect() throws GenomicsDBException {
     GenomicsDBQuery query = new GenomicsDBQuery();
     long genomicsDBHandle = connect();

--- a/src/test/java/org/genomicsdb/spark/GenomicsDBInputFormatTest.java
+++ b/src/test/java/org/genomicsdb/spark/GenomicsDBInputFormatTest.java
@@ -45,6 +45,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Testcase0 for creating InputSplits",
       dataProvider = "loaderQueryHostFilesTest0",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testGetSplits0(String queryPath, String loaderPath, String hostPath) 
               throws IOException, FileNotFoundException, InterruptedException{
     Job job = Job.getInstance();
@@ -77,6 +78,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Test each query maps to same partition, no split",
       dataProvider = "loaderQueryHostFilesTest1",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testAllQueriesMapsToSamePartitionNoSplit(String queryPath, String loaderPath, String hostPath) 
               throws IOException, FileNotFoundException, InterruptedException{
     Job job = Job.getInstance();
@@ -107,6 +109,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Test single query splits up by query block over single partition",
       dataProvider = "loaderQueryHostFilesTest2",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testQuerySplitUpSinglePartition(String queryPath, String loaderPath, String hostPath) 
               throws IOException, FileNotFoundException, InterruptedException {
     Job job = Job.getInstance();
@@ -154,6 +157,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Test local filesystem splits same as hdfs-compliant",
       dataProvider = "loaderQueryHostFilesTest3",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testGetSplits3(String queryPath, String loaderPath, String hostPath) 
               throws IOException, FileNotFoundException, InterruptedException {
     Job job = Job.getInstance();
@@ -182,6 +186,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Test query larger than partitions",
       dataProvider = "loaderQueryHostFilesTest4",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testQueryLargerThanPartitions(String queryPath, 
               String loaderPath, String hostPath) 
               throws IOException, FileNotFoundException, InterruptedException {
@@ -213,6 +218,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Testcase5 for creating InputSplits",
       dataProvider = "loaderQueryHostFilesTest5",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testGetSplits4(String queryPath, String loaderPath, String hostPath) 
               throws IOException, FileNotFoundException, InterruptedException{
     Job job = Job.getInstance();
@@ -261,6 +267,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Test query larger than query block size",
       dataProvider = "loaderQueryHostFilesTest6",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testQueryLargerThanQueryBlockSize(String queryPath, 
               String loaderPath, String hostPath) 
               throws IOException, FileNotFoundException, InterruptedException {
@@ -286,6 +293,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Test loader and query are protobuf",
       dataProvider = "loaderQueryPB7",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testLoaderPB(String loader, 
               String query) 
               throws IOException, FileNotFoundException, InterruptedException {
@@ -302,6 +310,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Test loader not specified",
       expectedExceptions = RuntimeException.class,
       expectedExceptionsMessageRegExp = "Must specify either.*")
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testLoaderNotSpecified() {
     Map<String, String> options = new HashMap<String, String>();
     options.put(GenomicsDBConfiguration.QUERYJSON, "fakequeryfile");
@@ -311,6 +320,7 @@ public class GenomicsDBInputFormatTest {
   @Test(testName = "Test assert on malformed protobuf",
       dataProvider = "loaderQueryPB7",
       dataProviderClass = GenomicsDBTestUtils.class)
+  @SuppressWarnings({"unchecked", "deprecation"})
   public void testMalformedLoaderProtobuf(String loader, 
               String query) 
               throws IOException, FileNotFoundException, InterruptedException {

--- a/src/test/java/org/genomicsdb/spark/GenomicsDBQueryInputFormatTest.java
+++ b/src/test/java/org/genomicsdb/spark/GenomicsDBQueryInputFormatTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 public class GenomicsDBQueryInputFormatTest {
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testBasicQueryFormatClass() throws IOException, InterruptedException {
     GenomicsDBQueryInputFormat inputFormat = new GenomicsDBQueryInputFormat();
     Assert.assertNull(inputFormat.getConf());
@@ -84,6 +85,7 @@ public class GenomicsDBQueryInputFormatTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testBasicInputSplitsNonExistentQueryJSON() throws IOException, InterruptedException{
     final GenomicsDBConfiguration tryConfiguration = new GenomicsDBConfiguration();
     tryConfiguration.set(GenomicsDBConfiguration.QUERYJSON, "xxx");


### PR DESCRIPTION
- Remove incompatible log4j between surefire plugins and the one GenomicsDB uses. 
- Cleaned up and suppressed unchecked and deprecation warnings, to figure out real mvn issues more easily.
- `brew install lcov` installs the new 2.0 which breaks a lot of our code. Need to wait for this 2.x version to be hardened a little before we fix the errors with changes in our source code and/or invoke `lcov` with additional `--ignore-errors` arguments. The scripts for macOS now explicitly install version `1.16` for non-breaking macOS builds.