### PR TITLE
Revert to jammy due to size issues

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          build-args: os=ubuntu:24.04
+          build-args: os=ubuntu:jammy
           load: true
           tags: ghcr.io/genomicsdb/genomicsdb:test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /build
 RUN ./install_prereqs.sh release &&\
     useradd -r -U -m ${user}
 
-COPY --from=full /usr/local/bin/*genomicsdb* /usr/local/bin/gt_mpi_gather /usr/local/bin/vcf* ${install_dir}/bin/
+COPY --from=full /usr/local/bin/create_genomicsdb_workspace /usr/local/bin/gt_mpi_gather /usr/local/bin/vcf2genomicsdb* /usr/local/bin/consolidate* ${install_dir}/bin/
 
 USER ${user}
 WORKDIR /home/${user}


### PR DESCRIPTION
I'm not entirely sure why (maybe because noble isn't officially released and some things are in flux?) but the change to noble seems to double the docker image we're building. Reverting back to jammy since that will be supported till 2027.

Also, removing a few executables that we mostly don't use from the final image