### PR TITLE
Use genomicsdb::version instead of deprecated genomicsdb_version()

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -32,9 +32,6 @@ jobs:
         type: [basic]
         java: [17]
         include:
-          - os: ubuntu-20.04
-            type: hdfs
-            java: 17
           - os: ubuntu-22.04
             type: hdfs
             java: 17

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -49,9 +49,6 @@
 #include <vector>
 #include <functional>
 
-[[deprecated("Use genomicsdb::version instead")]]
-GENOMICSDB_EXPORT std::string genomicsdb_version();
-
 typedef std::pair<uint64_t, uint64_t> interval_t;
 
 typedef struct genomic_interval_t {

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -6,6 +6,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019-2020,2022 Omics Data Automation, Inc.
+ * Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -63,10 +64,6 @@
 #define TO_GENOMICSDB_VARIANT_VECTOR(X) (reinterpret_cast<std::vector<genomicsdb_variant_t> *>(static_cast<void *>(X)))
 #define TO_GENOMICSDB_VARIANT_CALL_VECTOR(X) (reinterpret_cast<std::vector<genomicsdb_variant_call_t> *>(static_cast<void *>(X)))
 
-
-std::string genomicsdb_version() {
-  return genomicsdb::version();
-}
 
 #define VERIFY(X) if(!(X)) throw GenomicsDBException(#X);
 

--- a/src/main/jni/src/genomicsdb_GenomicsDBQuery.cc
+++ b/src/main/jni/src/genomicsdb_GenomicsDBQuery.cc
@@ -1,5 +1,5 @@
-/**
- * The MIT License (MIT)
+  /**
+   * The MIT License (MIT)
  * Copyright (c) 2019-2020,2022 Omics Data Automation, Inc.
  * Copyright (c) 2023 dātma, inc™
  *
@@ -208,7 +208,7 @@ void handleJNIException(JNIEnv *env, GenomicsDBException& exception) {
 
 JNIEXPORT jstring JNICALL
 Java_org_genomicsdb_reader_GenomicsDBQuery_jniVersion(JNIEnv *env, jclass cls) {
-  return env->NewStringUTF(genomicsdb_version().c_str());
+  return env->NewStringUTF(genomicsdb::version().c_str());
 }
 
 JNIEXPORT jlong JNICALL

--- a/src/main/jni/src/genomicsdb_GenomicsDBQuery.cc
+++ b/src/main/jni/src/genomicsdb_GenomicsDBQuery.cc
@@ -1,5 +1,5 @@
-  /**
-   * The MIT License (MIT)
+/**
+ * The MIT License (MIT)
  * Copyright (c) 2019-2020,2022 Omics Data Automation, Inc.
  * Copyright (c) 2023 dātma, inc™
  *

--- a/src/main/jni/src/genomicsdb_GenomicsDBUtils.cc
+++ b/src/main/jni/src/genomicsdb_GenomicsDBUtils.cc
@@ -2,6 +2,7 @@
  * The MIT License (MIT)
  * Copyright (c) 2018 Omics Data Automation Inc. and Intel Corporation
  * Copyright (c) 2021 Omics Data Automation Inc.
+ * Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of 
  * this software and associated documentation files (the "Software"), to deal in 
@@ -33,7 +34,7 @@
 
 JNIEXPORT jstring JNICALL
 Java_org_genomicsdb_GenomicsDBUtilsJni_jniLibraryVersion(JNIEnv *env, jclass cls) {
-  return env->NewStringUTF(genomicsdb_version().c_str());
+  return env->NewStringUTF(genomicsdb::version().c_str());
 }
 
 JNIEXPORT jint JNICALL 

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -64,11 +64,6 @@ TEST_CASE_METHOD(TempDir, "utils", "[genomicsdb_utils]") {
   CHECK(genomicsdb::read_entire_file(filename+".another", (void **)txt, &length) == TILEDB_ERR);
 }
 
-TEST_CASE("api get_version", "[get_version]") {
-  REQUIRE(genomicsdb_version().size() > 0);
-  REQUIRE_THAT(genomicsdb_version(), Catch::Equals(GENOMICSDB_VERSION));
-}
-
 TEST_CASE("api empty_args", "[empty_args]") {
   std::string empty_string;
 


### PR DESCRIPTION
Removed the already deprecated `genomicsdb_version()` from the api, we now rely only on genomicsdb::version().
Also, restricted testing of spark-hdfs to ubuntu 22.04 in GitHub workflows.