### PR TITLE
Refactor create_genomicsdb_workspace to handle error messages and fit the pattern of the other tools

### DIFF
--- a/.github/scripts/test_hdfs_htslib_support.sh
+++ b/.github/scripts/test_hdfs_htslib_support.sh
@@ -27,7 +27,7 @@ set -e
 # Name Node is $1 - optional
 # hdfs path is $2 - optional
 
-NAME_NODE=${1:-"hdfs://localhost:9000/"}
+NAME_NODE=${1:-"hdfs://localhost:9000"}
 HDFS_PATH=${2:-"/home/hadoop/input/vcfs"}
 
 VCF_DIRS=$GITHUB_WORKSPACE/tests/inputs/vcfs

--- a/.github/scripts/test_hdfs_htslib_support.sh
+++ b/.github/scripts/test_hdfs_htslib_support.sh
@@ -1,6 +1,7 @@
 #
 # The MIT License (MIT)
 # Copyright (c) 2020 Omics Data Automation, Inc.
+# Copyright (c) 2023 dātma, inc™
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/src/main/cpp/src/vcf/htslib_fs_adapter.cc
+++ b/src/main/cpp/src/vcf/htslib_fs_adapter.cc
@@ -118,7 +118,7 @@ ssize_t genomicsdb_filesystem_read(void *context, const char *filename, off_t of
 
 ssize_t genomicsdb_filesystem_write(void *context, const char *filename, const void *buffer, size_t nbytes) {
   if (write_file(reinterpret_cast<TileDB_CTX *>(context), filename, buffer, nbytes)) {
-    logger.error("hts_plugin read {} error {}", filename, tiledb_errmsg[0]?tiledb_errmsg:"");
+    logger.error("hts_plugin write {} error {}", filename, tiledb_errmsg[0]?tiledb_errmsg:"");
     return -1;
   } else {
     return nbytes;

--- a/src/main/cpp/src/vcf/htslib_fs_adapter.cc
+++ b/src/main/cpp/src/vcf/htslib_fs_adapter.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2020-2021 Omics Data Automation, Inc.
+ * Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/tests/test_hfile_plugin.sh
+++ b/tests/test_hfile_plugin.sh
@@ -152,7 +152,7 @@ echo $1/t2.vcf.gz >> $SAMPLE_LIST
 echo "cat sample.list"
 cat $SAMPLE_LIST
 
-if $1 == hdfs://*; then
+if [[ $1 == "hdfs://*" ]]; then
   echo "Processing hadoop"
   check_rc `vcf2genomicsdb_init -w $WORKSPACE -o -S $1 -t $TEMPLATE_LOADER_JSON`
 else

--- a/tests/test_hfile_plugin.sh
+++ b/tests/test_hfile_plugin.sh
@@ -152,7 +152,7 @@ echo $1/t2.vcf.gz >> $SAMPLE_LIST
 echo "cat sample.list"
 cat $SAMPLE_LIST
 
-if [[ $1 == "hdfs://*" ]]; then
+if [[ $1 == hdfs://* ]]; then
   echo "Processing hadoop"
   check_rc `vcf2genomicsdb_init -w $WORKSPACE -o -S $1 -t $TEMPLATE_LOADER_JSON`
 else

--- a/tests/test_hfile_plugin.sh
+++ b/tests/test_hfile_plugin.sh
@@ -2,6 +2,7 @@
 #
 # The MIT License (MIT)
 # Copyright (c) 2020 Omics Data Automation Inc.
+# Copyright (c) 2023 dātma, inc™
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/tests/test_hfile_plugin.sh
+++ b/tests/test_hfile_plugin.sh
@@ -152,10 +152,11 @@ echo $1/t2.vcf.gz >> $SAMPLE_LIST
 echo "cat sample.list"
 cat $SAMPLE_LIST
 
-if [[ $1 == hdfs://* ]]; then
-  echo "Processing hadoop"
+if [[ $1 == *//* ]]; then
+  echo "Processing from samples dir $1"
   check_rc `vcf2genomicsdb_init -w $WORKSPACE -o -S $1 -t $TEMPLATE_LOADER_JSON`
 else
+  echo "Processing from sample list"
   check_rc `vcf2genomicsdb_init -w $WORKSPACE -o -s $SAMPLE_LIST -t $TEMPLATE_LOADER_JSON`
 fi
 
@@ -168,5 +169,4 @@ if [[ $ACTUAL_FILESIZE_NEW/10 -ne $ACTUAL_FILESIZE/10 ]]; then
   die "vcf2genomicsdb with vcf2genomicsdb_init did not generate the expected vcf"
 fi
 
-echo $TEMP_DIR
 cleanup

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -45,7 +45,11 @@ else
 fi
 
 VCFS_DIR=$(cd $1 && pwd)
-TEMP_DIR=$(mktemp -d -t test_tools-XXXXXXXXXX)
+if [[ $(uname) == "Darwin" ]]; then
+  TEMP_DIR=$(mktemp -d -t test_tools-GenomicsDB)
+else
+  TEMP_DIR=$(mktemp -d -t test_tools-GenomicsDB-XXXXXXXXXX)
+fi
 
 WORKSPACE=$TEMP_DIR/ws
 
@@ -229,12 +233,18 @@ OK=0
 ERR=1
 
 # Sanity Checks for Tools
+sanity_check "create_genomicsdb_workspace"
 sanity_check "vcf2genomicsdb_init"
 sanity_check "vcf2genomicsdb"
 sanity_check "consolidate_genomicsdb_array"
 if [[ $DISABLE_MPI == 0 ]]; then
   sanity_check "gt_mpi_gather"
 fi
+
+run_command "create_genomicsdb_workspace" ERR
+run_command "create_genomicsdb_workspace $WORKSPACE" OK
+run_command "create_genomicsdb_workspace $WORKSPACE/nested_ws" ERR
+run_command "create_gemomicsdb_workspace non-existent-dir/ws" ERR
 
 WORKSPACE=$TEMP_DIR/ws_$RANDOM
 run_command "vcf2genomicsdb_init -w $WORKSPACE" ERR

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -243,6 +243,9 @@ fi
 
 run_command "create_genomicsdb_workspace" ERR
 run_command "create_genomicsdb_workspace $WORKSPACE" OK
+# Should be OK with a logged message that the workspace already exists
+# and is unchanged
+run_command "create_genomicsdb_workspace $WORKSPACE" OK
 run_command "create_genomicsdb_workspace $WORKSPACE/nested_ws" ERR
 run_command "create_gemomicsdb_workspace non-existent-dir/ws" ERR
 

--- a/tools/include/common.h
+++ b/tools/include/common.h
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2021 Omics Data Automation, Inc.
+ * Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/tools/include/common.h
+++ b/tools/include/common.h
@@ -26,7 +26,16 @@
 #include "genomicsdb_logger.h"
 #include "tiledb_utils.h"
 
+#include <getopt.h>
+
 #define OK   0
 #define ERR -1
+
+enum GenomicsDBArgsEnum {
+  VERSION=1000,
+};
+
+#define LOG_TILEDB_ERRMSG if (strnlen(tiledb_errmsg, TILEDB_ERRMSG_MAX_LEN) > 0) \
+                            g_logger.error("{}", tiledb_errmsg)
 
 #endif /* GENOMICSDB_TOOLS_COMMON_H */

--- a/tools/src/consolidate_genomicsdb_array.cc
+++ b/tools/src/consolidate_genomicsdb_array.cc
@@ -2,6 +2,7 @@
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
  * Copyright (c) 2022 Omics Data Automation, Inc.
+ * Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/tools/src/consolidate_genomicsdb_array.cc
+++ b/tools/src/consolidate_genomicsdb_array.cc
@@ -31,10 +31,6 @@
 
 static Logger g_logger(Logger::get_logger("consolidate_genomicsdb_array"));
 
-enum GenomicsDBArgsEnum {
-  VERSION=1000,
-};
-
 void print_usage() {
   std::cerr << "Usage: consolidate_genomicsdb_array [options]\n"
             << "where options include:\n"

--- a/tools/src/create_genomicsdb_workspace.cc
+++ b/tools/src/create_genomicsdb_workspace.cc
@@ -39,11 +39,6 @@ void print_usage() {
       }
 
 int main(int argc, char** argv) {
-  if (argc < 2) {
-    print_usage();
-    return ERR;
-  }
-
   static struct option long_options[] = {
     {"help",                       0, 0, 'h'},
     {"version",                    0, 0, VERSION},
@@ -67,7 +62,8 @@ int main(int argc, char** argv) {
   }
 
   if (optind >= argc) {
-    g_logger.error("Workspace directory required to be specified");
+    g_logger.error("Workspace directory required to be specified. See usage");
+    print_usage();
     return ERR;
   }
 

--- a/tools/src/create_genomicsdb_workspace.cc
+++ b/tools/src/create_genomicsdb_workspace.cc
@@ -1,6 +1,7 @@
 /**
  * The MIT License (MIT)
  * Copyright (c) 2016-2017 Intel Corporation
+ * Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/tools/src/vcf2genomicsdb.cc
+++ b/tools/src/vcf2genomicsdb.cc
@@ -26,8 +26,6 @@
 #include "tiledb_loader.h"
 #include "vcf2binary.h"
 
-#include <getopt.h>
-
 #ifdef USE_GPERFTOOLS
 #include "gperftools/profiler.h"
 #endif

--- a/tools/src/vcf2genomicsdb_init.cc
+++ b/tools/src/vcf2genomicsdb_init.cc
@@ -693,11 +693,13 @@ std::set<std::string> process_samples(const std::string& sample_list, const std:
     return samples;
   }
 
-  // TileDB returns only the path for cloud URIs, so get container/bucket prefix and query suffix
+  // TODO: This part is hacky now and should be handled by TileDB. Currently, it returns only the path for
+  // cloud URIs, but the entire URI for hdfs for TileDBUtils::get_files. Get container/bucket prefix and
+  // query suffix to reconstruct filename!
   std::string suffix;
   auto pos = samples_dir.find('?');
   if (pos != std::string::npos) {
-    suffix = samples_dir.substr(pos+1);
+    suffix = samples_dir.substr(pos);
   } else {
     pos = samples_dir.length();
   }
@@ -716,7 +718,9 @@ std::set<std::string> process_samples(const std::string& sample_list, const std:
     g_logger.info("sample_file from TileDB: {}", sample_file);
     std::regex pattern("^.*(.vcf.gz$|.bcf.gz$)");
     if (std::regex_search(sample_file, pattern)) {
-      sample_file = prefix+sample_file+suffix;
+      if (sample_file.find("hdfs://") == std::string::npos) { 
+        sample_file = prefix+sample_file+suffix;
+      }
       g_logger.info("sample_file after processing: {}", sample_file);
       samples.insert(sample_file);
     }

--- a/tools/src/vcf2genomicsdb_init.cc
+++ b/tools/src/vcf2genomicsdb_init.cc
@@ -25,7 +25,6 @@
 #include <errno.h>
 #include <iostream>
 #include <fstream>
-#include <getopt.h>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -381,6 +380,7 @@ static int write_json(google::protobuf::Message *message, const std::vector<std:
   int status = OK;
   if (TileDBUtils::write_file(output, json.data(), json.length())) {
     g_logger.error("Could not write out json file at {}", output);
+    LOG_TILEDB_ERRMSG;
     status = ERR;
   }
   delete message;
@@ -419,6 +419,7 @@ static int generate_json(import_config_t import_config) {
     size_t template_json_length;
     if (TileDBUtils::read_entire_file(import_config.template_loader_json, (void **)&template_json_contents, &template_json_length)) {
       g_logger.error("Could not read template loader json file {}", import_config.template_loader_json);
+      LOG_TILEDB_ERRMSG;
       return ERR;
     }
     google::protobuf::StringPiece template_json_string(template_json_contents, template_json_length);
@@ -506,18 +507,29 @@ static int generate_json(import_config_t import_config) {
     google::protobuf::util::MessageToJsonString(*vidmap_pb, &json, json_options);
     g_logger.debug("Writing out vidmap json file to {}", vidmap_output);
     fix_protobuf_generated_json_for_int64(json, {"tiledb_column_offset", "length"});
-    TileDBUtils::write_file(vidmap_output, json.data(), json.length());
-    delete vidmap_pb;
+    rc = TileDBUtils::write_file(vidmap_output, json.data(), json.length());
+    if (rc) {
+      g_logger.error("Error writing out vidmap json file to {}", vidmap_output);
+      LOG_TILEDB_ERRMSG;
+    }
 
     // Write out loader.json
-    json.clear();
-    google::protobuf::util::MessageToJsonString(*import_config_protobuf, &json, json_options);
-    g_logger.debug("Writing out loader json file to {}", loader_output);
-    fix_protobuf_generated_json_for_int64(json, {"tiledb_column", "size_per_column_partition", "segment_size",
-	  "num_cells_per_tile"});
-    rc = TileDBUtils::write_file(loader_output, json.data(), json.length());
-    delete import_config_protobuf;
+    if (!rc) {
+      json.clear();
+      google::protobuf::util::MessageToJsonString(*import_config_protobuf, &json, json_options);
+      g_logger.debug("Writing out loader json file to {}", loader_output);
+      fix_protobuf_generated_json_for_int64(json, {"tiledb_column", "size_per_column_partition", "segment_size",
+          "num_cells_per_tile"});
+      rc = TileDBUtils::write_file(loader_output, json.data(), json.length());
+      if (rc) {
+        g_logger.error("Error writing out loader json file to {}", loader_output);
+        LOG_TILEDB_ERRMSG;
+      }
+    }
   }
+
+  delete vidmap_pb;
+  delete import_config_protobuf;
 
   return rc;
 }
@@ -526,15 +538,18 @@ static int rename_file(const std::string& src, const std::string& dest) {
   if (TileDBUtils::is_file(dest)) {
     if (TileDBUtils::delete_file(dest)) {
       g_logger.error("Could not delete existing file at path {} for renaming {}", dest, src);
+      LOG_TILEDB_ERRMSG;
       return ERR;
     }
   }
   if (TileDBUtils::move_across_filesystems(src, dest)) {
-     g_logger.error("Could not rename file {} to {}", src, dest);
-     return ERR;
+    g_logger.error("Could not rename file {} to {}", src, dest);
+    LOG_TILEDB_ERRMSG;
+    return ERR;
   }
   if (TileDBUtils::delete_file(src)) {
     g_logger.error("Could not delete {} after copying to {}", src, dest);
+    LOG_TILEDB_ERRMSG;
     return ERR;
   }
   return OK;
@@ -545,6 +560,7 @@ static int update_json(import_config_t import_config) {
   size_t callset_length;
   if (TileDBUtils::read_entire_file(import_config.callset_output, (void **)&callset_contents, &callset_length)) {
     g_logger.error("Could not read callset json file {}", import_config.callset_output);
+    LOG_TILEDB_ERRMSG;
     return ERR;
   }
   google::protobuf::StringPiece callset_string(callset_contents, callset_length);
@@ -607,6 +623,7 @@ static int update_json(import_config_t import_config) {
     size_t loader_json_length;
     if (TileDBUtils::read_entire_file(import_config.loader_json, (void **)&loader_json_contents, &loader_json_length)) {
       g_logger.error("Could not read loader json file {}", import_config.loader_json);
+      LOG_TILEDB_ERRMSG;
       return ERR;
     }
     google::protobuf::StringPiece loader_json_string(loader_json_contents, loader_json_length);
@@ -677,17 +694,21 @@ std::set<std::string> process_samples(const std::string& sample_list, const std:
   }
 
   // TileDB returns only the path for cloud URIs, so get container/bucket prefix
-  std::regex uri_pattern("(.*//)(.*?/)(.*$)");
+  std::regex uri_pattern("(.*//.*?/)(.*)(\\?.*$)", std::regex_constants::ECMAScript);
   std::string prefix;
+  std::string suffix;
   if (std::regex_search(samples_dir, uri_pattern)) {
-    prefix = std::regex_replace(samples_dir, uri_pattern, "$1$2");
+    prefix = std::regex_replace(samples_dir, uri_pattern, "$1");
+    suffix = std::regex_replace(samples_dir, uri_pattern, "$3");
   }
+
+  g_logger.debug("URI {} has been parsed to prefix={} suffix={}", samples_dir, prefix, suffix);
 
   std::vector<std::string> sample_files = TileDBUtils::get_files(samples_dir); 
   for (auto sample_file: sample_files) {
     std::regex pattern(".*(.vcf.gz$|.bcf.gz$)");
     if (std::regex_search(sample_file, pattern)) {
-      samples.insert(TileDBUtils::real_dir(prefix+sample_file));
+      samples.insert(TileDBUtils::real_dir(prefix+sample_file+suffix));
     }
   }
 
@@ -795,10 +816,6 @@ static void process_include_fields(std::set<std::string>& fields, const std::str
     fields.insert(it->str());
   }
 }
-
-enum GenomicsDBArgsEnum {
-  VERSION=1000,
-};
 
 void print_usage() {
   std::cerr << "Usage: vcf2genomicsdb_init [options]\n"
@@ -969,11 +986,13 @@ int main(int argc, char** argv) {
 
   if (!sample_list.empty() && !TileDBUtils::is_file(sample_list)) {
     g_logger.error("Sample list {} specified with --sample-list/-s option cannot be accessed", sample_list);
+    LOG_TILEDB_ERRMSG;
     return ERR;
   }
 
   if (!samples_dir.empty() && !TileDBUtils::is_dir(samples_dir)) {
     g_logger.error("Samples dir {} specified with --samples-dir/-S option cannot be accessed", samples_dir);
+    LOG_TILEDB_ERRMSG;
     return ERR;
   }
 
@@ -991,6 +1010,7 @@ int main(int argc, char** argv) {
     if (generate) {
       if (TileDBUtils::create_workspace(workspace, overwrite_workspace) != TILEDB_OK) {
         g_logger.error("Could not create workspace {}", workspace);
+        LOG_TILEDB_ERRMSG;
         return ERR;
       }
     }
@@ -1018,7 +1038,7 @@ int main(int argc, char** argv) {
     google::protobuf::ShutdownProtobufLibrary();
 
   } catch(const GenomicsDBConfigException& genomicsdb_ex) {
-    g_logger.error(genomicsdb_ex.what());
+    g_logger.error("GenomicsDBConfigException: {}", genomicsdb_ex.what());
     return ERR;
   } catch (const std::exception& ex) {
     g_logger.error(ex.what());

--- a/tools/src/vcf2genomicsdb_init.cc
+++ b/tools/src/vcf2genomicsdb_init.cc
@@ -710,13 +710,14 @@ std::set<std::string> process_samples(const std::string& sample_list, const std:
 
   g_logger.info("URI {} has been parsed to prefix={} suffix={}", samples_dir, prefix, suffix);
 
-  std::vector<std::string> sample_files = TileDBUtils::get_files(samples_dir); 
+  std::vector<std::string> sample_files = TileDBUtils::get_files(samples_dir);
+  g_logger.info("Found {} sample_files at {}", sample_files.size(), samples_dir);
   for (auto sample_file: sample_files) {
-    std::cout << "original sample_file: " << sample_file << std::endl;
+    g_logger.info("sample_file from TileDB: {}", sample_file);
     std::regex pattern("^.*(.vcf.gz$|.bcf.gz$)");
     if (std::regex_search(sample_file, pattern)) {
       sample_file = prefix+sample_file+suffix;
-      std::cout << "sample_file: " << sample_file << std::endl;
+      g_logger.info("sample_file after processing: {}", sample_file);
       samples.insert(sample_file);
     }
   }


### PR DESCRIPTION
[Techincal Debt] to help diagnose issues earlier in our pipelines. Refactored a little to move common code from other tools to `common.h` and are logging all tiledb related error message as much as we can. In the process, had to modify the parsing to accommodate `azb://` URIs in `vcf2genomicsdb_init`. This parsing is already in the TileDB layer and both `TileDBUtils::get_dirs()` and `TileDBUtils::get_files()` should return URIs. See https://github.com/datma-health/TileDB/issues/159. Also, see related issue - https://github.com/datma-health/TileDB/issues/158.  