### PR TITLE
Expose more storage functionality as genomicsdb_utils api

### DIFF
--- a/src/main/cpp/include/api/genomicsdb_utils.h
+++ b/src/main/cpp/include/api/genomicsdb_utils.h
@@ -72,6 +72,19 @@ GENOMICSDB_EXPORT ssize_t file_size(const std::string& filename);
  */
 GENOMICSDB_EXPORT int read_entire_file(const std::string& filename, void **buffer, size_t *length);
 
+/** Check whether workspace exists
+ * @param workspace storage URL
+ * @return true if given workspace exists, false otherwise
+ */ 
+GENOMICSDB_EXPORT bool workspace_exists(const std::string& workspace);
+
+/** Check whether an array in a given workspace exists
+ * @param workspace storage URL
+ * @param array_name
+ * @return true if array exists in the workspace, false otherwise
+ */
+GENOMICSDB_EXPORT bool array_exists(const std::string& workspace, const std::string& array_name);
+
 /**
  * Get all array names under a workspace
  * @param workspace storage URL

--- a/src/main/cpp/src/api/genomicsdb_utils.cc
+++ b/src/main/cpp/src/api/genomicsdb_utils.cc
@@ -33,8 +33,6 @@
 #include "tiledb_utils.h"
 #include "genomicsdb_logger.h"
 
-#include "string.h"
-
 namespace genomicsdb {
 
 std::string version() {

--- a/src/main/cpp/src/api/genomicsdb_utils.cc
+++ b/src/main/cpp/src/api/genomicsdb_utils.cc
@@ -31,7 +31,9 @@
  **/
 #include "genomicsdb_utils.h"
 #include "tiledb_utils.h"
+#include "genomicsdb_logger.h"
 
+#include "string.h"
 
 namespace genomicsdb {
 
@@ -39,23 +41,60 @@ std::string version() {
   return GENOMICSDB_VERSION;
 }
 
+#define LOG_ERRMSG if (strlen(tiledb_errmsg)) logger.error(std::string("\n")+tiledb_errmsg)
+
 bool is_file(const std::string& filename) {
-  return TileDBUtils::is_file(filename);
+  bool found =  TileDBUtils::is_file(filename);
+  if (!found) {
+    LOG_ERRMSG;
+  }
+  return found;
 }
 
 ssize_t file_size(const std::string& filename) {
-  return TileDBUtils::file_size(filename);
+  auto size = TileDBUtils::file_size(filename);
+  if (size == -1) {
+    LOG_ERRMSG;
+  }
+  return size;
 }
 
 int read_entire_file(const std::string& filename, void **buffer, size_t *length) {
-  return TileDBUtils::read_entire_file(filename, buffer, length);
+  if (is_file(filename)) {
+    return TileDBUtils::read_entire_file(filename, buffer, length);
+  } else {
+    return GENOMICSDB_ERR;
+  }
+}
+
+bool workspace_exists(const std::string& workspace) {
+  bool found = TileDBUtils::workspace_exists(workspace);
+  if (!found) {
+    LOG_ERRMSG;
+  }
+  return found;
+}
+
+bool array_exists(const std::string& workspace, const std::string& array_name) {
+  bool found = TileDBUtils::array_exists(workspace, array_name);
+  if (!found) {
+    LOG_ERRMSG;
+  }
+  return found;
 }
 
 std::vector<std::string> get_array_names(const std::string& workspace) {
-  return TileDBUtils::get_array_names(workspace);
+  auto names = TileDBUtils::get_array_names(workspace);
+  if (!names.size()) {
+    LOG_ERRMSG;
+  }
+  return names;
 }
 
 int cache_fragment_metadata(const std::string& workspace, const std::string& array_name) {
+  if (!TileDBUtils::array_exists(workspace, array_name)) {
+    return GENOMICSDB_ERR;
+  }
   return TileDBUtils::cache_fragment_metadata(workspace, array_name);
 }
 

--- a/src/main/cpp/src/api/genomicsdb_utils.cc
+++ b/src/main/cpp/src/api/genomicsdb_utils.cc
@@ -39,7 +39,7 @@ std::string version() {
   return GENOMICSDB_VERSION;
 }
 
-#define LOG_ERRMSG if (strlen(tiledb_errmsg)) logger.error(std::string("\n")+tiledb_errmsg)
+#define LOG_ERRMSG if (strlen(tiledb_errmsg)) logger.error(tiledb_errmsg)
 
 bool is_file(const std::string& filename) {
   bool found =  TileDBUtils::is_file(filename);

--- a/src/main/cpp/src/api/genomicsdb_utils.cc
+++ b/src/main/cpp/src/api/genomicsdb_utils.cc
@@ -52,11 +52,11 @@ bool is_file(const std::string& filename) {
 }
 
 ssize_t file_size(const std::string& filename) {
-  auto size = TileDBUtils::file_size(filename);
-  if (size == -1) {
-    LOG_ERRMSG;
+  if (is_file(filename)) {
+    return TileDBUtils::file_size(filename);;
+  } else {
+    return GENOMICSDB_ERR;
   }
-  return size;
 }
 
 int read_entire_file(const std::string& filename, void **buffer, size_t *length) {


### PR DESCRIPTION
Expose more storage functionality as genomicsdb_utils api with the api logging error messages when necessary. This should especially help with cloud url related issues from TileDB.