### PR TITLE
Bump to ubuntu 24.05

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          build-args: os=ubuntu:lunar
+          build-args: os=ubuntu:24.04
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Minor -- lunar is outside of support now so updating the 24.04 which is LTS. 