### PR TITLE
Support a samples list for json output in api queries

### DIFF
--- a/src/main/cpp/include/api/genomicsdb.h
+++ b/src/main/cpp/include/api/genomicsdb.h
@@ -270,7 +270,7 @@ class GENOMICSDB_EXPORT GenomicsDBVariantCallProcessor {
 
 class GENOMICSDB_EXPORT JSONVariantCallProcessor : public GenomicsDBVariantCallProcessor {
  public:
-  enum payload_t {all=0, all_by_calls=1, samples_with_ncalls=2, just_ncalls=3};
+  enum payload_t {all=0, all_by_calls=1, samples_with_ncalls=2, just_ncalls=3, just_samples=4};
   JSONVariantCallProcessor() : JSONVariantCallProcessor(all) {}
   JSONVariantCallProcessor(payload_t payload_mode);
   ~JSONVariantCallProcessor();
@@ -287,6 +287,8 @@ class GENOMICSDB_EXPORT JSONVariantCallProcessor : public GenomicsDBVariantCallP
   void *m_json_document;
   // payload num_calls
   int64_t m_num_calls = 0ul;
+  // payload samples set
+  std::unique_ptr<std::set<std::string>> m_samples_set;
   // payload samples_with_ncalls
   std::unique_ptr<std::map<std::string, int64_t>> m_samples;
   // payload all

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -954,14 +954,22 @@ TEST_CASE("api query_variant_calls with JSONVariantCallProcessor", "[query_varia
   CHECK(output.length() == 15);
   printf("%lu %s\n\n", output.length(), output.c_str());
 
+  JSONVariantCallProcessor json_processor4;
+  json_processor4.set_payload_mode(JSONVariantCallProcessor::just_samples);
+  gdb->query_variant_calls(json_processor4, "", GenomicsDB::NONE);
+  output = json_processor4.construct_json_output();
+  // ["HG00141","HG01530","HG01958"]
+  CHECK(output.length() == 31);
+  printf("%lu %s\n\n", output.length(), output.c_str());
+
   delete gdb;
 
   config->clear_attributes();
   CHECK(config->SerializeToString(&config_string));
   gdb = new GenomicsDB(config_string, GenomicsDB::PROTOBUF_BINARY_STRING);
-  JSONVariantCallProcessor json_processor4(JSONVariantCallProcessor::all);
-  gdb->query_variant_calls(json_processor4, "", GenomicsDB::NONE);
-  output = json_processor4.construct_json_output();
+  JSONVariantCallProcessor json_processor5(JSONVariantCallProcessor::all);
+  gdb->query_variant_calls(json_processor5, "", GenomicsDB::NONE);
+  output = json_processor5.construct_json_output();
   // {"HG00141":{"CHR":["1","1"],"POS":[12141,17385],"AD":[null,58],"BaseQRankSum":[null,-2.0959999561309816],
   //             "ClippingRankSum":[null,-1.8589999675750733],"DP":[null,null],"DP_FORMAT":[2,80],"DS":["1","1"],
   //             "FILTER":[null,0],"GQ":[0,99],"GT":["C/C","G/A"],"HaplotypeScore":[null,null],"InbreedingCoeff":[null,null],


### PR DESCRIPTION
The corresponding python test yielded this against our demo genomicsdb workspace :
```
test/test_genomicsdb_demo.py::TestGenomicsDBDemo::test_genomicsdb_demo_with_json_output test_genomicsdb_demo_with_json_output

Summary for mode=json_output_mode.NUM_CALLS:
output json length=19
	Elapsed time: 2.9342398643493652

Summary for mode=json_output_mode.SAMPLES:
output json length=518592
	Elapsed time: 2.978851795196533

Summary for mode=json_output_mode.SAMPLES_WITH_NUM_CALLS:
output json length=605884
	Elapsed time: 3.0043089389801025

Summary for mode=json_output_mode.ALL_BY_CALLS:
output json length=2344617
	Elapsed time: 3.001533269882202

Summary for mode=json_output_mode.ALL:
output json length=3558514
	Elapsed time: 3.014052152633667
```