### PR TITLE
Expose fragment metadata caching api to GenomicsDB

### DIFF
--- a/src/main/cpp/include/api/genomicsdb_utils.h
+++ b/src/main/cpp/include/api/genomicsdb_utils.h
@@ -70,6 +70,22 @@ GENOMICSDB_EXPORT ssize_t file_size(const std::string& filename);
  */
 GENOMICSDB_EXPORT int read_entire_file(const std::string& filename, void **buffer, size_t *length);
 
+/**
+ * Get all array names under a workspace
+ * @param workspace storage URL
+ * @return vector of array names in the workspace
+ */
+GENOMICSDB_EXPORT std::vector<std::string> get_array_names(const std::string& workspace);
+
+/**
+ * Cache fragment metadata associated with array in a workspace. Used by the underlying storage system only
+ * when the workspace is a cloud URL for now.
+ * @param workspace storage URL
+ * @param array URL under workspace
+ * @return GENOMICSDB_OK for success, GENOMICSDB_ERR otherwise
+ */
+GENOMICSDB_EXPORT int cache_fragment_metadata(const std::string& workspace, const std::string& array_name);
+
 }
 
 

--- a/src/main/cpp/include/api/genomicsdb_utils.h
+++ b/src/main/cpp/include/api/genomicsdb_utils.h
@@ -37,6 +37,8 @@
 #define GENOMICSDB_EXPORT __attribute__((visibility("default")))
 
 #include <string>
+#include <vector>
+
 #include "genomicsdb_status.h"
 
 namespace genomicsdb {

--- a/src/main/cpp/src/api/genomicsdb_utils.cc
+++ b/src/main/cpp/src/api/genomicsdb_utils.cc
@@ -51,4 +51,12 @@ int read_entire_file(const std::string& filename, void **buffer, size_t *length)
   return TileDBUtils::read_entire_file(filename, buffer, length);
 }
 
+std::vector<std::string> get_array_names(const std::string& workspace) {
+  return TileDBUtils::get_array_names(workspace);
+}
+
+int cache_fragment_metadata(const std::string& workspace, const std::string& array_name) {
+  return TileDBUtils::cache_fragment_metadata(workspace, array_name);
+}
+
 }

--- a/src/test/cpp/src/test_genomicsdb_api.cc
+++ b/src/test/cpp/src/test_genomicsdb_api.cc
@@ -46,6 +46,8 @@
 #  include <nanoarrow/nanoarrow.h>
 #endif
 
+static std::string ctests_input_dir(GENOMICSDB_CTESTS_DIR);
+
 TEST_CASE_METHOD(TempDir, "utils", "[genomicsdb_utils]") {
   REQUIRE(genomicsdb::version().size() > 0);
   REQUIRE_THAT(genomicsdb::version(), Catch::Equals(GENOMICSDB_VERSION));
@@ -66,6 +68,12 @@ TEST_CASE_METHOD(TempDir, "utils", "[genomicsdb_utils]") {
   CHECK(length == 11);
   CHECK(hello_world == txt);
   CHECK(genomicsdb::read_entire_file(filename+".another", (void **)txt, &length) == TILEDB_ERR);
+
+  auto ws = ctests_input_dir+"ws";
+  auto arrays = genomicsdb::get_array_names(ws);
+  CHECK(arrays.size() == 1);
+  CHECK(arrays[0] == "t0_1_2");
+  CHECK(genomicsdb::cache_fragment_metadata(ws, "t0_1_2") == GENOMICSDB_OK);
 }
 
 TEST_CASE("api empty_args", "[empty_args]") {
@@ -91,8 +99,6 @@ TEST_CASE("api empty_args", "[empty_args]") {
     CHECK(strlen(e.what()) > 0);
   }
 }
-
-static std::string ctests_input_dir(GENOMICSDB_CTESTS_DIR);
 
 static std::string workspace(ctests_input_dir+"ws");
 static std::string callset_mapping(ctests_input_dir+"callset_t0_1_2.json");


### PR DESCRIPTION
Expose fragment metadata caching api to GenomicsDB to be utilized in bindings.