### PR TITLE
Support JSON output from genomicsdb api query_variant_calls()

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -69,6 +69,7 @@ set(GenomicsDB_library_sources
     cpp/src/api/genomicsdb_field.cc
     cpp/src/api/genomicsdb_plink.cc
     cpp/src/api/genomicsdb_utils.cc
+    cpp/src/api/genomicsdb_json_processor.cc
     )
 
 include_directories(${PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS})

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -268,7 +268,7 @@ class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
 
 class GENOMICSDB_EXPORT JSONVariantCallProcessor : public GenomicsDBVariantCallProcessor {
  public:
-  enum payload_t {all=0, samples_with_ncalls=1, just_ncalls=2};
+  enum payload_t {all=0, all_by_calls=1, samples_with_ncalls=2, just_ncalls=3};
   JSONVariantCallProcessor() : JSONVariantCallProcessor(all) {}
   JSONVariantCallProcessor(payload_t payload_mode);
   ~JSONVariantCallProcessor();
@@ -278,15 +278,18 @@ class GENOMICSDB_EXPORT JSONVariantCallProcessor : public GenomicsDBVariantCallP
                const int64_t* coordinates,
                const genomic_interval_t& genomic_interval,
                const std::vector<genomic_field_t>& genomic_fields);
-  const char *construct_json_output();
+  std::string construct_json_output();
  private:
   payload_t m_payload_mode;
   bool m_is_initialized = false;
   void *m_json_document;
-  void *m_json_buffer;
+  // payload num_calls
   int64_t m_num_calls = 0ul;
+  // payload samples_with_ncalls
+  std::unique_ptr<std::map<std::string, int64_t>> m_samples;
+  // payload all
   std::vector<std::string> m_field_names;
-  std::map<std::string, std::vector<void *>> m_sample_info;
+  std::unique_ptr<std::map<std::string, std::vector<void *>>> m_samples_info;
 };
 
 class GENOMICSDB_EXPORT GenomicsDBVariantProcessor {

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -284,7 +284,7 @@ class GENOMICSDB_EXPORT JSONVariantCallProcessor : public GenomicsDBVariantCallP
   bool m_is_initialized = false;
   void *m_json_document;
   void *m_json_buffer;
-  size_t m_num_calls = 0ul;
+  int64_t m_num_calls = 0ul;
   std::vector<std::string> m_field_names;
   std::map<std::string, std::vector<void *>> m_sample_info;
 };

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -256,6 +256,7 @@ class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
       throw GenomicsDBException("Genomic Field="+name+" does not seem to have an associated type");
     }
   }
+  const std::string resolve_gt(const std::vector<genomic_field_t>& genomic_fields) const;
   virtual void process(const interval_t& interval);
   virtual void process(const std::string& sample_name,
                        const int64_t* coordinates,
@@ -263,6 +264,29 @@ class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
                        const std::vector<genomic_field_t>& genomic_fields);
  private:
   std::shared_ptr<std::map<std::string, genomic_field_type_t>> m_genomic_field_types;
+};
+
+class GENOMICSDB_EXPORT JSONVariantCallProcessor : public GenomicsDBVariantCallProcessor {
+ public:
+  enum payload_t {all=0, samples_with_ncalls=1, just_ncalls=2};
+  JSONVariantCallProcessor() : JSONVariantCallProcessor(all) {}
+  JSONVariantCallProcessor(payload_t payload_mode);
+  ~JSONVariantCallProcessor();
+  void set_payload_mode(payload_t payload_mode) { m_payload_mode = payload_mode; }
+  void process(const interval_t& interval);
+  void process(const std::string& sample_name,
+               const int64_t* coordinates,
+               const genomic_interval_t& genomic_interval,
+               const std::vector<genomic_field_t>& genomic_fields);
+  const char *construct_json_output();
+ private:
+  payload_t m_payload_mode;
+  bool m_is_initialized = false;
+  void *m_json_document;
+  void *m_json_buffer;
+  size_t m_num_calls = 0ul;
+  std::vector<std::string> m_field_names;
+  std::map<std::string, std::vector<void *>> m_sample_info;
 };
 
 class GENOMICSDB_EXPORT GenomicsDBVariantProcessor {

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -241,7 +241,7 @@ class VariantCall;
 class VariantQueryConfig;
 
 // Utility funtion to resolve GT w.r.t REF/ALT
-const std::string resolve_gt(const std::vector<genomic_field_t>& genomic_fields);
+GENOMICSDB_EXPORT const std::string resolve_gt(const std::vector<genomic_field_t>& genomic_fields);
 
 class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
  public:

--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -240,6 +240,9 @@ class Variant;
 class VariantCall;
 class VariantQueryConfig;
 
+// Utility funtion to resolve GT w.r.t REF/ALT
+const std::string resolve_gt(const std::vector<genomic_field_t>& genomic_fields);
+
 class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
  public:
   GenomicsDBVariantCallProcessor() {};
@@ -256,7 +259,6 @@ class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
       throw GenomicsDBException("Genomic Field="+name+" does not seem to have an associated type");
     }
   }
-  const std::string resolve_gt(const std::vector<genomic_field_t>& genomic_fields) const;
   virtual void process(const interval_t& interval);
   virtual void process(const std::string& sample_name,
                        const int64_t* coordinates,

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -784,6 +784,60 @@ void GenomicsDBResults<genomicsdb_variant_call_t>::free() {
   // NOP: free'ing is done at the Variant(genomicsdb_variant_t) level
 }
 
+#define PIPED_SEP '|'
+#define SLASHED_SEP '/'
+std::string_view get_segment(std::string_view str, int segment_pos) {
+  std::string::size_type pos;
+  std::string::size_type next_pos = -1;
+  for (int j=0; j<segment_pos; j++) {
+    pos = next_pos + 1;
+    next_pos = str.find(PIPED_SEP);
+    if (next_pos == std::string::npos) {
+      if (j != segment_pos-1) {
+        return ".";
+      } else {
+        return str.substr(pos, str.length());
+      }
+    }
+  }
+  return str.substr(pos, next_pos);
+}
+
+std::string resolve(std::vector<int32_t>& gt, std::string_view ref, std::string_view alt) {
+  std::string resolved_gt;
+  for (auto i=0ul; i<gt.size(); i++) {
+    if (i%2) { // Phase
+      if (gt[i]) resolved_gt += PIPED_SEP; else resolved_gt += SLASHED_SEP;
+    } else if (gt[i] > 0) { // ALT
+      resolved_gt += get_segment(alt, gt[i]);
+    } else if (gt[i] == 0) { // REF
+      resolved_gt += ref;
+    } else { // UNKNOWN
+      resolved_gt += ".";
+    }
+  }
+  return resolved_gt;
+}
+
+const std::string GenomicsDBVariantCallProcessor::resolve_gt(const std::vector<genomic_field_t>& genomic_fields) const {
+  std::string ref;
+  std::string alt;
+  std::vector<int32_t> gt_vec;
+  for (auto genomic_field: genomic_fields) {
+    if (genomic_field.name == "REF") {
+      ref = genomic_field.str_value();
+    } else if (genomic_field.name == "ALT") {
+      alt = genomic_field.str_value();
+    } else if (genomic_field.name == "GT") {
+      for (auto i=0u; i<genomic_field.num_elements; i++) {
+        gt_vec.push_back(genomic_field.int_value_at(i));
+      }
+    }
+  }
+  return resolve(gt_vec, ref, alt);
+}
+
+
 void GenomicsDBVariantCallProcessor::process(const std::string& sample_name,
                                              const int64_t* coords,
                                              const genomic_interval_t& genomic_interval,

--- a/src/main/cpp/src/api/genomicsdb.cc
+++ b/src/main/cpp/src/api/genomicsdb.cc
@@ -819,7 +819,7 @@ std::string resolve(std::vector<int32_t>& gt, std::string_view ref, std::string_
   return resolved_gt;
 }
 
-const std::string GenomicsDBVariantCallProcessor::resolve_gt(const std::vector<genomic_field_t>& genomic_fields) const {
+const std::string resolve_gt(const std::vector<genomic_field_t>& genomic_fields)  {
   std::string ref;
   std::string alt;
   std::vector<int32_t> gt_vec;

--- a/src/main/cpp/src/api/genomicsdb_json_processor.cc
+++ b/src/main/cpp/src/api/genomicsdb_json_processor.cc
@@ -92,7 +92,6 @@ const char *JSONVariantCallProcessor::construct_json_output() {
     }
   }
 
-  
   rapidjson::StringBuffer *buffer = reinterpret_cast<rapidjson::StringBuffer *>(m_json_buffer);
   buffer->Clear();
   rapidjson::Writer<rapidjson::StringBuffer> writer(*buffer);

--- a/src/main/cpp/src/api/genomicsdb_json_processor.cc
+++ b/src/main/cpp/src/api/genomicsdb_json_processor.cc
@@ -148,6 +148,41 @@ void JSONVariantCallProcessor::process(const interval_t& interval) {
   }
 }
 
+static rapidjson::Value get_chr_value(const genomic_interval_t& genomic_interval,
+                                      rapidjson::Document::AllocatorType& allocator) {
+  rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
+  value.SetString(genomic_interval.contig_name.c_str(),
+                  genomic_interval.contig_name.length(),
+                  allocator);
+  return value;
+}
+
+static rapidjson::Value get_value(const std::string& field_name,
+                            genomic_field_type_t field_type,
+                            const std::vector<genomic_field_t>& genomic_fields,
+                            rapidjson::Document::AllocatorType& allocator) {
+  for (auto genomic_field: genomic_fields) {
+    if (genomic_field.name.compare(field_name) == 0) {
+      if (STRING_FIELD(field_name, field_type)) {
+        std::string str;
+        if (field_name == "GT") {
+          str = resolve_gt(genomic_fields);
+        } else {
+          str = genomic_field.to_string(field_type);
+        }
+        rapidjson::Value value(rapidjson::kStringType);
+        value.SetString(str.c_str(), str.length(), allocator);
+        return value;
+      } else if (INT_FIELD(field_type)) {
+        return rapidjson::Value(genomic_field.int_value_at(0));
+      } else if (FLOAT_FIELD(field_type)) {
+        return rapidjson::Value(genomic_field.float_value_at(0));
+      }
+    }
+  }
+  return rapidjson::Value(rapidjson::kNullType);
+}
+
 void JSONVariantCallProcessor::process(const std::string& sample_name,
                                        const int64_t* coordinates,
                                        const genomic_interval_t& genomic_interval,
@@ -174,44 +209,13 @@ void JSONVariantCallProcessor::process(const std::string& sample_name,
         sample_info = m_samples_info->find(sample_name);
       }
       rapidjson::Value *fields = new rapidjson::Value(rapidjson::kArrayType);
-      rapidjson::Value chrom_value = rapidjson::Value(rapidjson::kStringType);
-      chrom_value.SetString(genomic_interval.contig_name.c_str(),
-                            genomic_interval.contig_name.length(),
-                            allocator);
-      fields->PushBack(chrom_value, allocator);
+      // CHR value
+      fields->PushBack(get_chr_value(genomic_interval, allocator).Move(), allocator);
       // POS value
       fields->PushBack(rapidjson::Value(genomic_interval.interval.first).Move(), allocator);
       for (auto field_name : m_field_names) {
         auto field_type = get_genomic_field_types()->at(field_name);
-        bool found = false;
-        for (auto genomic_field: genomic_fields) {
-          if (genomic_field.name.compare(field_name) == 0) {
-            if (STRING_FIELD(field_name, field_type)) {
-              rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
-              std::string str;
-              if (field_name == "GT") {
-                str = resolve_gt(genomic_fields);
-              } else {
-                str = genomic_field.to_string(field_type);
-              }
-              value.SetString(str.c_str(), str.length(), allocator);
-              fields->PushBack(value, allocator);
-            } else if (INT_FIELD(field_type)) {
-              fields->PushBack(rapidjson::Value(genomic_field.int_value_at(0)).Move(), allocator);
-            } else if (FLOAT_FIELD(field_type)) {
-              fields->PushBack(rapidjson::Value(genomic_field.float_value_at(0)).Move(), allocator);
-            } else {
-              std::string msg = "Genomic field type for " + field_name + " not supported";
-              throw GenomicsDBException(msg.c_str());
-            }
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          rapidjson::Value value = rapidjson::Value(rapidjson::kNullType);
-          fields->PushBack(value, allocator);
-        }
+        fields->PushBack(get_value(field_name, field_type, genomic_fields, allocator).Move(), allocator);
       }
       sample_info->second.push_back(fields);
       break;
@@ -221,8 +225,8 @@ void JSONVariantCallProcessor::process(const std::string& sample_name,
       if (sample_info == m_samples_info->end()) {
         // Create Value Arrays and add to map
         std::vector<void *> fields;
-        rapidjson::Value *chrom = new rapidjson::Value(rapidjson::kArrayType);
-        fields.push_back(chrom);
+        rapidjson::Value *chr = new rapidjson::Value(rapidjson::kArrayType);
+        fields.push_back(chr);
         rapidjson::Value *pos = new rapidjson::Value(rapidjson::kArrayType);
         fields.push_back(pos);
         for (auto field_name : m_field_names) {
@@ -234,49 +238,15 @@ void JSONVariantCallProcessor::process(const std::string& sample_name,
       }
       auto i = 0u;
       auto& fields = sample_info->second;
-      rapidjson::Value *chrom = reinterpret_cast<rapidjson::Value *>(fields[i++]);
-      rapidjson::Value chrom_value = rapidjson::Value(rapidjson::kStringType);
-      chrom_value.SetString(genomic_interval.contig_name.c_str(),
-                            genomic_interval.contig_name.length(),
-                            allocator);
-      chrom->PushBack(chrom_value, allocator);
+      rapidjson::Value *chr = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+      chr->PushBack(get_chr_value(genomic_interval, allocator).Move(), allocator);
       rapidjson::Value *pos = reinterpret_cast<rapidjson::Value *>(fields[i++]);
       pos->PushBack(rapidjson::Value(genomic_interval.interval.first).Move(), allocator);
       for (auto field_name : m_field_names) {
         auto field_type = get_genomic_field_types()->at(field_name);
-        bool found = false;
-        for (auto genomic_field: genomic_fields) {
-          if (genomic_field.name.compare(field_name) == 0) {
-            rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
-            if (STRING_FIELD(field_name, field_type)) {
-              rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
-              std::string str;
-              if (field_name == "GT") {
-                str = resolve_gt(genomic_fields);
-              } else {
-                str = genomic_field.to_string(field_type);
-              }
-              value.SetString(str.c_str(), str.length(), allocator);
-              values->PushBack(value, allocator);
-            } else if (INT_FIELD(field_type)) {
-              values->PushBack(rapidjson::Value(genomic_field.int_value_at(0)).Move(), allocator);
-            } else if (FLOAT_FIELD(field_type)) {
-              values->PushBack(rapidjson::Value(genomic_field.float_value_at(0)).Move(), allocator);
-            } else {
-              std::string msg = "Genomic field type for " + field_name + " not supported";
-              throw GenomicsDBException(msg.c_str());
-            }
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
-          rapidjson::Value value = rapidjson::Value(rapidjson::kNullType);
-          values->PushBack(value, allocator);
-        }
+        rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+        values->PushBack(get_value(field_name, field_type, genomic_fields, allocator).Move(), allocator);
       }
-      break;
     }
   }
 }

--- a/src/main/cpp/src/api/genomicsdb_json_processor.cc
+++ b/src/main/cpp/src/api/genomicsdb_json_processor.cc
@@ -1,0 +1,197 @@
+/**
+ * @file genomicsdb_json_processor.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 dātma, inc™
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * GenomicsDB json processing payloads
+ *
+ **/
+#include "genomicsdb.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/reader.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/prettywriter.h"
+
+#define TO_JSON_DOCUMENT(X) (reinterpret_cast<rapidjson::Document *>(X))
+
+#define STRING_FIELD(NAME, TYPE) (TYPE.is_string() || TYPE.is_char() || TYPE.num_elements > 1 || (NAME.compare("GT") == 0))
+#define INT_FIELD(TYPE) (TYPE.is_int())
+#define FLOAT_FIELD(TYPE) (TYPE.is_float())
+
+JSONVariantCallProcessor::JSONVariantCallProcessor(payload_t payload_mode)
+    : m_payload_mode(payload_mode) {
+  m_json_document = new rapidjson::Document();
+  TO_JSON_DOCUMENT(m_json_document)->SetArray();
+  m_json_buffer = new rapidjson::StringBuffer();
+}
+
+JSONVariantCallProcessor::~JSONVariantCallProcessor() {
+  delete reinterpret_cast<rapidjson::StringBuffer *>(m_json_buffer);
+  delete TO_JSON_DOCUMENT(m_json_document);
+}
+
+const char *JSONVariantCallProcessor::construct_json_output() {
+  rapidjson::Document *json_doc = TO_JSON_DOCUMENT(m_json_document);
+  json_doc->Clear();
+  
+  if (m_payload_mode == just_ncalls) {
+    json_doc->SetObject();
+    json_doc->AddMember("num_calls", m_num_calls, json_doc->GetAllocator());
+  } else {
+    json_doc->SetObject();
+    auto& allocator = json_doc->GetAllocator();
+    for (auto const& [sample_name, fields] : m_sample_info) {
+      auto i = 0u;
+      rapidjson::Value sample_value = rapidjson::Value(rapidjson::kObjectType);
+      rapidjson::Value sample_name_value(rapidjson::StringRef(sample_name.c_str()), allocator);
+      if (m_payload_mode == samples_with_ncalls) {
+        auto chrom_val = reinterpret_cast<rapidjson::Value *>(fields[0]);
+        json_doc->AddMember(sample_name_value, chrom_val->Size(), allocator);
+      } else {
+        rapidjson::Value field_values = rapidjson::Value(rapidjson::kObjectType);
+        field_values.AddMember("CHROM",
+                               *(reinterpret_cast<rapidjson::Value *>(fields[i++])),
+                               allocator);
+        field_values.AddMember("POS",
+                               *(reinterpret_cast<rapidjson::Value *>(fields[i++])),
+                               allocator);
+      
+        for (auto field_name : m_field_names) {
+          rapidjson::Value field_name_value(rapidjson::StringRef(field_name.c_str()), allocator);
+          field_values.AddMember(field_name_value,
+                                 *(reinterpret_cast<rapidjson::Value *>(fields[i++])),
+                                 allocator);
+        }
+        json_doc->AddMember(sample_name_value, field_values, allocator);
+      }
+    }
+  }
+
+  
+  rapidjson::StringBuffer *buffer = reinterpret_cast<rapidjson::StringBuffer *>(m_json_buffer);
+  buffer->Clear();
+  rapidjson::Writer<rapidjson::StringBuffer> writer(*buffer);
+  json_doc->Accept(writer);
+  
+  return buffer->GetString();
+}
+
+void JSONVariantCallProcessor::process(const interval_t& interval) {
+  if (!m_is_initialized) {
+    m_is_initialized = true;
+    auto& genomic_field_types = get_genomic_field_types();
+    for (auto& field_type_pair : *genomic_field_types) {
+      std::string field_name = field_type_pair.first;
+      genomic_field_type_t field_type = field_type_pair.second;
+      if (field_name.compare("END") && field_name.compare("REF") && field_name.compare("ALT")) {
+        m_field_names.push_back(field_name);
+      }
+    }
+  }
+}
+
+void JSONVariantCallProcessor::process(const std::string& sample_name,
+                                       const int64_t* coordinates,
+                                       const genomic_interval_t& genomic_interval,
+                                       const std::vector<genomic_field_t>& genomic_fields) {
+  m_num_calls++;
+  if (m_payload_mode == just_ncalls) return;
+
+  rapidjson::Document *json_doc = TO_JSON_DOCUMENT(m_json_document);
+  auto& allocator = json_doc->GetAllocator();
+  auto sample_info = m_sample_info.find(sample_name);
+  if (sample_info == m_sample_info.end()) {
+    // Create Value Arrays and add to map
+    std::vector<void *> fields;
+    rapidjson::Value *chrom = new rapidjson::Value(rapidjson::kArrayType);
+    fields.push_back(chrom);
+    if (m_payload_mode == all) {
+      rapidjson::Value *pos = new rapidjson::Value(rapidjson::kArrayType);
+      fields.push_back(pos);
+      for (auto field_name : m_field_names) {
+        rapidjson::Value *field_array = new rapidjson::Value(rapidjson::kArrayType);
+        fields.push_back(field_array);
+      }
+    }
+    m_sample_info.emplace(std::make_pair(sample_name, std::move(fields)));
+    sample_info = m_sample_info.find(sample_name);
+  }
+
+  auto i = 0u;
+  auto& fields = sample_info->second;
+
+  rapidjson::Value *chrom = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+  rapidjson::Value chrom_value = rapidjson::Value(rapidjson::kStringType);
+  chrom_value.SetString(genomic_interval.contig_name.c_str(),
+                        genomic_interval.contig_name.length(),
+                        allocator);
+  chrom->PushBack(chrom_value, allocator);
+
+  if (m_payload_mode != all) return;
+
+  rapidjson::Value *pos = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+  pos->PushBack(rapidjson::Value(genomic_interval.interval.first).Move(), allocator);
+
+  for (auto field_name : m_field_names) {
+    auto field_type = get_genomic_field_types()->at(field_name);
+    
+    bool found = false;
+    for (auto genomic_field: genomic_fields) {
+      if (genomic_field.name.compare(field_name) == 0) {
+        rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+        if (STRING_FIELD(field_name, field_type)) {
+          rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
+          std::string str;
+          if (field_name == "GT") {
+            str = resolve_gt(genomic_fields);
+          } else {
+            str = genomic_field.to_string(field_type);
+          }
+          value.SetString(str.c_str(), str.length(), allocator);
+          values->PushBack(value, allocator);
+        } else if (INT_FIELD(field_type)) {
+          values->PushBack(rapidjson::Value(genomic_field.int_value_at(0)).Move(), allocator);
+        } else if (FLOAT_FIELD(field_type)) {
+          values->PushBack(rapidjson::Value(genomic_field.float_value_at(0)).Move(), allocator);
+        } else {
+          std::string msg = "Genomic field type for " + field_name + " not supported";
+          throw GenomicsDBException(msg.c_str());
+        }
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+      rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
+      value.SetString(".", allocator);
+      values->PushBack(value, allocator);
+    }
+  }
+}

--- a/src/main/cpp/src/api/genomicsdb_json_processor.cc
+++ b/src/main/cpp/src/api/genomicsdb_json_processor.cc
@@ -47,57 +47,83 @@ JSONVariantCallProcessor::JSONVariantCallProcessor(payload_t payload_mode)
     : m_payload_mode(payload_mode) {
   m_json_document = new rapidjson::Document();
   TO_JSON_DOCUMENT(m_json_document)->SetArray();
-  m_json_buffer = new rapidjson::StringBuffer();
 }
 
 JSONVariantCallProcessor::~JSONVariantCallProcessor() {
-  delete reinterpret_cast<rapidjson::StringBuffer *>(m_json_buffer);
+  if (m_samples_info)  {
+    for (auto const& [sample_name, fields] : *m_samples_info.get()) {
+      for (auto const& fields: fields) {
+        delete reinterpret_cast<rapidjson::Value *>(fields);
+      }
+    }
+  }
   delete TO_JSON_DOCUMENT(m_json_document);
 }
 
-const char *JSONVariantCallProcessor::construct_json_output() {
+std::string JSONVariantCallProcessor::construct_json_output() {
   rapidjson::Document *json_doc = TO_JSON_DOCUMENT(m_json_document);
-  json_doc->Clear();
-  
-  if (m_payload_mode == just_ncalls) {
-    json_doc->SetObject();
-    json_doc->AddMember("num_calls", m_num_calls, json_doc->GetAllocator());
-  } else {
-    json_doc->SetObject();
-    auto& allocator = json_doc->GetAllocator();
-    for (auto const& [sample_name, fields] : m_sample_info) {
-      auto i = 0u;
-      rapidjson::Value sample_value = rapidjson::Value(rapidjson::kObjectType);
-      rapidjson::Value sample_name_value(rapidjson::StringRef(sample_name.c_str()), allocator);
-      if (m_payload_mode == samples_with_ncalls) {
-        auto chrom_val = reinterpret_cast<rapidjson::Value *>(fields[0]);
-        json_doc->AddMember(sample_name_value, chrom_val->Size(), allocator);
-      } else {
+  json_doc->SetObject();
+  auto& allocator = json_doc->GetAllocator();
+  switch(m_payload_mode) {
+    case just_ncalls: {
+      json_doc->AddMember("num_calls", m_num_calls, allocator);
+      break;
+    }
+    case samples_with_ncalls: {
+      for (auto const& [sample_name, num_calls] : *m_samples.get()) {
+        rapidjson::Value sample_name_value(rapidjson::StringRef(sample_name.c_str()), allocator);
+        json_doc->AddMember(sample_name_value, rapidjson::Value(num_calls).Move(), allocator);
+      }
+      break;
+    }
+    case all_by_calls: {
+      // Create header with names of the fields in the JSON output
+      rapidjson::Value field_names = rapidjson::Value(rapidjson::kArrayType);
+      field_names.PushBack("CHR", allocator);
+      field_names.PushBack("POS", allocator);
+      for (auto field_name : m_field_names) {
+        rapidjson::Value value(rapidjson::StringRef(field_name.c_str()), allocator);
+        field_names.PushBack(value, allocator);
+      }
+      json_doc->AddMember("FIELD", field_names, allocator);
+      for (auto const& [sample_name, fields_vec] : *m_samples_info.get()) {
+        rapidjson::Value fields_array = rapidjson::Value(rapidjson::kArrayType);
+        for (auto const& fields: fields_vec) {
+          fields_array.PushBack(*(reinterpret_cast<rapidjson::Value *>(fields)), allocator);
+        }
+        rapidjson::Value sample_value = rapidjson::Value(rapidjson::kObjectType);
+        rapidjson::Value sample_name_value(rapidjson::StringRef(sample_name.c_str()), allocator);
+        json_doc->AddMember(sample_name_value, fields_array, allocator);
+      }
+      break;
+    }
+    case all: {
+      for (auto const& [sample_name, fields] : *m_samples_info.get()) {
+        auto i = 0u;
         rapidjson::Value field_values = rapidjson::Value(rapidjson::kObjectType);
-        field_values.AddMember("CHROM",
+        field_values.AddMember("CHR",
                                *(reinterpret_cast<rapidjson::Value *>(fields[i++])),
                                allocator);
         field_values.AddMember("POS",
                                *(reinterpret_cast<rapidjson::Value *>(fields[i++])),
-                               allocator);
-      
+                               allocator); 
         for (auto field_name : m_field_names) {
           rapidjson::Value field_name_value(rapidjson::StringRef(field_name.c_str()), allocator);
           field_values.AddMember(field_name_value,
                                  *(reinterpret_cast<rapidjson::Value *>(fields[i++])),
                                  allocator);
         }
+        rapidjson::Value sample_name_value(rapidjson::StringRef(sample_name.c_str()), allocator);
         json_doc->AddMember(sample_name_value, field_values, allocator);
       }
     }
   }
 
-  rapidjson::StringBuffer *buffer = reinterpret_cast<rapidjson::StringBuffer *>(m_json_buffer);
-  buffer->Clear();
-  rapidjson::Writer<rapidjson::StringBuffer> writer(*buffer);
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   json_doc->Accept(writer);
   
-  return buffer->GetString();
+  return std::string(buffer.GetString(), buffer.GetLength());
 }
 
 void JSONVariantCallProcessor::process(const interval_t& interval) {
@@ -106,10 +132,18 @@ void JSONVariantCallProcessor::process(const interval_t& interval) {
     auto& genomic_field_types = get_genomic_field_types();
     for (auto& field_type_pair : *genomic_field_types) {
       std::string field_name = field_type_pair.first;
-      genomic_field_type_t field_type = field_type_pair.second;
       if (field_name.compare("END") && field_name.compare("REF") && field_name.compare("ALT")) {
         m_field_names.push_back(field_name);
       }
+    }
+    switch (m_payload_mode) {
+      case just_ncalls:
+        break;
+      case samples_with_ncalls:
+        m_samples = std::make_unique<std::map<std::string, int64_t>>();
+        break;
+      case all_by_calls: case all:
+        m_samples_info = std::make_unique<std::map<std::string, std::vector<void *>>>();
     }
   }
 }
@@ -118,79 +152,131 @@ void JSONVariantCallProcessor::process(const std::string& sample_name,
                                        const int64_t* coordinates,
                                        const genomic_interval_t& genomic_interval,
                                        const std::vector<genomic_field_t>& genomic_fields) {
-  m_num_calls++;
-  if (m_payload_mode == just_ncalls) return;
-
-  rapidjson::Document *json_doc = TO_JSON_DOCUMENT(m_json_document);
-  auto& allocator = json_doc->GetAllocator();
-  auto sample_info = m_sample_info.find(sample_name);
-  if (sample_info == m_sample_info.end()) {
-    // Create Value Arrays and add to map
-    std::vector<void *> fields;
-    rapidjson::Value *chrom = new rapidjson::Value(rapidjson::kArrayType);
-    fields.push_back(chrom);
-    if (m_payload_mode == all) {
-      rapidjson::Value *pos = new rapidjson::Value(rapidjson::kArrayType);
-      fields.push_back(pos);
+  auto& allocator = TO_JSON_DOCUMENT(m_json_document)->GetAllocator();
+  switch (m_payload_mode) {
+    case just_ncalls:
+      m_num_calls++;
+      break;
+    case samples_with_ncalls: {
+      auto sample = m_samples->find(sample_name);
+      if (sample == m_samples->end()) {
+        m_samples->emplace(sample_name, 0ul);
+        sample = m_samples->find(sample_name);
+      }
+      m_samples->emplace(sample_name, sample->second++);
+      break;
+    }
+    case all_by_calls: {
+      auto sample_info = m_samples_info->find(sample_name);
+      if (sample_info == m_samples_info->end()) {
+        // Create Value Arrays and add to map
+        m_samples_info->emplace(sample_name, std::vector<void *>());
+        sample_info = m_samples_info->find(sample_name);
+      }
+      rapidjson::Value *fields = new rapidjson::Value(rapidjson::kArrayType);
+      rapidjson::Value chrom_value = rapidjson::Value(rapidjson::kStringType);
+      chrom_value.SetString(genomic_interval.contig_name.c_str(),
+                            genomic_interval.contig_name.length(),
+                            allocator);
+      fields->PushBack(chrom_value, allocator);
+      // POS value
+      fields->PushBack(rapidjson::Value(genomic_interval.interval.first).Move(), allocator);
       for (auto field_name : m_field_names) {
-        rapidjson::Value *field_array = new rapidjson::Value(rapidjson::kArrayType);
-        fields.push_back(field_array);
-      }
-    }
-    m_sample_info.emplace(std::make_pair(sample_name, std::move(fields)));
-    sample_info = m_sample_info.find(sample_name);
-  }
-
-  auto i = 0u;
-  auto& fields = sample_info->second;
-
-  rapidjson::Value *chrom = reinterpret_cast<rapidjson::Value *>(fields[i++]);
-  rapidjson::Value chrom_value = rapidjson::Value(rapidjson::kStringType);
-  chrom_value.SetString(genomic_interval.contig_name.c_str(),
-                        genomic_interval.contig_name.length(),
-                        allocator);
-  chrom->PushBack(chrom_value, allocator);
-
-  if (m_payload_mode != all) return;
-
-  rapidjson::Value *pos = reinterpret_cast<rapidjson::Value *>(fields[i++]);
-  pos->PushBack(rapidjson::Value(genomic_interval.interval.first).Move(), allocator);
-
-  for (auto field_name : m_field_names) {
-    auto field_type = get_genomic_field_types()->at(field_name);
-    
-    bool found = false;
-    for (auto genomic_field: genomic_fields) {
-      if (genomic_field.name.compare(field_name) == 0) {
-        rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
-        if (STRING_FIELD(field_name, field_type)) {
-          rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
-          std::string str;
-          if (field_name == "GT") {
-            str = resolve_gt(genomic_fields);
-          } else {
-            str = genomic_field.to_string(field_type);
+        auto field_type = get_genomic_field_types()->at(field_name);
+        bool found = false;
+        for (auto genomic_field: genomic_fields) {
+          if (genomic_field.name.compare(field_name) == 0) {
+            if (STRING_FIELD(field_name, field_type)) {
+              rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
+              std::string str;
+              if (field_name == "GT") {
+                str = resolve_gt(genomic_fields);
+              } else {
+                str = genomic_field.to_string(field_type);
+              }
+              value.SetString(str.c_str(), str.length(), allocator);
+              fields->PushBack(value, allocator);
+            } else if (INT_FIELD(field_type)) {
+              fields->PushBack(rapidjson::Value(genomic_field.int_value_at(0)).Move(), allocator);
+            } else if (FLOAT_FIELD(field_type)) {
+              fields->PushBack(rapidjson::Value(genomic_field.float_value_at(0)).Move(), allocator);
+            } else {
+              std::string msg = "Genomic field type for " + field_name + " not supported";
+              throw GenomicsDBException(msg.c_str());
+            }
+            found = true;
+            break;
           }
-          value.SetString(str.c_str(), str.length(), allocator);
-          values->PushBack(value, allocator);
-        } else if (INT_FIELD(field_type)) {
-          values->PushBack(rapidjson::Value(genomic_field.int_value_at(0)).Move(), allocator);
-        } else if (FLOAT_FIELD(field_type)) {
-          values->PushBack(rapidjson::Value(genomic_field.float_value_at(0)).Move(), allocator);
-        } else {
-          std::string msg = "Genomic field type for " + field_name + " not supported";
-          throw GenomicsDBException(msg.c_str());
         }
-        found = true;
-        break;
+        if (!found) {
+          rapidjson::Value value = rapidjson::Value(rapidjson::kNullType);
+          fields->PushBack(value, allocator);
+        }
       }
+      sample_info->second.push_back(fields);
+      break;
     }
-
-    if (!found) {
-      rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
-      rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
-      value.SetString(".", allocator);
-      values->PushBack(value, allocator);
+    case all: {
+      auto sample_info = m_samples_info->find(sample_name);
+      if (sample_info == m_samples_info->end()) {
+        // Create Value Arrays and add to map
+        std::vector<void *> fields;
+        rapidjson::Value *chrom = new rapidjson::Value(rapidjson::kArrayType);
+        fields.push_back(chrom);
+        rapidjson::Value *pos = new rapidjson::Value(rapidjson::kArrayType);
+        fields.push_back(pos);
+        for (auto field_name : m_field_names) {
+          rapidjson::Value *field_array = new rapidjson::Value(rapidjson::kArrayType);
+          fields.push_back(field_array);
+        }
+        m_samples_info->emplace(sample_name, std::move(fields));
+        sample_info = m_samples_info->find(sample_name);
+      }
+      auto i = 0u;
+      auto& fields = sample_info->second;
+      rapidjson::Value *chrom = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+      rapidjson::Value chrom_value = rapidjson::Value(rapidjson::kStringType);
+      chrom_value.SetString(genomic_interval.contig_name.c_str(),
+                            genomic_interval.contig_name.length(),
+                            allocator);
+      chrom->PushBack(chrom_value, allocator);
+      rapidjson::Value *pos = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+      pos->PushBack(rapidjson::Value(genomic_interval.interval.first).Move(), allocator);
+      for (auto field_name : m_field_names) {
+        auto field_type = get_genomic_field_types()->at(field_name);
+        bool found = false;
+        for (auto genomic_field: genomic_fields) {
+          if (genomic_field.name.compare(field_name) == 0) {
+            rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+            if (STRING_FIELD(field_name, field_type)) {
+              rapidjson::Value value = rapidjson::Value(rapidjson::kStringType);
+              std::string str;
+              if (field_name == "GT") {
+                str = resolve_gt(genomic_fields);
+              } else {
+                str = genomic_field.to_string(field_type);
+              }
+              value.SetString(str.c_str(), str.length(), allocator);
+              values->PushBack(value, allocator);
+            } else if (INT_FIELD(field_type)) {
+              values->PushBack(rapidjson::Value(genomic_field.int_value_at(0)).Move(), allocator);
+            } else if (FLOAT_FIELD(field_type)) {
+              values->PushBack(rapidjson::Value(genomic_field.float_value_at(0)).Move(), allocator);
+            } else {
+              std::string msg = "Genomic field type for " + field_name + " not supported";
+              throw GenomicsDBException(msg.c_str());
+            }
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          rapidjson::Value *values = reinterpret_cast<rapidjson::Value *>(fields[i++]);
+          rapidjson::Value value = rapidjson::Value(rapidjson::kNullType);
+          values->PushBack(value, allocator);
+        }
+      }
+      break;
     }
   }
 }

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -915,33 +915,39 @@ TEST_CASE("api query_variant_calls with JSONVariantCallProcessor", "[query_varia
 
   JSONVariantCallProcessor json_processor;
   gdb->query_variant_calls(json_processor, "", GenomicsDB::NONE);
-
   auto output = json_processor.construct_json_output();
-  // {"HG00141":{"CHROM":["1","1"],"POS":[12141,17385],"DP":[".","."],"GT":["C/C","G/A"]},"HG01530":{"CHROM":["1"],"POS":[17385],"DP":[76],"GT":["G/A"]},"HG01958":{"CHROM":["1","1"],"POS":[12145,17385],"DP":[".",120],"GT":["C/C","T/T"]}}
-  CHECK(strlen(output) == 232);
-  printf("%lu %s\n\n", strlen(output), output);
+  // {"HG00141":{"CHR":["1","1"],"POS":[12141,17385],"DP":[null,null],"GT":["C/C","G/A"]},"HG01530":{"CHR":["1"],"POS":[17385],"DP":[76],"GT":["G/A"]},"HG01958":{"CHR":["1","1"],"POS":[12145,17385],"DP":[null,120],"GT":["C/C","T/T"]}}
+  CHECK(output.length() == 229);
+  printf("%lu %s\n\n", output.length(), output.c_str());
+
+  JSONVariantCallProcessor json_processor0(JSONVariantCallProcessor::all_by_calls);
+  gdb->query_variant_calls(json_processor0, "", GenomicsDB::NONE);
+  output = json_processor0.construct_json_output();
+  // {"FIELD":["CHR","POS","DP","GT"],"HG00141":[["1",12141,null,"C/C"],["1",17385,null,"G/A"]],"HG01530":[["1",17385,76,"G/A"]],"HG01958":[["1",12145,null,"C/C"],["1",17385,120,"T/T"]]}
+  CHECK(output.length() == 181);
+  printf("%lu %s\n\n", output.length(), output.c_str());
 
   JSONVariantCallProcessor json_processor1(JSONVariantCallProcessor::samples_with_ncalls);
   gdb->query_variant_calls(json_processor1, "", GenomicsDB::NONE);
   output = json_processor1.construct_json_output();
   // {"HG00141":2,"HG01530":1,"HG01958":2}
-  CHECK(strlen(output) == 37);
-  printf("%lu %s\n\n", strlen(output), output);
+  CHECK(output.length() == 37);
+  printf("%lu %s\n\n", output.length(), output.c_str());
 
   JSONVariantCallProcessor json_processor2(JSONVariantCallProcessor::just_ncalls);
   gdb->query_variant_calls(json_processor2, "", GenomicsDB::NONE);
   output = json_processor2.construct_json_output();
   // {"num_calls":5}
-  CHECK(strlen(output)== 15);
-  printf("%lu %s\n\n", strlen(output), output);
+  CHECK(output.length()== 15);
+  printf("%lu %s\n\n", output.length(), output.c_str());
 
   JSONVariantCallProcessor json_processor3;
   json_processor3.set_payload_mode(JSONVariantCallProcessor::just_ncalls);
   gdb->query_variant_calls(json_processor3, "", GenomicsDB::NONE);
   output = json_processor3.construct_json_output();
   // {"num_calls":5}
-  CHECK(strlen(output)== 15);
-  printf("%lu %s\n\n", strlen(output), output);
+  CHECK(output.length() == 15);
+  printf("%lu %s\n\n", output.length(), output.c_str());
 
   delete gdb;
 }

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -916,14 +916,18 @@ TEST_CASE("api query_variant_calls with JSONVariantCallProcessor", "[query_varia
   JSONVariantCallProcessor json_processor;
   gdb->query_variant_calls(json_processor, "", GenomicsDB::NONE);
   auto output = json_processor.construct_json_output();
-  // {"HG00141":{"CHR":["1","1"],"POS":[12141,17385],"DP":[null,null],"GT":["C/C","G/A"]},"HG01530":{"CHR":["1"],"POS":[17385],"DP":[76],"GT":["G/A"]},"HG01958":{"CHR":["1","1"],"POS":[12145,17385],"DP":[null,120],"GT":["C/C","T/T"]}}
+  // {"HG00141":{"CHR":["1","1"],"POS":[12141,17385],"DP":[null,null],"GT":["C/C","G/A"]},
+  // "HG01530":{"CHR":["1"],"POS":[17385],"DP":[76],"GT":["G/A"]},
+  // "HG01958":{"CHR":["1","1"],"POS":[12145,17385],"DP":[null,120],"GT":["C/C","T/T"]}}
   CHECK(output.length() == 229);
   printf("%lu %s\n\n", output.length(), output.c_str());
 
   JSONVariantCallProcessor json_processor0(JSONVariantCallProcessor::all_by_calls);
   gdb->query_variant_calls(json_processor0, "", GenomicsDB::NONE);
   output = json_processor0.construct_json_output();
-  // {"FIELD":["CHR","POS","DP","GT"],"HG00141":[["1",12141,null,"C/C"],["1",17385,null,"G/A"]],"HG01530":[["1",17385,76,"G/A"]],"HG01958":[["1",12145,null,"C/C"],["1",17385,120,"T/T"]]}
+  // {"FIELD":["CHR","POS","DP","GT"],
+  // "HG00141":[["1",12141,null,"C/C"],["1",17385,null,"G/A"]],
+  // "HG01530":[["1",17385,76,"G/A"]],"HG01958":[["1",12145,null,"C/C"],["1",17385,120,"T/T"]]}
   CHECK(output.length() == 181);
   printf("%lu %s\n\n", output.length(), output.c_str());
 
@@ -949,6 +953,23 @@ TEST_CASE("api query_variant_calls with JSONVariantCallProcessor", "[query_varia
   CHECK(output.length() == 15);
   printf("%lu %s\n\n", output.length(), output.c_str());
 
+  delete gdb;
+
+  config->clear_attributes();
+  CHECK(config->SerializeToString(&config_string));
+  gdb = new GenomicsDB(config_string, GenomicsDB::PROTOBUF_BINARY_STRING);
+  JSONVariantCallProcessor json_processor4(JSONVariantCallProcessor::all);
+  gdb->query_variant_calls(json_processor4, "", GenomicsDB::NONE);
+  output = json_processor4.construct_json_output();
+  // {"HG00141":{"CHR":["1","1"],"POS":[12141,17385],"AD":[null,58],"BaseQRankSum":[null,-2.0959999561309816],
+  //     "ClippingRankSum":[null,-1.8589999675750733],"DP":[null,null],"DP_FORMAT":[2,80],"DS":["1","1"],
+  //     "FILTER":[null,0],"GQ":[0,99],"GT":["C/C","G/A"],"HaplotypeScore":[null,null],
+  //     "InbreedingCoeff":[null,null],"MIN_DP":[0,null],"MLEAC":[null,1],"MLEAF":[null,0.5],
+  //     "MQ":[null,31.719999313354493],"MQ0":[null,8],"MQRankSum":[null,-0.32899999618530276],
+  //     "PGT":[null,"0|1"],"PID":[null,"17385_G_A"],"PL":[0,504],"QUAL":[null,475.7699890136719],
+  //     "RAW_MQ":[null,5.5],"ReadPosRankSum":[null,0.004999999888241291],"SB":[null,"[58, 0, 22, 0]"]},...}
+  CHECK(output.length() == 1761);
+  printf("%lu %s\n\n", output.length(), output.c_str());
   delete gdb;
 }
 

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -982,15 +982,15 @@ TEST_CASE("Test genomicsdb demo test case", "[genomicsdb_demo]") {
   config->set_enable_shared_posixfs_optimizations(true);
 
   // filters
-  std::vector<std::string> filters = {""/*, // zlib arm64 - 1s
+  std::vector<std::string> filters = {"", // zlib arm64 - 1s
     "REF==\"A\"", // 2s
     "REF==\"A\" && ALT|=\"T\"", // 2s
     "REF==\"A\" &&  ALT|=\"T\" && ISHOMALT", // 3s
-    "REF==\"A\" && ALT|=\"T\" && resolve(GT, REF, ALT) &= \"T|T\"" // 3s*/
+    "REF==\"A\" && ALT|=\"T\" && resolve(GT, REF, ALT) &= \"T|T\"" // 3s
   };
 
   // sizes
-  std::vector<size_t> segment_sizes = { 0/*, 10240, 20480, 40960*/ };
+  std::vector<size_t> segment_sizes = { 0, 10240, 20480, 40960 };
 
   // results
   std::vector<int64_t> counts = { 2962039, 400432, 82245, 82245, 69548 };


### PR DESCRIPTION
Implemented a JSON processor in the native GenomicsDB layer to generate JSON files for queries emanating from REST interfaces. 4 modes are currently supported, 
1. `all` gets all the information for the attributes queried in addition to resolving GT w.r.t REF and ALT
```{"HG00141":{"CHR":["1","1"],"POS":[12141,17385],"DP":[null,null],"GT":["C/C","G/A"]},"HG01530":{"CHR":["1"],"POS":[17385],"DP":[76],"GT":["G/A"]},"HG01958":{"CHR":["1","1"],"POS":[12145,17385],"DP":[null,120],"GT":["C/C","T/T"]}}```
2. `all_by_calls` get all the information like (1), but orders them by calls per sample
```{"FIELD":["CHR","POS","DP","GT"],"HG00141":[["1",12141,null,"C/C"],["1",17385,null,"G/A"]],"HG01530":[["1",17385,76,"G/A"]],"HG01958":[["1",12145,null,"C/C"],["1",17385,120,"T/T"]]}```
3. `samples_with_num_calls` gets a list of samples with number of calls per sample
```"HG00141":2,"HG01530":1,"HG01958":2}```
4. and for a total number of calls for the query - `num_calls`
```{"num_calls":5}```
Queries seem to be consuming less memory and are faster than before. For querying `EGFR` in a az workspace, the json payload is about 800K and compresses to 140K all consuming under 1G memory and completing in < 10s.