### PR TITLE
Move to protobuf 3.25.5 and update GitHub action versions for vulnerability fixes

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04,ubuntu-22.04,macos-12]
+        os: [ubuntu-20.04,ubuntu-22.04,macos-13]
         type: [basic]
         java: [17]
         include:
@@ -69,7 +69,7 @@ jobs:
 
     - name: Cache Distributed FileSystems
       if: matrix.type == 'hdfs'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{runner.workspace}}/hadoop-${{env.HADOOP_VER}}
         key: ${{matrix.os}}-dfs-${{env.HADOOP_VER}}

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -43,14 +43,14 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
         cache: 'pip'
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with: 
         java-version: ${{matrix.java}}
         distribution: temurin
@@ -58,7 +58,7 @@ jobs:
         cache: maven
 
     - name: Cache built prerequisites
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{env.PREREQS_INSTALL_DIR}}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -103,4 +103,4 @@ jobs:
     #  uses: github/codeql-action/autobuild@v1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,9 +52,9 @@ jobs:
       # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-package: jdk
@@ -62,7 +62,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         config-file: ./.github/resources/codeql-config.yml
         languages: cpp, java
@@ -72,7 +72,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Cache built prerequisites for ubuntu
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{env.PREREQS_INSTALL_DIR}}
@@ -103,4 +103,4 @@ jobs:
     #  uses: github/codeql-action/autobuild@v1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,12 +40,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           build-args: os=ubuntu:jammy

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build and push to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           build-args: os=ubuntu:jammy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-java@v4
         with:
@@ -69,7 +69,7 @@ jobs:
           cp $CMAKE_INSTALL_PREFIX/lib/libtiledbgenomicsdb.dylib .
 
       - name: Archive libraries as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: libtiledbgenomicsdb.dylib.${{ github.ref_name }}
           path: libtiledbgenomicsdb.dylib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-push-mac-dylib:
-    runs-on: macos-12
+    runs-on: macos-13
     outputs: 
       tag_message: ${{env.TAG_MESSAGE}}
     permissions:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-package: jdk

--- a/.github/workflows/release_jar.yml
+++ b/.github/workflows/release_jar.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
 
       - name: Download dylib
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.dylib_artifact }}
 

--- a/.github/workflows/release_jar.yml
+++ b/.github/workflows/release_jar.yml
@@ -29,7 +29,7 @@ jobs:
           name: ${{ inputs.dylib_artifact }}
 
       - name: Build Centos 6 and create release jar
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.release

--- a/.github/workflows/release_jar.yml
+++ b/.github/workflows/release_jar.yml
@@ -54,7 +54,7 @@ jobs:
           sed -i.bak 's/${genomicsdb.version}/'"${VERSION_NUMBER}"'/' genomicsdb-${VERSION_NUMBER}.pom
 
       - name: Archive libraries as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release.${{ github.ref_name }}
           path: |

--- a/.github/workflows/release_jar.yml
+++ b/.github/workflows/release_jar.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true # cmake does this for us...but need to patch htslib before calling cmake
 

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -38,7 +38,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.release_artifact }}
 

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set version number
         run: echo VERSION_NUMBER=${GITHUB_REF_NAME:1} >> $GITHUB_ENV
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout TestGenomicsDBJar
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: GenomicsDB/TestGenomicsDBJar
           ref: master
@@ -63,7 +63,7 @@ jobs:
 
       - name: Checkout GATK
         if: ${{ !contains(inputs.tag_message,'skip-gatk-it') }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: broadinstitute/gatk
           lfs: 'true'

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest,macos-12]
+        os: [ubuntu-latest,macos-13]
 
     runs-on: ${{matrix.os}}
     permissions:
@@ -37,7 +37,7 @@ jobs:
           echo GENOMICSDB_MIN_TAG=v1.5.2-SNAPSHOT >> $GITHUB_ENV
 
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: '17'
   
       - name: Download release artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.release_artifact }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ option(DISABLE_TOOLS "Disable build of tools")
 set(HTSLIB_INSTALL_DIR "" CACHE PATH "Path to htslib install directory")
 
 #Sync the GENOMICSDB_PROTOBUF_VERSION with protobuf.version in pom.xml!
-set(GENOMICSDB_PROTOBUF_VERSION "3.21.7" CACHE STRING "Version of Google Protocol Buffer library")
+set(GENOMICSDB_PROTOBUF_VERSION "3.25.5" CACHE STRING "Version of Google Protocol Buffer library")
 set(PROTOBUF_ROOT_DIR "$ENV{HOME}/protobuf-install/${GENOMICSDB_PROTOBUF_VERSION}" CACHE PATH "Path to installed protobuf")
 set(PROTOBUF_URL "https://github.com/protocolbuffers/protobuf/archive/v${GENOMICSDB_PROTOBUF_VERSION}.zip" CACHE STRING "URL to protobuf github release")
 set(PROTOBUF_REGENERATE True CACHE BOOL "Regenerate protocol buffers C++ files")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ option(DISABLE_TOOLS "Disable build of tools")
 set(HTSLIB_INSTALL_DIR "" CACHE PATH "Path to htslib install directory")
 
 #Sync the GENOMICSDB_PROTOBUF_VERSION with protobuf.version in pom.xml!
-set(GENOMICSDB_PROTOBUF_VERSION "3.25.5" CACHE STRING "Version of Google Protocol Buffer library")
+set(GENOMICSDB_PROTOBUF_VERSION "3.21.7" CACHE STRING "Version of Google Protocol Buffer library")
 set(PROTOBUF_ROOT_DIR "$ENV{HOME}/protobuf-install/${GENOMICSDB_PROTOBUF_VERSION}" CACHE PATH "Path to installed protobuf")
 set(PROTOBUF_URL "https://github.com/protocolbuffers/protobuf/archive/v${GENOMICSDB_PROTOBUF_VERSION}.zip" CACHE STRING "URL to protobuf github release")
 set(PROTOBUF_REGENERATE True CACHE BOOL "Regenerate protocol buffers C++ files")

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <gson.version>[2.10.1,)</gson.version>
     <log4j.version>2.19.0</log4j.version>
     <!-- Sync the protobuf.version with GENOMICSDB_PROTOBUF_VERSION in CMakeLists.txt -->
-    <protobuf.version>3.21.7</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <google_shade_version>org.genomicsdb.shaded.com.google</google_shade_version>
     <testng.version>7.7.1</testng.version>
     <gnu.getopt.version>1.0.13</gnu.getopt.version>


### PR DESCRIPTION
See https://github.com/GenomicsDB/GenomicsDB/pull/340. We are not ready to move to protobuf 4 as yet, but `3.25.5"` has the security patches.