### PR TITLE
Performance fixes

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,84 @@
+#
+# valgrind.yml
+#
+# The MIT License
+#
+# Copyright (c) 2024 dātma, inc™
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+name: Valgrind
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.rst'
+
+env:
+  PREREQS_ENV: ${{github.workspace}}/prereqs.sh
+  PREREQS_INSTALL_DIR: ${{github.workspace}}/prereqs
+  CMAKE_INSTALL_PREFIX: ${{github.workspace}}/install
+  GENOMICSDB_BUILD_DIR: ${{github.workspace}}/build
+
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache built prerequisites
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{env.PREREQS_INSTALL_DIR}}
+          ~/awssdk-install
+          ~/gcssdk-install
+          ~/protobuf-install/${{env.PROTOBUF_VERSION}}
+        key: ubuntu-22.04-cache-prereqs-${{env.PROTOBUF_VERSION}}-v1
+
+    - name: Install Prerequisites
+      shell: bash
+      working-directory: ${{github.workspace}}/scripts/prereqs
+      run: |
+        $GITHUB_WORKSPACE/.github/scripts/cleanup_hosts.sh
+        sudo INSTALL_PREFIX=$PREREQS_INSTALL_DIR PREREQS_ENV=$PREREQS_ENV ./install_prereqs.sh
+        source $PREREQS_ENV
+        sudo apt-get update -q
+        sudo apt-get -y install valgrind
+
+    - name: Run valgrind
+      shell: bash
+      run: |
+        source $PREREQS_ENV
+        mkdir -p $GENOMICSDB_BUILD_DIR
+        cd $GENOMICSDB_BUILD_DIR
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX $GITHUB_WORKSPACE
+        make -j4
+        make install
+        export VALGRIND="valgrind --leak-check=full --suppressions=$GITHUB_WORKSPACE/src/test/inputs/valgrind_mpi.supp"
+        cd $GITHUB_WORKSPACE/tests
+        ./test_tools.sh inputs/vcfs $CMAKE_INSTALL_PREFIX

--- a/src/main/cpp/src/api/genomicsdb_nanoarrow_processor.cc
+++ b/src/main/cpp/src/api/genomicsdb_nanoarrow_processor.cc
@@ -223,7 +223,7 @@ void *ArrowVariantCallProcessor::arrow_schema() {
 }
 
 void *ArrowVariantCallProcessor::arrow_array() {
-  if (m_is_finalized && TO_ARROW_ARRAY(m_arrow_array)->children[0]->length == 0) return NULL;
+  if (m_is_finalized && (!m_arrow_array || TO_ARROW_ARRAY(m_arrow_array)->children[0]->length == 0)) return NULL;
   if (m_is_batching) array_ready.acquire();
   ArrowArray *arrow_array = new ArrowArray();
   ArrowArrayInitFromSchema(arrow_array, TO_ARROW_SCHEMA(m_arrow_schema), NULL);

--- a/src/main/cpp/src/query_operations/variant_operations.cc
+++ b/src/main/cpp/src/query_operations/variant_operations.cc
@@ -541,7 +541,7 @@ bool GA4GHOperator::check_if_too_many_alleles_and_print_message(
     std::stringstream ss;
     if (contig_status)
       ss << "Chromosome "<<contig_name<<" position "<<contig_position+1<<" ("; //VCF contig coords are 1 based
-    ss << "TileDB column "<<variant.get_column_begin();
+    ss << "GenomicsDB mapped column "<<variant.get_column_begin();
     if (contig_status)
       ss << ")";
     ss << " has too many alleles in the combined VCF record : "<<num_merged_alleles-1
@@ -578,14 +578,14 @@ bool GA4GHOperator::remap_if_needed(const Variant& variant,
 	  orig_call.get_row_idx(), callset_name);
       std::stringstream ss;
       if(callset_status)
-	ss << "Sample/Callset "<<callset_name << "( ";
-      ss << "TileDB row idx "<<orig_call.get_row_idx();
+	ss << "Sample/Callset "<<callset_name << "(";
+      ss << "GenomicsDB mapped row idx "<<orig_call.get_row_idx();
       if(callset_status)
 	ss << ")";
       ss << " at ";
       if (contig_status)
 	ss << "Chromosome "<<contig_name<<" position "<<contig_position+1<<" ("; //VCF contig coords are 1 based
-      ss << "TileDB column "<<variant.get_column_begin();
+      ss << "GenomicsDB mapped column "<<variant.get_column_begin();
       if (contig_status)
 	ss << ")";
       ss << " has too many genotypes in the combined VCF record : ";
@@ -596,8 +596,8 @@ bool GA4GHOperator::remap_if_needed(const Variant& variant,
 	ss << num_genotypes;
       ss  << " : current limit : "<<m_max_genotype_count
 	<< " (num_alleles, ploidy) = ("<<num_merged_alleles<< ", "<<curr_ploidy
-	<< "). Fields, such as  PL, with length equal to the number of genotypes will NOT be added \
-	for this sample for this location.\n";
+	<< "). Fields, such as  PL, with length equal to the number of genotypes will NOT be added "
+	<< "for this sample for this location.\n";
       logger.warn(ss.str());
       remapped_field->set_valid(false);
       return false; //no remapping done

--- a/src/test/inputs/valgrind_mpi.supp
+++ b/src/test/inputs/valgrind_mpi.supp
@@ -1,0 +1,22 @@
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   ...
+   obj:/usr/lib/x86_64-linux-gnu/libmpich*
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   ...
+   fun:_dl_open
+   ...
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   ...
+   fun:_dl_init
+   ...
+}


### PR DESCRIPTION
- Bring in new version of TileDB with performance fixes
- Change `test_tools.sh` to use `valgrind` if `VALGRIND` env is set
- Add `valgrind.yml` to GitHub Actions
- Minor changes to error messages where we want to use GenomicsDB instead of TileDB
- One potential issue in the GenomicDB nano arrow processor where a variable was not checked for null value before dereference.